### PR TITLE
fix: use Developer ID signing explicitly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
             -destination generic/platform=macOS \
             -archivePath $RUNNER_TEMP/OpenEmu.xcarchive \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_STYLE=Manual
 
       # ── Export (signs the .app with Developer ID) ─────────────────────────
       - name: Export signed app

--- a/Scripts/ExportOptions.plist
+++ b/Scripts/ExportOptions.plist
@@ -5,7 +5,9 @@
     <key>method</key>
     <string>developer-id</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Developer ID Application</string>
     <key>teamID</key>
     <string>$(APPLE_TEAM_ID)</string>
     <key>stripSwiftSymbols</key>


### PR DESCRIPTION
## Problem
Archive step failed with:
> No signing certificate "Mac Development" found

`CODE_SIGN_STYLE=Automatic` was resolving to the Mac Development cert instead of Developer ID Application during `xcodebuild archive`.

## Fix
- Set `CODE_SIGN_IDENTITY="Developer ID Application"` and `CODE_SIGN_STYLE=Manual` in the archive step
- Update `Scripts/ExportOptions.plist` to match (`manual` style + explicit `signingCertificate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)