### PR TITLE
fix: defer Sentry consent prompt until main window is visible

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -843,8 +843,6 @@ extension AppDelegate: NSMenuDelegate {
         notificationCenter.removeObserver(self, name: NSApplication.didFinishRestoringWindowsNotification, object: nil)
     }
     func applicationDidFinishLaunching(_ notification: Notification) {
-        SentryService.configureIfNeeded()
-
         // Get the “Customize Touch Bar…” menu to display in the View menu.
         NSApp.isAutomaticCustomizeTouchBarMenuItemEnabled = true
         
@@ -921,7 +919,12 @@ extension AppDelegate: NSMenuDelegate {
         if !restoreWindow {
             mainWindowController.showWindow(nil)
         }
-        
+
+        // Deferred from applicationDidFinishLaunching so the main window is visible
+        // before the consent sheet appears. Showing a runModal alert before the window
+        // rendered caused a CA transaction hang on macOS 26 (OPENEM-SILICON-8 et al).
+        SentryService.configureIfNeeded()
+
         CoreUpdater.shared.checkForNewCores()   // TODO: check error from completion handler
         
         let userDefaultsController = NSUserDefaultsController.shared

--- a/OpenEmu/SentryService.swift
+++ b/OpenEmu/SentryService.swift
@@ -91,15 +91,21 @@ enum SentryService {
         alert.addButton(withTitle: "Don't Send")
         alert.alertStyle = .informational
 
-        let opted = alert.runModal() == .alertFirstButtonReturn
-
-        let defaults = UserDefaults.standard
-        defaults.set(opted,  forKey: consentKey)
-        defaults.set(true,   forKey: hasPromptedKey)
-
-        if opted {
-            start()
+        guard let window = NSApp.mainWindow ?? NSApp.keyWindow else {
+            persistConsent(alert.runModal() == .alertFirstButtonReturn)
+            return
         }
+
+        alert.beginSheetModal(for: window) { response in
+            persistConsent(response == .alertFirstButtonReturn)
+        }
+    }
+
+    private static func persistConsent(_ opted: Bool) {
+        let defaults = UserDefaults.standard
+        defaults.set(opted, forKey: consentKey)
+        defaults.set(true,  forKey: hasPromptedKey)
+        if opted { start() }
     }
 
     private static func start() {


### PR DESCRIPTION
## Test setup

**Reset consent state so the prompt appears on launch:**

```bash
defaults delete org.openemu.OpenEmu OESentryCrashReportingPrompted
defaults delete org.openemu.OpenEmu OESentryCrashReportingEnabled
```

**After testing — clean up:**

```bash
defaults delete org.openemu.OpenEmu OESentryCrashReportingPrompted
defaults delete org.openemu.OpenEmu OESentryCrashReportingEnabled
```

## Build & run

Checkout, build, and launch this PR locally:

```bash
gh pr checkout 148 --repo nickybmon/OpenEmu-Silicon
```

```bash
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build 2>&1 | tail -30
```

```bash
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
```

---

## Summary

On first launch, the Sentry crash-reporting consent alert was shown via `runModal()` as the very first action in `applicationDidFinishLaunching` — before the main window had rendered. On macOS 26 Tahoe, a `CA::Transaction::commit` triggered inside the modal run loop took >2s, firing the ANR hang watchdog. This caused 5 separate hang events (same root cause) across multiple users.

Two changes:

**1. Move `SentryService.configureIfNeeded()` to after the main window appears**
Relocated from `applicationDidFinishLaunching` to `libraryDatabaseDidLoad`, after `mainWindowController.showWindow()`. The window's initial CA transaction has already flushed by this point, so the CA work inside any subsequent modal is minimal.

**2. Convert consent alert from `runModal()` to `beginSheetModal`**
The blocking standalone alert is replaced with a sheet attached to the main window. The result is passed to a `persistConsent(_:)` helper. A `runModal` fallback remains for the edge case where no window is available (should never happen post-library-load).

**Sentry issues closed:** OPENEM-SILICON-8 (3 users), OPENEM-SILICON-6 (2 users), OPENEM-SILICON-7, OPENEM-SILICON-B, OPENEM-SILICON-F
**Closes:** #146

## Test plan

- [x] Delete `OESentryCrashReportingPrompted` from UserDefaults, relaunch — confirm consent sheet appears attached to main window (not a standalone modal)
- [x] Confirm no hang on macOS 26 at launch
- [x] Accept consent → confirm Sentry starts (check for events in Sentry dashboard)
- [ ] Decline consent → confirm no Sentry events
- [x] On subsequent launches, confirm no prompt appears and Sentry starts/stays off per previous choice
- [x] `BUILD SUCCEEDED` verified locally