### PR TITLE
fix: move x86-only cores to Legacy/ on first launch

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -878,6 +878,7 @@ extension AppDelegate: NSMenuDelegate {
             return
         }
 
+        OECoreMigration.runIfNeeded()
         loadPlugins(with: database)
         removeIncompatibleSaveStates(from: database)
 

--- a/OpenEmu/OECoreMigration.swift
+++ b/OpenEmu/OECoreMigration.swift
@@ -1,0 +1,96 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import AppKit
+
+/// Moves Intel-only (x86_64) cores from the user's OpenEmu cores directory
+/// to a `Legacy/` subdirectory on the first launch of OpenEmu-Silicon.
+///
+/// This prevents old x86-only cores installed by the original OpenEmu app from
+/// conflicting with or shadowing the bundled ARM64 cores.
+///
+/// Runs exactly once, guarded by the `OEDidRemoveStaleX86Cores` UserDefaults key.
+/// Call `runIfNeeded()` before `loadPlugins(with:)` in AppDelegate.
+enum OECoreMigration {
+
+    private static let didRunKey = "OEDidRemoveStaleX86Cores"
+
+    private static var coresDirectory: URL {
+        let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
+        let appSupport = URL(fileURLWithPath: paths.first!).appendingPathComponent("OpenEmu")
+        return appSupport.appendingPathComponent("Cores")
+    }
+
+    static func runIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: didRunKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: didRunKey) }
+
+        let fm = FileManager.default
+        let cores = coresDirectory
+        let legacy = cores.appendingPathComponent("Legacy")
+
+        guard fm.fileExists(atPath: cores.path) else { return }
+
+        var movedCores: [String] = []
+
+        let items = (try? fm.contentsOfDirectory(at: cores, includingPropertiesForKeys: nil)) ?? []
+        for item in items where item.pathExtension == "oecoreplugin" {
+            guard let bundle = Bundle(url: item),
+                  let archs = bundle.executableArchitectures else { continue }
+
+            let hasARM64 = archs.contains(NSNumber(value: NSBundleExecutableArchitectureARM64))
+            guard !hasARM64 else { continue }
+
+            // Intel-only core — move it to Legacy/
+            do {
+                try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
+                let dest = legacy.appendingPathComponent(item.lastPathComponent)
+                if fm.fileExists(atPath: dest.path) {
+                    try fm.removeItem(at: dest)
+                }
+                try fm.moveItem(at: item, to: dest)
+                movedCores.append(item.deletingPathExtension().lastPathComponent)
+            } catch {
+                // Non-fatal: leave it in place if we can't move it
+            }
+        }
+
+        guard !movedCores.isEmpty else { return }
+
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Legacy Cores Moved"
+            alert.informativeText = """
+                OpenEmu-Silicon found \(movedCores.count == 1 ? "an Intel-only core" : "\(movedCores.count) Intel-only cores") \
+                from a previous OpenEmu installation and moved \(movedCores.count == 1 ? "it" : "them") to \
+                ~/Library/Application Support/OpenEmu/Cores/Legacy/ to avoid conflicts with the ARM64 cores built into this app.
+
+                Moved: \(movedCores.joined(separator: ", "))
+                """
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
+    }
+}

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		8F8DB27B26D2A69E003CF106 /* PreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53439B6813B932C5005C0CC8 /* PreferencePane.swift */; };
 		8F93FDDA27374F2000B59F3E /* GameInfoHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDD927374F2000B59F3E /* GameInfoHelperTests.swift */; };
 		8F93FDE02737506900B59F3E /* ROMImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDDF2737506900B59F3E /* ROMImporterTests.swift */; };
+		56ECCDC1488945C2A09403D7 /* OECoreMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */; };
 		8F9410C0273A0167004C47CC /* CoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */; };
 		8F94B44D25566FE00058AA94 /* NSShadow+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94B44C25566FE00058AA94 /* NSShadow+OEAdditions.swift */; };
 		8F94DEC1250EC701003A1F33 /* ThumbnailProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94DEC0250EC701003A1F33 /* ThumbnailProvider.swift */; };
@@ -1537,6 +1538,7 @@
 		8370D3E01A8D2A7600313F87 /* ArrowCursorTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrowCursorTextView.swift; sourceTree = "<group>"; };
 		83753F1614F537C400D708A7 /* PrefDebugController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefDebugController.swift; sourceTree = "<group>"; };
 		83753F1914F5383F00D708A7 /* PrefDebugController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrefDebugController.xib; sourceTree = "<group>"; };
+		6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OECoreMigration.swift; sourceTree = "<group>"; };
 		8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreUpdater.swift; sourceTree = "<group>"; };
 		837820B71907FADB0043593F /* IKRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKRenderer.h; sourceTree = "<group>"; };
 		837820B81907FB2D0043593F /* IKImageWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKImageWrapper.h; sourceTree = "<group>"; };
@@ -3192,6 +3194,7 @@
 			children = (
 				83CACEC7196D6D1300999E70 /* Download.swift */,
 				8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */,
+				6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */,
 				839310BB147802380020058E /* CoreDownload.swift */,
 			);
 			name = Downloader;
@@ -6470,6 +6473,7 @@
 				0544B69723D16D0C00F63D61 /* ImageCacheService.swift in Sources */,
 				8337F38E1726B3600068DD90 /* BackgroundImageView.swift in Sources */,
 				94A4E98D179F9A4D00AD8C7D /* OEDBSaveStatesMedia.swift in Sources */,
+				56ECCDC1488945C2A09403D7 /* OECoreMigration.swift in Sources */,
 				8F9410C0273A0167004C47CC /* CoreUpdater.swift in Sources */,
 				94A4E992179F9D0400AD8C7D /* OEDBScreenshotsMedia.swift in Sources */,
 				94A4E996179FAB9F00AD8C7D /* OEMediaViewController.m in Sources */,


### PR DESCRIPTION
## Summary

Users with a prior OpenEmu installation have Intel-only `.oecoreplugin` bundles at `~/Library/Application Support/OpenEmu/Cores/`. Because OpenEmu-Silicon uses the same path, those stale x86_64 cores were loading before (or conflicting with) the bundled ARM64 ones. The only workaround was manually deleting the library folder.

- Adds `OECoreMigration.swift` — scans `~/Library/Application Support/OpenEmu/Cores/` on first launch for bundles with no ARM64 slice and moves them to `Cores/Legacy/` (preserves rather than deletes, in case the user wants to revert)
- Shows a one-time informational `NSAlert` listing any cores that were moved
- Guarded by `OEDidRemoveStaleX86Cores` UserDefaults key — runs exactly once per installation
- Called from `AppDelegate.libraryDatabaseDidLoad` before `loadPlugins(with:)` so the user directory is clean before plugin discovery runs

Closes #92, #95

## Test plan

- [ ] Copy a known x86-only `.oecoreplugin` into `~/Library/Application Support/OpenEmu/Cores/` (or thin a current core: `lipo -remove arm64 <plugin>/Contents/MacOS/<binary> -output <...>`)
- [ ] Delete the guard key: `defaults delete org.openemu.OpenEmu OEDidRemoveStaleX86Cores`
- [ ] Launch the app — confirm the core was moved to `Cores/Legacy/` and the alert appeared
- [ ] Launch any ROM — confirm the bundled ARM64 core is used (no crash)
- [ ] Re-launch — confirm the alert does not appear again
- [ ] Confirm users who never had the original OpenEmu see no alert and the guard key is still set

🤖 Generated with [Claude Code](https://claude.com/claude-code)