### PR TITLE
fix: allow keyboard remapping when IOHIDCheckAccess returns unknown

### DIFF
--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
@@ -173,7 +173,12 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
 - (void)rescanKeyboardDevices
 {
     if (@available(macOS 10.15, *)) {
-        if (self.accessType != OEDeviceAccessTypeGranted) return;
+        // Only skip if the user has explicitly denied access. "Unknown" means TCC
+        // couldn't confirm the grant (common on ad-hoc/dev-signed builds and on
+        // some macOS beta releases), but the permission is typically still in effect.
+        // Letting IOKit attempt the match is safe: if permission truly isn't present,
+        // no keyboard devices will appear in the matching callback.
+        if (self.accessType == OEDeviceAccessTypeDenied) return;
         if (_keyboardHandlers.count > 0) return;  // already enumerated
 
         // Rebuild the matching array with keyboards included and re-apply it.

--- a/OpenEmu/PrefControlsController.swift
+++ b/OpenEmu/PrefControlsController.swift
@@ -206,8 +206,8 @@ final class PrefControlsController: NSViewController {
         OEBindingsController.default.synchronize()
         
         let nc = NotificationCenter.default
-        nc.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: view.window)
-        nc.removeObserver(self, name: NSWindow.didResignKeyNotification, object: view.window)
+        nc.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: nil)
+        nc.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
         
         tearDownEventMonitor()
     }


### PR DESCRIPTION
## Test setup

None.

## Build & run

Checkout, build, and launch this PR locally:

```bash
gh pr checkout 149 --repo nickybmon/OpenEmu-Silicon
```

```bash
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build 2>&1 | tail -30
```

```bash
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
```

---


## Summary

- **`OEDeviceManager.rescanKeyboardDevices`** — change the access-type guard from `!= Granted` to `== Denied`. `IOHIDCheckAccess` returns `unknown` (not `granted`) on ad-hoc/dev-signed builds and on some macOS beta releases even when Input Monitoring is fully granted. The old strict guard caused `rescanKeyboardDevices` to bail early every time, so no keyboard device handler was ever created and keystrokes were silently dropped in the Controls preferences panel. Only bailing on explicit denial is safe — if permission truly isn't present, IOKit simply won't produce keyboard matching callbacks.

- **`PrefControlsController.viewWillDisappear`** — fix a `NSNotificationCenter` observer mismatch. Observers were added in `viewDidAppear` with `object: nil` (listening to all windows) but removed with `object: view.window`. The `removeObserver` call never matched the registered observer, so observers accumulated on each appearance cycle.

## Root cause

When a user grants Input Monitoring and opens Controls → Preferences, the app calls `rescanKeyboardDevices()` to enumerate the physical keyboard via IOKit. That function checked `self.accessType != OEDeviceAccessTypeGranted` as a guard. On certain builds (ad-hoc signed, running on macOS beta, or shortly after a permission grant before a restart) `IOHIDCheckAccess` returns `unknown` rather than `granted`. The guard fired and returned early, so the keyboard was never enumerated, and every keystroke in the Controls panel was silently ignored.

## Test plan

- [x] Open Preferences → Controls, select any system, ensure Input is set to **Keyboard**
- [x] Click a binding button — it highlights
- [x] Press a keyboard key — confirm the binding updates
- [x] Repeat for a second binding to confirm auto-advance works
- [x] Quit and reopen — confirm bindings persisted
- [x] `BUILD SUCCEEDED` ✓

Fixes #132