### PR TITLE
fix: populate Available Libraries on first show

### DIFF
--- a/OpenEmu/PrefLibraryController.swift
+++ b/OpenEmu/PrefLibraryController.swift
@@ -53,6 +53,8 @@ final class PrefLibraryController: NSViewController {
             scrollView.widthAnchor.constraint(equalToConstant: size.width),
             scrollView.heightAnchor.constraint(equalToConstant: size.height)
         ])
+
+        availableLibrariesViewController.loadData()
     }
     
     deinit {


### PR DESCRIPTION
## Summary

- `viewWillAppear` is not reliably propagated to `AvailableLibrariesViewController` when the preferences tab system swaps views via `NSGridView` `contentView` — the standard AppKit appearance lifecycle doesn't fire in this context
- As a result, `loadData()` was never called on first open, leaving the Available Libraries box empty
- Fix: call `availableLibrariesViewController.loadData()` explicitly from `PrefLibraryController.viewDidLoad` after the child VC is configured

## Test plan

- [ ] Open Preferences → Library tab
- [ ] Available Libraries list populates immediately (all systems shown with checkboxes)
- [ ] Toggling a system on/off still works
- [ ] Closing and reopening Preferences → Library still shows list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)