### PR TITLE
Implement  more advanced fuzzy metadata scraper for fallback

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -2,14 +2,14 @@
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-// * Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// * Neither the name of the OpenEmu Team nor the
-// names of its contributors may be used to endorse or promote products
-// derived from this software without specific prior written permission.
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -45,10 +45,13 @@ final class GameInfoHelper {
             let md5 = gameInfo["md5"] as? String
             let url = gameInfo["URL"] as? URL
 
-            // Determine ScreenScraper credentials once, used throughout this function.
-            let ssUsername = UserDefaults.standard.string(forKey: "ScreenScraperUsername") ?? ""
-            let ssPassword = ScreenScraperCredentials.storedPassword() ?? ""
-            let hasSScredentials = !ssUsername.isEmpty && !ssPassword.isEmpty
+            // ScreenScraper credentials — resolved lazily so we don't hit the Keychain
+            // on every ROM lookup (e.g. during a full library scan).
+            lazy var hasSScredentials: Bool = {
+                let user = UserDefaults.standard.string(forKey: "ScreenScraperUsername") ?? ""
+                guard !user.isEmpty else { return false }
+                return !(ScreenScraperCredentials.storedPassword() ?? "").isEmpty
+            }()
 
             guard let database = database else {
                 // OpenVGDB unavailable.
@@ -220,32 +223,35 @@ final class GameInfoHelper {
                 let rawName     = (url.lastPathComponent as NSString).deletingPathExtension
                 let cleanedName = cleanROMName(rawName)
 
-                // Pass 1 – full word AND match
-                if results.isEmpty || missingBoxArt {
-                    let words = cleanedName
-                        .components(separatedBy: .whitespaces)
-                        .filter { $0.count > 1 }
-                    if !words.isEmpty {
-                        let conditions = words.map { "releaseTitleName LIKE '%\($0)%'" }.joined(separator: " AND ")
-                        let fuzzySql = """
-                        SELECT DISTINCT releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL', releaseDescription as 'gameDescription', regionName as 'region'
-                        FROM ROMs rom LEFT JOIN RELEASES release USING (romID) LEFT JOIN REGIONS region on (regionLocalizedID=region.regionID)
-                        WHERE \(conditions)
-                          AND romSystemID IN (SELECT systemID FROM SYSTEMS WHERE systemOEID = '\(systemIdentifier)')
-                          AND releaseCoverFront IS NOT NULL AND releaseCoverFront != ''
-                        LIMIT 5
-                        """
-                        let fuzzyResults = (try? database.executeQuery(fuzzySql)) ?? []
-                        if !fuzzyResults.isEmpty {
-                            results = fuzzyResults
-                        }
+                // Three cascading passes — each only runs if the previous found nothing.
+                // All fuzzy queries filter for releaseCoverFront IS NOT NULL so any
+                // non-empty result means we found art; fuzzyFound tracks this.
+                var fuzzyFound = false
+
+                // Pass 1 – full title word AND match
+                let words = cleanedName
+                    .components(separatedBy: .whitespaces)
+                    .filter { $0.count > 1 }
+                if !words.isEmpty {
+                    let conditions = words.map { "releaseTitleName LIKE '%\($0)%'" }.joined(separator: " AND ")
+                    let fuzzySql = """
+                    SELECT DISTINCT releaseTitleName as 'gameTitle', releaseCoverFront as 'boxImageURL', releaseDescription as 'gameDescription', regionName as 'region'
+                    FROM ROMs rom LEFT JOIN RELEASES release USING (romID) LEFT JOIN REGIONS region on (regionLocalizedID=region.regionID)
+                    WHERE \(conditions)
+                      AND romSystemID IN (SELECT systemID FROM SYSTEMS WHERE systemOEID = '\(systemIdentifier)')
+                      AND releaseCoverFront IS NOT NULL AND releaseCoverFront != ''
+                    LIMIT 5
+                    """
+                    let fuzzyResults = (try? database.executeQuery(fuzzySql)) ?? []
+                    if !fuzzyResults.isEmpty {
+                        results = fuzzyResults
+                        fuzzyFound = true
                     }
                 }
 
-                // Pass 2 – compilation splitter (only + and & to avoid splitting subtitles on -)
-                // FIX: removed '-' as a separator; it incorrectly splits "Game Name - Subtitle"
-                // style titles that are not multi-game compilations.
-                if results.isEmpty || missingBoxArt {
+                // Pass 2 – compilation splitter (+ and & only; - excluded to avoid
+                // splitting "Game Name - Subtitle" style titles incorrectly)
+                if !fuzzyFound {
                     let compilationSeparators = CharacterSet(charactersIn: "+&")
                     let parts = cleanedName
                         .components(separatedBy: compilationSeparators)
@@ -269,6 +275,7 @@ final class GameInfoHelper {
                             let splitResults = (try? database.executeQuery(splitSql)) ?? []
                             if !splitResults.isEmpty {
                                 results = splitResults
+                                fuzzyFound = true
                                 break
                             }
                         }
@@ -276,7 +283,7 @@ final class GameInfoHelper {
                 }
 
                 // Pass 3 – last resort: first two significant words only
-                if results.isEmpty || missingBoxArt {
+                if !fuzzyFound {
                     let firstTwo = cleanedName
                         .components(separatedBy: .whitespaces)
                         .filter { $0.count > 1 }


### PR DESCRIPTION
…tting and regional priority

## What does this PR do?

<!-- One or two sentences describing the change. What problem does it solve, or what does it add? -->

Provides a better fuzzy logic search for OpenVGDB. If you do have Screenscrapper credentials it will use that first but for those that just want to use this out of the box it provides a better fallback cover art search. Solves the problem of "missing artwork" for compilation ROMs and multi-game titles by implementing a smart "Compilation Splitter" that parses titles using separators like +, &, or -. It also enforces strict System-ID filtering to prevent cross-platform mismatches (e.g., N64 games matching GBA art).

## What did you test?

<!-- How did you verify this works? Which game(s), system(s), or workflow(s) did you test with? --> 
System: Genesis / Mega Drive ROM: Disney Collection, The - QuackShot + Castle of Illusion. The scraper correctly split the title and retrieved the individual QuackShot artwork.
System: Nintendo 64  ROM: Banjo-Kazooie. Fixed an issue where the Japanese title or GBA version was sometimes prioritized over the English N64 version.
General: Verified that "ghost records" (titles without artwork URLs) are now correctly skipped in favor of better fuzzy matches.## Which cores or systems are affected?

<!-- List the emulation cores or systems this change touches, if any. If it's a general app change, say so. -->

all of them

## Did you use AI tools?

<!-- We're fully open to AI-assisted contributions — just be transparent about it. Did you use Claude, Copilot, Cursor, or anything else? If so, briefly describe how. (e.g. "Used Claude to draft the fix, reviewed and tested it myself.") -->

Used Antigravity  for compilation splitter logic. Used personal code testing and review for multiword matching logic.

## Linked issues

<!-- Use "Fixes #N" to auto-close an issue on merge, or "Related to #N" to soft-link -->

Fixes #

---

## PR checklist

- [ Staging ] Branched from an up-to-date `staging` (ran `git fetch origin && git merge origin/staging`)
- [ yes ] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [ M4 Tested] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [None ] No build logs, binaries, or credentials committed
- [ yes ] Copyright headers preserved on all modified files
- [ yes ] New files (if any) include the BSD 2-Clause license header
