### PR TITLE
chore: update all CI runners to macos-26

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build (arm64)
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: macos-14
+    runs-on: macos-26
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build OpenEmu
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout


### PR DESCRIPTION
macos-26 (Tahoe) has been GA on GitHub Actions since 2026-02-26. macos-14 is deprecated and macos-15 is a step behind.

Updates all four workflows: `build-check.yml`, `openemu.yml`, `codeql.yml`, `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)