### PR TITLE
fix: add PokeMini and Potator-Core to Metal workspace

### DIFF
--- a/OpenEmu-metal.xcworkspace/contents.xcworkspacedata
+++ b/OpenEmu-metal.xcworkspace/contents.xcworkspacedata
@@ -25,4 +25,10 @@
    <FileRef
       location = "group:Mupen64Plus/Mupen64Plus.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:PokeMini/PokeMini.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Potator-Core/Potator.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## Summary

- Adds `PokeMini/PokeMini.xcodeproj` to `OpenEmu-metal.xcworkspace`
- Adds `Potator-Core/Potator.xcodeproj` to `OpenEmu-metal.xcworkspace`

Both cores had complete, correct `.xcodeproj` files but were never added to the workspace. As workspace members, Xcode automatically satisfies their `OpenEmuBase.framework` dependency via `BUILT_PRODUCTS_DIR` — no `FRAMEWORK_SEARCH_PATHS` override needed.

Closes #37

## Test plan

- [ ] Open `OpenEmu-metal.xcworkspace` in Xcode — PokeMini and Potator targets appear in the scheme list
- [ ] Build PokeMini target — no `OpenEmuBase/OEGameCore.h` error
- [ ] Build Potator target — no `OpenEmuBase/OEGameCore.h` error
- [ ] Install and sign each `.oecoreplugin`, verify it loads in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)