### PR TITLE
feat: update Sparkle EdDSA public key

### DIFF
--- a/OpenEmu/OpenEmu-Info.plist
+++ b/OpenEmu/OpenEmu-Info.plist
@@ -160,7 +160,7 @@
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>lI9DtKt5iDVR48ifKaP94mrFrHwYn75bfQLr+0alpRY=</string>
+	<string>wVICc/NGoDFzkEbDb63QMFpKlRs14e/WhIiwIngQGsg=</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary

- Replaces the old `SUPublicEDKey` in `OpenEmu-Info.plist` with a freshly generated EdDSA public key
- Previous key was unknown/lost — this establishes a clean key pair where the private key is securely stored in the owner's macOS Keychain

## After merging

After each release, run this to generate the `sparkle:edSignature` for `appcast.xml`:
```bash
~/Library/Developer/Xcode/DerivedData/OpenEmu-.../SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update OpenEmu-Silicon.dmg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)