### PR TITLE
feat: add Homebrew tap cask for openemu-silicon

### DIFF
--- a/Casks/openemu-silicon.rb
+++ b/Casks/openemu-silicon.rb
@@ -1,0 +1,19 @@
+cask "openemu-silicon" do
+  version "1.0.3"
+  sha256 "70c4000259c5e8f0433fd6d81c85118871fce18ed1695099260472f2d48c1bdf"
+
+  url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
+  name "OpenEmu Silicon"
+  desc "Native Apple Silicon port of the OpenEmu multi-system emulator"
+  homepage "https://github.com/nickybmon/OpenEmu-Silicon"
+
+  depends_on macos: ">= :big_sur"
+
+  app "OpenEmu.app"
+
+  zap trash: [
+    "~/Library/Application Support/OpenEmu",
+    "~/Library/Preferences/org.openemu.OpenEmu.plist",
+    "~/Library/Caches/org.openemu.OpenEmu",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ If original OpenEmu meets your needs today, there's no urgency. But if you've ha
 
 Get the latest build from the **[Releases](https://github.com/nickybmon/OpenEmu-Silicon/releases)** page.
 
+### Install via Homebrew
+
+```bash
+brew tap nickybmon/OpenEmu-Silicon
+brew install --cask openemu-silicon
+```
+
 ---
 
 ## What's New


### PR DESCRIPTION
## Summary

- Adds `Casks/openemu-silicon.rb` so the repo functions as a Homebrew tap
- Users can now install via `brew tap nickybmon/OpenEmu-Silicon && brew install --cask openemu-silicon`
- SHA256 matches the notarized v1.0.3 DMG on GitHub Releases
- README updated with Homebrew install instructions

## Cask stanzas

- `depends_on macos: ">= :big_sur"` — matches the project's macOS 11.0 deployment target
- `zap` removes `~/Library/Application Support/OpenEmu`, preferences plist, and caches on `brew zap`

## Updating after each release

After publishing a new GitHub Release:
1. Compute SHA256: `curl -sL <dmg_url> | shasum -a 256`
2. Update `version` and `sha256` in `Casks/openemu-silicon.rb`
3. Commit directly to `main` (config-only change per CLAUDE.md)

## Test plan

- [ ] `brew tap nickybmon/OpenEmu-Silicon`
- [ ] `brew install --cask openemu-silicon` — app installs, opens, loads cores
- [ ] `brew uninstall --cask openemu-silicon` — app removed cleanly
- [ ] `brew zap --cask openemu-silicon` — support files removed

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)