### PR TITLE
feat: add Sentry crash reporting with first-launch opt-in prompt

### DIFF
--- a/OpenEmu-metal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "61e90e581b0a7c8675618d40069455d7e1df5419c3f96c091a07e39e1cb59732",
+  "originHash" : "7acc79c7e8bd2b0f6e137970910445e4a85a2a8c39da16100f82b961884a0e07",
   "pins" : [
     {
       "identity" : "cwlcatchexception",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
         "version" : "10.0.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "d459ff99b1912c9603c9e607e030b4b98e2e199a",
+        "version" : "9.9.0"
       }
     },
     {

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -841,6 +841,8 @@ extension AppDelegate: NSMenuDelegate {
         notificationCenter.removeObserver(self, name: NSApplication.didFinishRestoringWindowsNotification, object: nil)
     }
     func applicationDidFinishLaunching(_ notification: Notification) {
+        SentryService.configureIfNeeded()
+
         // Get the “Customize Touch Bar…” menu to display in the View menu.
         NSApp.isAutomaticCustomizeTouchBarMenuItemEnabled = true
         

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -208,6 +208,8 @@
 		1BFC26D0116C1CA300B95689 /* OpenEmuHelperApp in Resources */ = {isa = PBXBuildFile; fileRef = 1BEF2A9411682A530090F72B /* OpenEmuHelperApp */; };
 		1E0E90051A8932BB72161909 /* PrefCloudSyncController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF37C00BE9099269AB29467 /* PrefCloudSyncController.swift */; };
 		1E2F3DBB10DEAB4C0019AA84 /* OEVersionMigrationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F3DBA10DEAB4C0019AA84 /* OEVersionMigrationController.m */; };
+		22477F282F81F85500C2A0BD /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 22477F272F81F85500C2A0BD /* Sentry */; };
+		22477F2A2F81F99300C2A0BD /* SentryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22477F292F81F99300C2A0BD /* SentryService.swift */; };
 		277CBA3719DE54200059A2C1 /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120C417112E1300E868A8 /* OpenEmuSystem.framework */; };
 		277CBA4A19DE54A80059A2C1 /* OEIntellivisionSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 277CBA4819DE54A80059A2C1 /* OEIntellivisionSystemResponder.m */; };
 		277CBA5A19DE55210059A2C1 /* Keyboard-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 277CBA5819DE55210059A2C1 /* Keyboard-Mappings.plist */; };
@@ -272,6 +274,7 @@
 		55BE99BC254333FC00E3841E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55BE99BB254333FC00E3841E /* Images.xcassets */; };
 		55BE9A2E2543344300E3841E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55BE9A2D2543344300E3841E /* Images.xcassets */; };
 		55BE9B1025439A1E00E3841E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55BE9B0F25439A1E00E3841E /* Images.xcassets */; };
+		56ECCDC1488945C2A09403D7 /* OECoreMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */; };
 		5A2CE89A206EA61B00790F89 /* NSArray+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2CE899206EA61B00790F89 /* NSArray+OEAdditions.swift */; };
 		5A3BB0391D964A4500E10F27 /* CenteredTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3BB0381D964A4500E10F27 /* CenteredTextFieldCell.swift */; };
 		5A3DB1691D8C93C3009445EC /* PreferencesControlsBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3DB1681D8C93C3009445EC /* PreferencesControlsBox.swift */; };
@@ -442,7 +445,6 @@
 		8F8DB27B26D2A69E003CF106 /* PreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53439B6813B932C5005C0CC8 /* PreferencePane.swift */; };
 		8F93FDDA27374F2000B59F3E /* GameInfoHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDD927374F2000B59F3E /* GameInfoHelperTests.swift */; };
 		8F93FDE02737506900B59F3E /* ROMImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDDF2737506900B59F3E /* ROMImporterTests.swift */; };
-		56ECCDC1488945C2A09403D7 /* OECoreMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */; };
 		8F9410C0273A0167004C47CC /* CoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */; };
 		8F94B44D25566FE00058AA94 /* NSShadow+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94B44C25566FE00058AA94 /* NSShadow+OEAdditions.swift */; };
 		8F94DEC1250EC701003A1F33 /* ThumbnailProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94DEC0250EC701003A1F33 /* ThumbnailProvider.swift */; };
@@ -1354,6 +1356,7 @@
 		1BEF2A9411682A530090F72B /* OpenEmuHelperApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = OpenEmuHelperApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E2F3DB910DEAB4C0019AA84 /* OEVersionMigrationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEVersionMigrationController.h; sourceTree = "<group>"; };
 		1E2F3DBA10DEAB4C0019AA84 /* OEVersionMigrationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEVersionMigrationController.m; sourceTree = "<group>"; };
+		22477F292F81F99300C2A0BD /* SentryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryService.swift; sourceTree = "<group>"; };
 		277CBA4519DE54200059A2C1 /* Intellivision.oesystemplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Intellivision.oesystemplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		277CBA4719DE54A80059A2C1 /* OEIntellivisionSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEIntellivisionSystemResponder.h; sourceTree = "<group>"; };
 		277CBA4819DE54A80059A2C1 /* OEIntellivisionSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEIntellivisionSystemResponder.m; sourceTree = "<group>"; };
@@ -1469,6 +1472,7 @@
 		5AFD06BC2058893B00DFE765 /* GameScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameScannerViewController.swift; sourceTree = "<group>"; };
 		5CCE228E57ED51524BAE52BB /* OESyncStatusOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OESyncStatusOverlayView.swift; sourceTree = "<group>"; };
 		6F74677D2124A2E934C10038 /* OESaveSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OESaveSyncManager.swift; sourceTree = "<group>"; };
+		6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OECoreMigration.swift; sourceTree = "<group>"; };
 		7699EC921D6303EB005BC437 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		7699EC931D6303EC005BC437 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7699EC941D6303EC005BC437 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ControlLabels.strings; sourceTree = "<group>"; };
@@ -1538,7 +1542,6 @@
 		8370D3E01A8D2A7600313F87 /* ArrowCursorTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrowCursorTextView.swift; sourceTree = "<group>"; };
 		83753F1614F537C400D708A7 /* PrefDebugController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefDebugController.swift; sourceTree = "<group>"; };
 		83753F1914F5383F00D708A7 /* PrefDebugController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrefDebugController.xib; sourceTree = "<group>"; };
-		6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OECoreMigration.swift; sourceTree = "<group>"; };
 		8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreUpdater.swift; sourceTree = "<group>"; };
 		837820B71907FADB0043593F /* IKRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKRenderer.h; sourceTree = "<group>"; };
 		837820B81907FB2D0043593F /* IKImageWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKImageWrapper.h; sourceTree = "<group>"; };
@@ -2201,6 +2204,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22477F282F81F85500C2A0BD /* Sentry in Frameworks */,
 				05F5BAED228662D3004D713C /* OpenEmuShaders.framework in Frameworks */,
 				052B92D4226EE66C00701431 /* libc++.tbd in Frameworks */,
 				058B557D27AF240A00EE0E47 /* OrderedCollections in Frameworks */,
@@ -2882,6 +2886,7 @@
 		2A37F4AAFDCFA73011CA2CEA /* OpenEmu */ = {
 			isa = PBXGroup;
 			children = (
+				22477F292F81F99300C2A0BD /* SentryService.swift */,
 				5AECA14A1BE1D26700C3B4E2 /* Swift Bridging Header */,
 				2A37F4ABFDCFA73011CA2CEA /* Sources */,
 				C67118201363687A0034379A /* System Plugins */,
@@ -4721,6 +4726,7 @@
 				8F44DEB426DFD07200893A18 /* Sparkle */,
 				8F2543F92714C274003FC137 /* Finite */,
 				058B557C27AF240A00EE0E47 /* OrderedCollections */,
+				22477F272F81F85500C2A0BD /* Sentry */,
 			);
 			productName = OpenEmu;
 			productReference = 8D15AC370486D014006FF6A4 /* OpenEmu.app */;
@@ -5399,6 +5405,7 @@
 				8F2543F82714C273003FC137 /* XCRemoteSwiftPackageReference "Finite" */,
 				058B557B27AF240A00EE0E47 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				8F7C2953288A2D7C00A16C09 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
+				22477F262F81F85500C2A0BD /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = 19C28FB0FE9D524F11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -6404,6 +6411,7 @@
 				0571307F259A8859001CB13A /* AppMover.swift in Sources */,
 				05888F3A25A0373300286232 /* ShaderParametersViewController.swift in Sources */,
 				8F80217A24F45E4800DC82E3 /* ControlsScroller.swift in Sources */,
+				22477F2A2F81F99300C2A0BD /* SentryService.swift in Sources */,
 				EFBD5D7814EFE19A00FBD1E0 /* NSColor+OEAdditions.swift in Sources */,
 				8F3A184E2860B5D9008A7AC9 /* OELibraryDatabase+Moving.swift in Sources */,
 				EFBD5D7F14EFE26300FBD1E0 /* OEGridView.m in Sources */,
@@ -9366,6 +9374,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		22477F262F81F85500C2A0BD /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.9.0;
+			};
+		};
 		8F2543F82714C273003FC137 /* XCRemoteSwiftPackageReference "Finite" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/vknabel/Finite.git";
@@ -9397,6 +9413,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 058B557B27AF240A00EE0E47 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
+		};
+		22477F272F81F85500C2A0BD /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 22477F262F81F85500C2A0BD /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 		8F2543F92714C274003FC137 /* Finite */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/OpenEmu/SentryService.swift
+++ b/OpenEmu/SentryService.swift
@@ -1,0 +1,82 @@
+/*
+ Copyright (c) 2026, OpenEmu Team
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+     * Neither the name of the OpenEmu Team nor the
+       names of its contributors may be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Cocoa
+import Sentry
+
+enum SentryService {
+
+    private static let dsn = "https://387777a8153aae33cb514deea3601946@o4511164820815872.ingest.us.sentry.io/4511164891529216"
+
+    // UserDefaults keys
+    private static let consentKey    = "OESentryCrashReportingEnabled"
+    private static let hasPromptedKey = "OESentryCrashReportingPrompted"
+
+    /// Call once at the top of applicationDidFinishLaunching.
+    /// On first launch, shows a consent prompt. On subsequent launches,
+    /// starts Sentry automatically if the user previously opted in.
+    static func configureIfNeeded() {
+        let defaults = UserDefaults.standard
+
+        if !defaults.bool(forKey: hasPromptedKey) {
+            showConsentPrompt()
+            return
+        }
+
+        if defaults.bool(forKey: consentKey) {
+            start()
+        }
+    }
+
+    // MARK: - Private
+
+    private static func showConsentPrompt() {
+        let alert = NSAlert()
+        alert.messageText = "Help Improve OpenEmu"
+        alert.informativeText = "Would you like to automatically send crash reports when OpenEmu crashes? This helps the team find and fix bugs faster.\n\nNo personal data, game files, or save data is ever included."
+        alert.addButton(withTitle: "Send Crash Reports")
+        alert.addButton(withTitle: "Don't Send")
+        alert.alertStyle = .informational
+
+        let opted = alert.runModal() == .alertFirstButtonReturn
+
+        let defaults = UserDefaults.standard
+        defaults.set(opted,  forKey: consentKey)
+        defaults.set(true,   forKey: hasPromptedKey)
+
+        if opted {
+            start()
+        }
+    }
+
+    private static func start() {
+        SentrySDK.start { options in
+            options.dsn   = dsn
+            options.debug = false
+            options.tracesSampleRate = 0   // crash reports only — no performance tracing
+        }
+    }
+}

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -104,6 +104,21 @@ xcodebuild archive \
 [ -d "$ARCHIVE_PATH" ] || die "Archive not found at expected path: $ARCHIVE_PATH"
 echo "Archive: $ARCHIVE_PATH"
 
+# ── 1.5. Upload dSYMs to Sentry ───────────────────────────────────────────────
+step "Uploading dSYMs to Sentry (symbolicated crash reports)"
+
+if command -v sentry-cli &>/dev/null; then
+  sentry-cli upload-dif \
+    --org openemu-silicon \
+    --project openemu-silicon \
+    "$ARCHIVE_PATH/dSYMs/" \
+    || echo "WARNING: dSYM upload to Sentry failed — crash stack traces may be unreadable. Check sentry-cli auth."
+else
+  echo "WARNING: sentry-cli not installed. Crash stack traces in Sentry will not be symbolicated."
+  echo "         Install with: brew install getsentry/tools/sentry-cli"
+  echo "         Then authenticate: sentry-cli login"
+fi
+
 # ── 2. Notarize (re-sign + notarize + DMG + staple) ──────────────────────────
 step "2/5  Re-signing, notarizing, and creating DMG"
 


### PR DESCRIPTION
## Summary

- Adds `SentryService.swift` — initializes the Sentry SDK; on first launch shows a native consent alert before sending any data
- Wires `SentryService.configureIfNeeded()` into `AppDelegate.applicationDidFinishLaunching` as the very first call
- Adds `sentry-cli` dSYM upload step to `Scripts/release.sh` so crash stack traces are symbolicated in the Sentry dashboard
- Crash reports only — performance tracing is disabled (`tracesSampleRate = 0`)

## Test plan

- [ ] Fresh install (or clear `OESentryCrashReportingPrompted` from UserDefaults): consent prompt appears on launch
- [ ] Choose "Send Crash Reports" → Sentry initializes, subsequent launches skip the prompt and start Sentry automatically
- [ ] Choose "Don't Send" → Sentry never initializes, no data sent on any launch
- [ ] Trigger a test crash (`SentrySDK.crash()` in a debug build) → report appears in the Sentry dashboard
- [ ] Release build: `sentry-cli upload-dif` runs and dSYMs appear in Sentry project settings

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)