### PR TITLE
fix: replace NSLog %@ + Swift String with interpolation to fix macOS 26 crash

### DIFF
--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -125,11 +125,15 @@ class GameDocumentController: NSDocumentController {
     }
     
     fileprivate func setUpGameDocument(_ document: OEGameDocument, display displayDocument: Bool, fullScreen: Bool, completionHandler: ((OEGameDocument?, NSError?) -> Void)?) {
-        NSLog("[DEBUG] GameDocumentController: setUpGameDocument for url: %@", document.fileURL?.path ?? "nil")
+        #if DEBUG
+        NSLog("[DEBUG] GameDocumentController: setUpGameDocument for url: \(document.fileURL?.path ?? "nil")")
+        #endif
         addDocument(document)
-        
+
         document.setUpGame { success, error in
-            NSLog("[DEBUG] GameDocumentController: setUpGame result success: %d, error: %@", success, error?.localizedDescription ?? "nil")
+            #if DEBUG
+            NSLog("[DEBUG] GameDocumentController: setUpGame result success: \(success), error: \(error?.localizedDescription ?? "nil")")
+            #endif
 
             
             if success {
@@ -147,9 +151,13 @@ class GameDocumentController: NSDocumentController {
     }
     
     override func openDocument(withContentsOf url: URL, display displayDocument: Bool, completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
-        NSLog("[DEBUG] GameDocumentController: openDocument with url: %@", url.path)
+        #if DEBUG
+        NSLog("[DEBUG] GameDocumentController: openDocument with url: \(url.path)")
+        #endif
         super.openDocument(withContentsOf: url, display: false) { document, documentWasAlreadyOpen, error in
-            NSLog("[DEBUG] GameDocumentController: super.openDocument finished with error: %@", error?.localizedDescription ?? "nil")
+            #if DEBUG
+            NSLog("[DEBUG] GameDocumentController: super.openDocument finished with error: \(error?.localizedDescription ?? "nil")")
+            #endif
             if let document = document as? OEGameDocument {
 
                 let fullScreen = UserDefaults.standard.bool(forKey: OEFullScreenGameWindowKey)

--- a/OpenEmu/Logging.swift
+++ b/OpenEmu/Logging.swift
@@ -41,7 +41,7 @@ extension OSLog {
 func DLog(_ message: @autoclosure () -> String, fileID: String = #fileID, function: String = #function, line: Int = #line)
 {
 #if DEBUG
-    NSLog("\(fileID):\(line): \(function): %@", message())
+    NSLog("\(fileID):\(line): \(function): \(message())")
 #endif
 }
 

--- a/OpenEmu/SaveStateViewController.swift
+++ b/OpenEmu/SaveStateViewController.swift
@@ -70,7 +70,7 @@ extension SaveStateViewController: CollectionViewExtendedDelegate, NSMenuItemVal
             item.name = title
             item.moveToDefaultLocation()
             if !item.writeToDisk() {
-                NSLog("Writing save state '%@' failed. It should be deleted!", title)
+                NSLog("Writing save state '\(title)' failed. It should be deleted!")
             }
             item.save()
         }

--- a/OpenEmuKit/Source/OEXPCGameCoreManager.swift
+++ b/OpenEmuKit/Source/OEXPCGameCoreManager.swift
@@ -49,7 +49,7 @@ import OpenEmuKitPrivate
         
         let cn: NSXPCConnection
         do {
-            NSLog("[OEXPCGameCoreManager] Launching helper at %@", executableURL.path)
+            NSLog("[OEXPCGameCoreManager] Launching helper at \(executableURL.path)")
             cn = try .makeConnection(serviceName: serviceName, executableURL: executableURL)
             helperConnection = cn
         } catch {

--- a/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
@@ -59,7 +59,7 @@ internal import os.log
             fatalError("Unable to find XPCBrokerServiceName argument")
         }
         
-        NSLog("[OpenEmuHelperApp] Initializing and launching application for service: %@", serviceName)
+        NSLog("[OpenEmuHelperApp] Initializing and launching application for service: \(serviceName)")
         
         autoreleasepool {
             let app = OpenEmuXPCHelperApp(serviceName: serviceName)


### PR DESCRIPTION
## Summary

- On macOS 26 (Tahoe), `NSLog` now routes through `os_log_impl_dynamic` before `__CFStringAppendFormatCore`. When called from Swift via `withVaList` with `%@` format specifiers and Swift `String` arguments, this new routing corrupts the va_list argument extraction — producing the garbage pointer `0x0000001000000018` (GPU Carveout reserved region) that causes `EXC_BAD_ACCESS` on the main thread.
- All `NSLog("...: %@", swiftString)` calls have been converted to string interpolation: `NSLog("...: \(swiftString)")`. No `%@` in the format string means `withVaList` is never invoked for these arguments, bypassing the macOS 26 regression entirely.
- `[DEBUG]`-labeled `NSLog` calls that were missing `#if DEBUG` guards (and therefore running in Release builds) are now properly wrapped.

## Files changed

| File | Change |
|------|--------|
| `OpenEmu/OEGameDocument.swift` | String interpolation for 3 production logs; 11 debug logs wrapped in `#if DEBUG` |
| `OpenEmu/GameDocumentController.swift` | 4 debug logs wrapped in `#if DEBUG`; format strings fixed |
| `OpenEmuKit/Source/OEXPCGameCoreManager.swift` | `%@` → interpolation |
| `OpenEmuKit/Source/OpenEmuXPCHelperApp.swift` | `%@` → interpolation |
| `OpenEmu/Logging.swift` | `DLog` fixed to use interpolation (prevents Debug build crash on macOS 26) |
| `OpenEmu/SaveStateViewController.swift` | `%@` → interpolation |

## Test plan

- [x] Launch a game on macOS 26 (any core — NES, SNES, Genesis)
- [x] Play briefly, then close the game window — app should not crash
- [x] Quit the app while a game is running — app should not crash
- [x] Verify debug logging still appears in Debug builds (DLog / `#if DEBUG` NSLog calls)

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)