### PR TITLE
fix: switch release workflow runner to macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Build, Sign, Notarize, DMG
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- `macos-26` runners are in limited public beta — release jobs have been sitting in queue indefinitely with no runner ever assigned
- Switches `release.yml` back to `macos-latest` (macos-15) which has available runner capacity
- `setup-xcode` action with `latest-stable` will select the best available Xcode on that runner

## Test plan

- [ ] Trigger the Release workflow via `workflow_dispatch` and confirm it picks up a runner (no longer stuck in queue)
- [ ] Confirm archive step succeeds — if Xcode 16 can't build the project, we'll fall back to a local manual release

🤖 Generated with [Claude Code](https://claude.com/claude-code)