### PR TITLE
feat: add BSNES to primary workspace with build fixes

### DIFF
--- a/BSNES/BSNES.xcodeproj/project.pbxproj
+++ b/BSNES/BSNES.xcodeproj/project.pbxproj
@@ -79,10 +79,6 @@
 		C6D120EC1711307900E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120EB1711307900E868A8 /* OpenEmuBase.framework */; };
                 CC00000123B985A800F0B36E /* debugger.c in Sources */ = {isa = PBXBuildFile; fileRef = 0167A44C23B9843600F0B36E /* debugger.c */; };
                 CC00000223B985A800F0B36E /* sm83_disassembler.c in Sources */ = {isa = PBXBuildFile; fileRef = 0167A45B23B9843600F0B36E /* sm83_disassembler.c */; };
-                CC00000323B985A800F0B36E /* cheat_search.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000123B9843600F0B36E /* cheat_search.c */; };
-                CC00000423B985A800F0B36E /* cheats.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000223B9843600F0B36E /* cheats.c */; };
-                CC00000523B985A800F0B36E /* rumble.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000323B9843600F0B36E /* rumble.c */; };
-                CC00000623B985A800F0B36E /* workboy.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000423B9843600F0B36E /* workboy.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -758,10 +754,6 @@
 		C6480FFB1364B2E10094FA33 /* OESNESSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OESNESSystemResponderClient.h; path = ../OpenEmu/SystemPlugins/SuperNES/OESNESSystemResponderClient.h; sourceTree = "<group>"; };
 		C6D120EB1711307900E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
-                BB00000123B9843600F0B36E /* cheat_search.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cheat_search.c; sourceTree = "<group>"; };
-                BB00000223B9843600F0B36E /* cheats.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cheats.c; sourceTree = "<group>"; };
-                BB00000323B9843600F0B36E /* rumble.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rumble.c; sourceTree = "<group>"; };
-                BB00000423B9843600F0B36E /* workboy.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = workboy.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2006,10 +1998,6 @@
 		0167A43F23B9843600F0B36E /* Core */ = {
 			isa = PBXGroup;
 			children = (
-                                BB00000123B9843600F0B36E /* cheat_search.c */,
-                                BB00000223B9843600F0B36E /* cheats.c */,
-                                BB00000323B9843600F0B36E /* rumble.c */,
-                                BB00000423B9843600F0B36E /* workboy.c */,
 				0167A44023B9843600F0B36E /* sm83_cpu.h */,
 				0167A44123B9843600F0B36E /* sgb_animation_logo.inc */,
 				0167A44223B9843600F0B36E /* printer.h */,
@@ -2377,10 +2365,6 @@
 			files = (
                                 CC00000123B985A800F0B36E /* debugger.c in Sources */,
                                 CC00000223B985A800F0B36E /* sm83_disassembler.c in Sources */,
-                                CC00000323B985A800F0B36E /* cheat_search.c in Sources */,
-                                CC00000423B985A800F0B36E /* cheats.c in Sources */,
-                                CC00000523B985A800F0B36E /* rumble.c in Sources */,
-                                CC00000623B985A800F0B36E /* workboy.c in Sources */,
 				0167A56223B985A800F0B36E /* mbc.c in Sources */,
 				0167A56D23B985E600F0B36E /* lzma.cpp in Sources */,
 				0167A54A23B984DA00F0B36E /* dsp.cpp in Sources */,

--- a/BSNES/BSNES.xcodeproj/xcshareddata/xcschemes/BSNES.xcscheme
+++ b/BSNES/BSNES.xcodeproj/xcshareddata/xcschemes/BSNES.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "BSNES.oecoreplugin"
+               BlueprintName = "BSNES"
+               ReferencedContainer = "group:BSNES/BSNES.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu-metal.xcworkspace/contents.xcworkspacedata
+++ b/OpenEmu-metal.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
       location = "group:SNES9x/SNES9x.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:BSNES/BSNES.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:OpenEmuKit/OpenEmuKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + BSNES.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + BSNES.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "BSNES.oecoreplugin"
+               BlueprintName = "BSNES"
+               ReferencedContainer = "group:BSNES/BSNES.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmuARM64.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmuARM64.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmuARM64.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

- Adds `BSNES/BSNES.xcodeproj` to `OpenEmu-metal.xcworkspace` — the primary workspace previously couldn't see or build the bsnes core at all
- Removes 4 stale source file references (`cheat_search.c`, `cheats.c`, `rumble.c`, `workboy.c`) from `BSNES.xcodeproj` that pointed to newer SameBoy files not present in the checked-in source snapshot; these are peripheral GB accessories (Workboy keyboard, rumble pak, cheat database) that no commercial games depend on
- Adds `BSNES.xcscheme` for standalone core builds
- Adds `OpenEmu + BSNES.xcscheme` for combined app+core development builds

## Why

The bsnes source and Xcode project were fully present but never wired into `OpenEmu-metal.xcworkspace`. Users had no way to build or install it. This completes the integration so bsnes can be offered alongside SNES9x, letting users choose the high-accuracy core if they want it.

## Test plan

- [x] `BUILD SUCCEEDED` for `OpenEmu + BSNES` scheme (Debug, arm64) — verified locally
- [ ] Build and install the plugin: build `OpenEmu + BSNES` scheme, then install via CoreUpdater or manually from DerivedData
- [ ] Load a SNES ROM — verify core selection shows both SNES9x and bsnes as options in Preferences → Cores

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)