### PR TITLE
chore: switch all runners to macos-latest

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build (arm64)
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: macos-26
+    runs-on: macos-latest
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build OpenEmu
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/xadmaster.yml
+++ b/.github/workflows/xadmaster.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build XADMaster and UniversalDetector frameworks
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Stops hardcoding macOS runner versions. `macos-latest` is maintained by GitHub and always points to the best available runner — no more manual updates when versions are deprecated or queues back up.

Also fixes `xadmaster.yml` which was still on `macos-12` (deprecated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)