### PR TITLE
fix: guard controller nil in OESystemPlugin.systemIcon

### DIFF
--- a/OpenEmuKit/Source/OESystemPlugin.swift
+++ b/OpenEmuKit/Source/OESystemPlugin.swift
@@ -150,7 +150,7 @@ public class OESystemPlugin: OEPlugin {
     }
     
     public var systemIcon: NSImage {
-        return controller.systemIcon
+        return controller?.systemIcon ?? NSImage()
     }
     
     public var responderClass: AnyClass {


### PR DESCRIPTION
## Test setup

None.

## Build & run

Checkout, build, and launch this PR locally:

```bash
gh pr checkout 147 --repo nickybmon/OpenEmu-Silicon
```

```bash
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build 2>&1 | tail -30
```

```bash
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
```

---


## Summary

- `OESystemPlugin.controller` is an implicitly unwrapped optional. When `bundle.principalClass` is nil or can't be cast to `OESystemController.Type`, the controller stays nil.
- Accessing `.systemIcon` on a nil controller caused a fatal force-unwrap crash during `NSTableView` layout as a system-browser window became visible, triggering a stack overflow.
- Fix: use optional chaining (`controller?.systemIcon`) with an `NSImage()` fallback so a plugin with a broken/unloaded controller degrades gracefully.

**Sentry:** OPENEM-SILICON-5 (3 events, fatal crash, macOS 26.3)
**Closes:** #145

## Test plan

- [x] Launch app and open the system/core browser — confirm no crash
- [x] Verify system icons still appear for all installed system plugins
- [x] Confirm `BUILD SUCCEEDED` (verified locally)