### PR TITLE
fix: pin release workflow to macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout


### PR DESCRIPTION
`macos-latest` resolves to `macos-15`, not `macos-26`. For a release workflow, `macos-26` is the correct explicit pin — current stable generation, GA since 2026-02-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)