### PR TITLE
chore: pin release workflow to macos-15, make CI manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- Pins release workflow to `macos-15` — `macos-latest` appears to resolve to `macos-26` which has limited runner capacity and queues indefinitely
- Makes `build-check` and `openemu` workflows manual-only (`workflow_dispatch`) to stop them competing with the release workflow for runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)