### PR TITLE
feat: Dolphin Phase 3a-2 — single-core mode and host job dispatch

### DIFF
--- a/Dolphin/DolHost.mm
+++ b/Dolphin/DolHost.mm
@@ -140,8 +140,8 @@ void DolHost::Init(std::string supportDirectoryPath, std::string cpath)
     Config::SetBase(Config::MAIN_DSP_THREAD, true);
     Config::SetBase(Config::MAIN_AUDIO_VOLUME, 0);
     
-    //Split CPU thread from GPU
-    Config::SetBase(Config::MAIN_CPU_THREAD, true);
+    // Single-core mode: CPU and GPU on same thread (simpler, safer for OE process model)
+    Config::SetBase(Config::MAIN_CPU_THREAD, false);
     
     //Analitics
     Config::SetBase(Config::MAIN_ANALYTICS_PERMISSION_ASKED, true);
@@ -268,10 +268,11 @@ void DolHost::Reset()
 
 void DolHost::UpdateFrame()
 {
-    //Core::HostDispatchJobs();
-    
+    // Dispatch any pending host jobs (state changes, UI callbacks) each frame
+    Core::HostDispatchJobs(Core::System::GetInstance());
+
     //Input::OpenEmu_Input_Update();
-    
+
     if(_onBoot) _onBoot = false;
 }
 


### PR DESCRIPTION
## Summary

Wires the two configuration steps needed before a ROM can boot stably, per issue #64.

- **Single-core mode** (`MAIN_CPU_THREAD = false`): CPU and GPU now run on Dolphin's single EmuThread instead of two separate threads. Eliminates the dual-core synchronization complexity that risks deadlock in OE's process model.
- **Host job dispatch in `UpdateFrame()`**: `Core::HostDispatchJobs` is called every frame so pending host callbacks (state changes, UI events) are drained on schedule. Previously `UpdateFrame()` was a no-op after boot.
- **Host stubs audit**: All `Host_*` symbols declared in `Core/Host.h` are already stubbed in `DolHost.mm`. No changes needed.
- **`willRenderFrameOnAlternateThread` stays**: In single-core mode Dolphin's EmuThread is still a separate thread from OE's emulation thread, so rendering is still on an alternate thread.

**Note on `RunSingleFrame()`**: The issue referenced `system.GetCPU().RunSingleFrame()` from the libretro/dolphin fork. That API does not exist in this Dolphin fork's `CPU.h`. `HostDispatchJobs` is the correct per-frame host-side mechanism for this version.

## Stacking note

This PR targets `feat/dolphin-3a-build` (#69) because that branch is not yet merged. Once #69 merges to `main`, this PR will auto-retarget.

## Test plan

- [ ] `Build (arm64)` CI check passes
- [ ] Local build: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build` — **BUILD SUCCEEDED** ✓
- [ ] Confirm `MAIN_CPU_THREAD` is `false` in `DolHost::Init()` (`DolHost.mm:144`)
- [ ] Confirm `UpdateFrame()` calls `Core::HostDispatchJobs` (`DolHost.mm:272`)
- [ ] Phase 3a-3 (first boot / sign / install / load a GC ROM) is the next step

Closes #64
Related to #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)