### PR TITLE
fix: Available Libraries list not visible on first show and not scrollable

### DIFF
--- a/OpenEmu/AvailableLibrariesViewController.swift
+++ b/OpenEmu/AvailableLibrariesViewController.swift
@@ -84,6 +84,7 @@ final class AvailableLibrariesViewController: NSViewController {
     }
     
     override func viewWillAppear() {
+        super.viewWillAppear()
         loadData()
     }
     

--- a/OpenEmu/PrefLibraryController.swift
+++ b/OpenEmu/PrefLibraryController.swift
@@ -47,6 +47,7 @@ final class PrefLibraryController: NSViewController {
         librariesView.removeFromSuperview()
         librariesView = scrollView
         
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.borderType = .bezelBorder
         NSLayoutConstraint.activate([
             scrollView.widthAnchor.constraint(equalToConstant: size.width),


### PR DESCRIPTION
## Summary

- Set `scrollView.translatesAutoresizingMaskIntoConstraints = false` in `PrefLibraryController.viewDidLoad()` before adding explicit width/height constraints — the XIB-loaded scroll view defaults to TAMMIC=YES, which auto-translated its autoresizing mask into constraints that conflicted with the manually added anchors, causing an undetermined frame (invisible list on first show) and a broken scroll range (no scrolling)
- Added missing `super.viewWillAppear()` call in `AvailableLibrariesViewController.viewWillAppear()` to ensure appearance notifications propagate correctly

## Test locally

```bash
# 1. Check out this PR
gh pr checkout 53 --repo chris-p-bacon-sudo/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -10

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
```

## Test plan

- [ ] Open Preferences → Library tab — Available Libraries list should be immediately visible without needing to switch tabs
- [ ] With many cores installed, the Available Libraries list should be scrollable
- [ ] Toggle a system checkbox — it should still function correctly
- [ ] Switch away from the Library tab and back — list should remain visible and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)