### PR TITLE
chore: switch release workflow to macos-15 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
macos-14 runners were sitting in queue for 20+ minutes. macos-15 has better availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)