### PR TITLE
feat: signing, notarization, and DMG release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+name: Release
+
+# Triggered manually or on version tags (e.g. v1.0.0)
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v1.0.0)"
+        required: true
+        default: "v1.0.0"
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Build, Sign, Notarize, DMG
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Generate credentials stubs
+        run: |
+          cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+
+      # ── Certificate ──────────────────────────────────────────────────────────
+      - name: Import Developer ID certificate
+        env:
+          CERT_BASE64: ${{ secrets.DEVELOPER_ID_CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+
+          # Create a temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$CERT_BASE64" | base64 --decode > $RUNNER_TEMP/cert.p12
+          security import $RUNNER_TEMP/cert.p12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/productsign
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Make it the default so Xcode finds the identity
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+      # ── Archive ──────────────────────────────────────────────────────────────
+      - name: Archive OpenEmu
+        run: |
+          xcodebuild archive \
+            -workspace OpenEmu-metal.xcworkspace \
+            -scheme OpenEmu \
+            -configuration Release \
+            -destination generic/platform=macOS \
+            -archivePath $RUNNER_TEMP/OpenEmu.xcarchive \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            CODE_SIGN_STYLE=Automatic
+
+      # ── Export (signs the .app with Developer ID) ─────────────────────────
+      - name: Export signed app
+        run: |
+          # Inject team ID into export options
+          sed "s/\$(APPLE_TEAM_ID)/${{ secrets.APPLE_TEAM_ID }}/g" \
+            Scripts/ExportOptions.plist > $RUNNER_TEMP/ExportOptions.plist
+
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/OpenEmu.xcarchive \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/export
+
+      # ── Notarize ─────────────────────────────────────────────────────────────
+      - name: Zip app for notarization
+        run: |
+          ditto -c -k --keepParent \
+            "$RUNNER_TEMP/export/OpenEmu.app" \
+            "$RUNNER_TEMP/OpenEmu-notarize.zip"
+
+      - name: Notarize
+        run: |
+          xcrun notarytool submit "$RUNNER_TEMP/OpenEmu-notarize.zip" \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --wait
+
+      - name: Staple notarization ticket
+        run: |
+          xcrun stapler staple "$RUNNER_TEMP/export/OpenEmu.app"
+
+      # ── DMG ──────────────────────────────────────────────────────────────────
+      - name: Create DMG
+        run: |
+          hdiutil create \
+            -volname "OpenEmu" \
+            -srcfolder "$RUNNER_TEMP/export/OpenEmu.app" \
+            -ov \
+            -format UDZO \
+            "$RUNNER_TEMP/OpenEmu.dmg"
+
+      - name: Notarize DMG
+        run: |
+          xcrun notarytool submit "$RUNNER_TEMP/OpenEmu.dmg" \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --wait
+
+      - name: Staple DMG
+        run: |
+          xcrun stapler staple "$RUNNER_TEMP/OpenEmu.dmg"
+
+      # ── Release ──────────────────────────────────────────────────────────────
+      - name: Determine tag name
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload DMG to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: "OpenEmu-Silicon ${{ steps.tag.outputs.name }}"
+          draft: true
+          files: ${{ runner.temp }}/OpenEmu.dmg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Cleanup ───────────────────────────────────────────────────────────────
+      - name: Remove temporary keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/signing.keychain-db 2>/dev/null || true

--- a/Scripts/ExportOptions.plist
+++ b/Scripts/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>developer-id</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>$(APPLE_TEAM_ID)</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds the full release pipeline triggered on `v*` tags or manually via `workflow_dispatch`.

**Pipeline steps:**
1. Import Developer ID Application cert into a temporary keychain
2. `xcodebuild archive` (Release, generic/platform=macOS)
3. `xcodebuild -exportArchive` with Developer ID + automatic signing
4. `xcrun notarytool submit --wait` (notarize the .app)
5. `xcrun stapler staple` the .app
6. `hdiutil create` → `OpenEmu.dmg`
7. Notarize + staple the DMG
8. Upload DMG to a **draft** GitHub Release (requires manual publish)

Keychain is cleaned up in an `always()` step so secrets don't persist on the runner.

## Secrets required (already added to repo)
- `DEVELOPER_ID_CERT_BASE64`
- `DEVELOPER_ID_CERT_PASSWORD`
- `APPLE_ID`
- `APPLE_ID_PASSWORD`
- `APPLE_TEAM_ID`

## Test plan
- [ ] Merge and trigger via `workflow_dispatch` with tag `v1.0.0`
- [ ] Confirm archive step succeeds and app is signed (`codesign -dv`)
- [ ] Confirm notarytool returns `status: Accepted`
- [ ] Confirm DMG mounts and Gatekeeper passes on a clean Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)