### PR TITLE
fix: generate ScreenScraper credentials stub in CI before building

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,8 +25,13 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Generate credentials stubs
+        run: |
+          cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+
       - name: Build OpenEmu (Debug, arm64)
         run: |
+          set -o pipefail
           xcodebuild build \
             -workspace OpenEmu-metal.xcworkspace \
             -scheme OpenEmu \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,10 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: manual
 
+      - name: Generate credentials stubs
+        run: |
+          cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+
       - name: Build
         run: |
           xcodebuild -workspace "OpenEmu-metal.xcworkspace" \

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -20,6 +20,9 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+      - name: Generate credentials stubs
+        run: |
+          cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
       - name: Build OpenEmu
         working-directory: ${{github.workspace}}
         run: xcodebuild -workspace "OpenEmu-metal.xcworkspace" -scheme "OpenEmu" -configuration Release -sdk macosx -arch arm64 -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
## Summary

- Adds a **Generate credentials stubs** step to all three CI workflows (`build-check.yml`, `openemu.yml`, `codeql.yml`) that copies `ScreenScraperDevCredentials.template.swift` → `ScreenScraperDevCredentials.swift` before building
- Fixes **silent false-positive** in `build-check.yml`: the `xcodebuild | tail -50` pipe was swallowing non-zero exit codes, so Build Check appeared green on broken builds. Added `set -o pipefail` to restore correct failure propagation.

## Root cause

`ScreenScraperDevCredentials.swift` is gitignored (it holds API credentials) but is compiled into the `OpenEmu` target. Every PR since the ScreenScraper feature landed has failed `OpenEmu.app` and `CodeQL` with:

```
error: Build input file cannot be found: '.../ScreenScraperDevCredentials.swift'
```

`Build Check` appeared to pass because `| tail -50` silently swallowed the failure exit code.

## Test plan

- [ ] `Build Check` passes and correctly propagates build failures
- [ ] `OpenEmu.app` workflow passes (Release build succeeds)
- [ ] `CodeQL` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)