### PR TITLE
chore: fix Metal 4 shader crash and enable fast math

### DIFF
--- a/OpenEmu-Shaders/Source/CompiledShader.swift
+++ b/OpenEmu-Shaders/Source/CompiledShader.swift
@@ -122,11 +122,8 @@ public enum Compiled {
             case .version2_1:
                 self = .version2_1
             default:
-                if ((3 << 16)..<(4 << 16)).contains(mtl.rawValue) {
-                    self = .version2_4
-                } else {
-                    throw LanguageVersionError.unsupportedVersion
-                }
+                // Metal 4.0+ or any unrecognised future version: map to highest supported SPIRV-Cross output
+                self = .version2_4
             }
         }
     }

--- a/OpenEmu-Shaders/Source/FilterChain.swift
+++ b/OpenEmu-Shaders/Source/FilterChain.swift
@@ -880,6 +880,7 @@ public final class FilterChain {
             
             let options = MTLCompileOptions()
             options.languageVersion = try MTLLanguageVersion(ss.languageVersion)
+            options.fastMathEnabled = true
             do {
                 let lib = try device.makeLibrary(source: pass.vertexSource, options: options)
                 psd.vertexFunction = lib.makeFunction(name: "main0")


### PR DESCRIPTION
## Summary

- **`CompiledShader.swift`** — The `default:` branch in `LanguageVersion.init(_:)` had a range check `(3 << 16)..<(4 << 16)` that intentionally covered Metal 3.x but accidentally excluded Metal 4.0 exactly (`4 << 16 = 262144` is not `< 262144`). On a Metal 4.0 device, every Slang shader would throw `unsupportedVersion` and silently fail to compile. Replaced with an unconditional `self = .version2_4` fallback so any unknown/future Metal version maps gracefully.
- **`FilterChain.swift`** — Added `fastMathEnabled = true` to `MTLCompileOptions` when compiling Slang shader passes. This is a free win on Apple Silicon's shader compiler (relaxed IEEE float semantics → better vectorisation).

## Source

Both fixes identified by reviewing `pystIC/OpenEmuARM64-metal4-shaders-core-updates` commit `15a137575b`. Their implementations differed slightly; these versions are adapted to our existing code.

## Test plan

- [ ] Build with `OpenEmu-metal.xcworkspace` — confirm no regressions
- [ ] Load a Slang shader preset in-game — confirm it applies correctly
- [ ] Verify no crash on shader load (the Metal 4 crash would surface here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)