### PR TITLE
fix: polish Image Adjustments sliders and prefs window sizing

### DIFF
--- a/OpenEmu/GameControlsBarView.swift
+++ b/OpenEmu/GameControlsBarView.swift
@@ -254,7 +254,7 @@ final class GameControlsBarView: NSView {
         }
         
         let popover = NSPopover()
-        popover.behavior = .transient
+        popover.behavior = .semitransient
         self.adjustmentsPopover = popover
         
         let vc = NSViewController()

--- a/OpenEmu/PrefGameplayController.swift
+++ b/OpenEmu/PrefGameplayController.swift
@@ -70,88 +70,85 @@ final class PrefGameplayController: NSViewController {
         let sat = OEGameDocument.clampedSaturation((UserDefaults.standard.object(forKey: OEGameSaturationKey) as? Float) ?? 1.0)
         let gam = OEGameDocument.clampedGamma((UserDefaults.standard.object(forKey: OEGameGammaKey) as? Float) ?? 1.0)
 
-        let rowH:   CGFloat = 24
-        let gap:    CGFloat = 12
-        let extraH: CGFloat = gap + rowH + gap + rowH + gap
-        let extraW: CGFloat = 140
+        // The XIB has one NSGridView (2 columns) as the only direct subview.
+        // Walk up from the shader popup to find it, then insert two new rows
+        // at index 0 (above Shader). NSGridView handles all layout automatically.
+        var ancestor: NSView? = globalDefaultShaderSelection
+        while let parent = ancestor?.superview, parent !== view { ancestor = parent }
+        guard let gridView = ancestor as? NSGridView else { return }
 
-        // Capture original height before growing — the new space for sliders
-        // sits at y = originalHeight … y = originalHeight + extraH (flipped view).
-        let originalHeight = view.frame.height
+        // ── Build Saturation row ──────────────────────────────────────────
+        let satLabel = NSTextField(labelWithString: "Saturation:")
+        satLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
 
-        // ── Grow the view ─────────────────────────────────────────────────
-        view.setFrameSize(NSSize(width: view.frame.width + extraW,
-                                 height: view.frame.height + extraH))
+        let satSlider = NSSlider(value: Double(sat), minValue: 0.5, maxValue: 3.0,
+                                 target: self, action: #selector(saturationChanged(_:)))
+        satSlider.isContinuous = true
+        satSlider.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        // ── Grow the window to match ───────────────────────────────────────
-        if let window = view.window {
+        let satPct = NSTextField(labelWithString: String(format: "%.0f%%", sat * 100))
+        satPct.font = .monospacedDigitSystemFont(ofSize: NSFont.systemFontSize - 1, weight: .regular)
+        satPct.setContentHuggingPriority(.required, for: .horizontal)
+
+        let satRow = NSStackView(views: [satSlider, satPct])
+        satRow.orientation = .horizontal
+        satRow.spacing = 8
+        satRow.distribution = .fill
+
+        // ── Build Gamma row ───────────────────────────────────────────────
+        let gamLabel = NSTextField(labelWithString: "Gamma:")
+        gamLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+
+        let gamSlider = NSSlider(value: Double(gam), minValue: 0.5, maxValue: 2.0,
+                                 target: self, action: #selector(gammaChanged(_:)))
+        gamSlider.isContinuous = true
+        gamSlider.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let gamPct = NSTextField(labelWithString: String(format: "%.0f%%", gam * 100))
+        gamPct.font = .monospacedDigitSystemFont(ofSize: NSFont.systemFontSize - 1, weight: .regular)
+        gamPct.setContentHuggingPriority(.required, for: .horizontal)
+
+        let gamRow = NSStackView(views: [gamSlider, gamPct])
+        gamRow.orientation = .horizontal
+        gamRow.spacing = 8
+        gamRow.distribution = .fill
+
+        // ── Insert rows above Shader ──────────────────────────────────────
+        // Insert Gamma at 0 first, then Saturation at 0 → Saturation ends up on top.
+        let sizeBefore = view.fittingSize
+        gridView.insertRow(at: 0, with: [gamLabel, gamRow])
+        gridView.insertRow(at: 0, with: [satLabel, satRow])
+
+        // Center the grid horizontally within the (potentially wider) window.
+        // Deactivate the XIB's fixed leading=30 and soft trailing>=30 constraints,
+        // then pin the grid to the center with minimum side margins.
+        for c in view.constraints where (c.firstItem as? NSView) === gridView
+                                     && c.firstAttribute == .leading {
+            c.isActive = false
+        }
+        for c in view.constraints where c.secondItem as? NSView === gridView
+                                     && c.secondAttribute == .trailing {
+            c.isActive = false
+        }
+        NSLayoutConstraint.activate([
+            gridView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            gridView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 30),
+            gridView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -30)
+        ])
+
+        // ── Grow the window upward to fit the new rows ────────────────────
+        view.layoutSubtreeIfNeeded()
+        let deltaH = view.fittingSize.height - sizeBefore.height
+        if let window = view.window, deltaH > 0 {
             var wf = window.frame
-            wf.origin.y    -= extraH
-            wf.size.height += extraH
-            wf.size.width  += extraW
+            wf.size.height += deltaH
             window.setFrame(wf, display: true, animate: false)
         }
 
-        let shaderX = globalDefaultShaderSelection.frame.minX
-        let rowW    = view.frame.width - shaderX - 20
-
-        // Place sliders in the newly-added space below all existing content.
-        // The view is flipped (y=0 at top), so "below" means higher y values.
-        let gamY = originalHeight + gap
-        let satY = originalHeight + gap + rowH + gap
-
-        let (satView, satSlider, satLbl) = makeRow(
-            label: "Saturation:", value: sat, minValue: 0.5, maxValue: 3.0,
-            frame: NSRect(x: shaderX, y: satY, width: rowW, height: rowH),
-            action: #selector(saturationChanged(_:))
-        )
-        let (gamView, gamSlider, gamLbl) = makeRow(
-            label: "Gamma:", value: gam, minValue: 0.5, maxValue: 2.0,
-            frame: NSRect(x: shaderX, y: gamY, width: rowW, height: rowH),
-            action: #selector(gammaChanged(_:))
-        )
-
-        view.addSubview(satView)
-        view.addSubview(gamView)
-
         saturationSlider = satSlider
-        saturationLabel  = satLbl
+        saturationLabel  = satPct
         gammaSlider      = gamSlider
-        gammaLabel       = gamLbl
-    }
-
-    private func makeRow(
-        label: String, value: Float,
-        minValue: Double, maxValue: Double,
-        frame: NSRect, action: Selector
-    ) -> (NSView, NSSlider, NSTextField) {
-
-        let container = NSView(frame: frame)
-
-        let labelW: CGFloat = 80
-        let pctW:   CGFloat = 44
-        let sliderW = frame.width - labelW - pctW - 8
-
-        let lbl = NSTextField(labelWithString: label)
-        lbl.font  = .systemFont(ofSize: NSFont.systemFontSize)
-        lbl.frame = NSRect(x: 0, y: 0, width: labelW, height: frame.height)
-        container.addSubview(lbl)
-
-        let slider = NSSlider(value: Double(value), minValue: minValue, maxValue: maxValue,
-                              target: self, action: action)
-        slider.isContinuous = true
-        slider.frame = NSRect(x: labelW + 4, y: 0, width: sliderW, height: frame.height)
-        container.addSubview(slider)
-
-        let pct = NSTextField(
-            labelWithString: String(format: "%.0f%%", value * 100))
-        pct.font  = .monospacedDigitSystemFont(ofSize: NSFont.systemFontSize - 1,
-                                               weight: .regular)
-        pct.frame = NSRect(x: labelW + 4 + sliderW + 4, y: 0,
-                           width: pctW, height: frame.height)
-        container.addSubview(pct)
-
-        return (container, slider, pct)
+        gammaLabel       = gamPct
     }
 
     // MARK: - Slider actions
@@ -224,5 +221,5 @@ extension PrefGameplayController: PreferencePane {
     
     var panelTitle: String { "Gameplay" }
     
-    var viewSize: NSSize { view.frame.size }
+    var viewSize: NSSize { view.fittingSize }
 }

--- a/OpenEmu/PrefLibraryController.swift
+++ b/OpenEmu/PrefLibraryController.swift
@@ -46,12 +46,29 @@ final class PrefLibraryController: NSViewController {
         gridView.cell(for: librariesView)?.contentView = scrollView
         librariesView.removeFromSuperview()
         librariesView = scrollView
-        
+
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.borderType = .bezelBorder
+        // Use a minimum height but allow the scroll view to grow taller.
         NSLayoutConstraint.activate([
             scrollView.widthAnchor.constraint(equalToConstant: size.width),
-            scrollView.heightAnchor.constraint(equalToConstant: size.height)
+            scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: size.height)
+        ])
+
+        // Center the grid horizontally within the (potentially wider) window.
+        // Deactivate XIB's fixed leading=30 and soft trailing>=30, then pin to center.
+        for c in view.constraints where (c.firstItem as? NSView) === gridView
+                                     && c.firstAttribute == .leading {
+            c.isActive = false
+        }
+        for c in view.constraints where c.secondItem as? NSView === gridView
+                                     && c.secondAttribute == .trailing {
+            c.isActive = false
+        }
+        NSLayoutConstraint.activate([
+            gridView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            gridView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 30),
+            gridView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -30)
         ])
 
         availableLibrariesViewController.loadData()

--- a/OpenEmu/PreferencesWindowController.swift
+++ b/OpenEmu/PreferencesWindowController.swift
@@ -151,6 +151,9 @@ final class PreferencesTabViewController: NSTabViewController {
     
     /// Used to track when viewDidLoad has completed so that the default pane index selection of 0 doesn't get recorded in tabView(_:, didSelectTabViewItem:).
     fileprivate var viewDidLoadFinished = false
+
+    /// Floor width computed from all panes at load time so the window never opens narrower than the widest pane.
+    private var minimumContentWidth: CGFloat = 0
     
     override func viewDidLoad() {
         
@@ -188,7 +191,10 @@ final class PreferencesTabViewController: NSTabViewController {
         
         // Select a pane.
         tabView.selectTabViewItem(at: indexOfPaneToSelect)
-        
+
+        // Pre-compute the widest pane so the window never opens too narrow.
+        minimumContentWidth = children.compactMap { $0 as? PreferencePane }.map { $0.viewSize.width }.max() ?? 0
+
         viewDidLoadFinished = true
     }
     
@@ -242,12 +248,20 @@ final class PreferencesTabViewController: NSTabViewController {
     }
     
     func updateWindowFrame(animated: Bool) {
-        
+
         guard let selectedItem = tabView.selectedTabViewItem, let window = view.window else {
             return
         }
-        
-        let contentSize = (selectedItem.viewController! as! PreferencePane).viewSize
+
+        let paneSize = (selectedItem.viewController! as! PreferencePane).viewSize
+
+        // Never shrink width — once a wide pane (Controls) has been shown,
+        // all other panes keep that width. Height changes per pane so each
+        // pane fills its content area correctly (no black bars).
+        let currentContentWidth = window.contentRect(forFrameRect: window.frame).width
+        let contentSize = NSSize(width: max(paneSize.width, currentContentWidth, minimumContentWidth),
+                                 height: paneSize.height)
+
         let newWindowSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: contentSize)).size
         
         var frame = window.frame


### PR DESCRIPTION
## Summary

- **GameControlsBarView**: popover `.behavior` changed from `.transient` to `.semitransient` — slider drags no longer accidentally dismiss the Image Adjustments popover
- **PrefGameplayController**: Saturation/Gamma sliders injected via `NSGridView.insertRow()` instead of manual frame math; grid centered horizontally; `viewSize` returns `fittingSize`
- **PrefLibraryController**: grid centered horizontally; Available Libraries scroll view height changed to `greaterThanOrEqualToConstant` so it scales correctly at the wider Controls width
- **PreferencesWindowController**: window width never shrinks below widest pane; `minimumContentWidth` is computed from all panes at load time so the window opens at the full Controls width on first launch, not only after clicking the Controls tab

## Test plan

- [x] Open Preferences → window opens at full Controls width immediately (not narrow)
- [x] Switch between every pane — width never shrinks, height adjusts per pane
- [x] Open a game → open Image Adjustments popover → drag Saturation slider — popover stays open
- [x] Drag Gamma slider — popover stays open
- [x] Gameplay pane: Saturation and Gamma sliders appear, are aligned with the rest of the grid, and percentage labels update while dragging
- [x] Library pane: grid is centered; Available Libraries list is visible and scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)