### PR TITLE
chore: run CodeQL on schedule only, not every push/PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,9 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '22 8 * * 1'  # Every Monday at 08:22 UTC
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
CodeQL runs two jobs in parallel (c-cpp + swift matrix). Triggering it on every push/PR was queuing 3 macos-26 runners at once alongside Build Check and OpenEmu.app, causing 20+ minute queue waits.

Weekly schedule (Mondays) is the right cadence for security scanning. Added `workflow_dispatch` so it can be triggered manually before a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)