### PR TITLE
chore: make build-check and openemu workflows manual-only

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,13 +1,7 @@
 name: Build Check
 
 on:
-  pull_request:
-    branches:
-      - staging
-      - main
-  push:
-    branches:
-      - staging
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -1,9 +1,6 @@
 name: OpenEmu.app
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes push/PR triggers from `build-check.yml` and `openemu.yml`. Both now only run on `workflow_dispatch`.

Automatic CI runs were competing with the release workflow for runners and causing long queue waits. These can be triggered manually before merging any significant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)