### PR TITLE
fix: Dreamcast — threaded rendering, interpreter, and 14ms frame timeout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,31 @@ Fixes #
 
 ---
 
+## How to test locally
+
+```bash
+# 1. Check out this PR
+gh pr checkout <PR_NUMBER> --repo nickybmon/OpenEmu-Silicon
+
+# 2. Build
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme OpenEmu \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -20
+
+# 3. Launch
+open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
+```
+
+<!-- Replace <PR_NUMBER> with this PR's number. Add any PR-specific setup steps here (e.g. BIOS files needed, permissions to revoke first, specific ROM to test with). -->
+
+---
+
 ## PR checklist
 
-- [ ] Branched from an up-to-date `staging` (ran `git fetch origin && git merge origin/staging`)
+- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
 - [ ] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
 - [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
 - [ ] No build logs, binaries, or credentials committed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,10 @@ Fixes #
 # 1. Check out this PR
 gh pr checkout <PR_NUMBER> --repo nickybmon/OpenEmu-Silicon
 
-# 2. Build
+# 2. Build — use the scheme that covers the changed target.
+#    For main app changes: -scheme OpenEmu
+#    For Flycast core changes: -scheme "OpenEmu + Flycast" with 'clean build'
+#    (incremental builds will not recompile core C++ files)
 xcodebuild \
   -workspace OpenEmu-metal.xcworkspace \
   -scheme OpenEmu \
@@ -36,7 +39,11 @@ xcodebuild \
   -destination 'platform=macOS,arch=arm64' \
   build 2>&1 | tail -20
 
-# 3. Launch
+# 3. If this PR touches a core (Flycast, etc.), install the rebuilt binary:
+#    cp -f ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/<CoreName>.oecoreplugin/Contents/MacOS/<CoreName> \
+#      ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin/Contents/MacOS/<CoreName>
+
+# 4. Launch
 open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,28 @@ These rules exist because AI-assisted sessions have previously created orphaned 
 - Reference the issue with `Fixes #N` in the commit body (auto-closes on merge) or `Related to #N` (soft link)
 - For core-specific fixes, note which systems are affected
 
+**Every PR description must include a "How to test locally" section** with exact copy-paste commands:
+
+```
+## How to test locally
+
+# 1. Check out this PR
+gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon
+
+# 2. Build
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme OpenEmu \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -20
+
+# 3. Launch
+open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
+```
+
+Replace `<N>` with the actual PR number. Add any PR-specific setup steps below the commands — for example: which ROM or system to test, any BIOS files required, any permissions to revoke first, or specific behaviors to verify from the QA spec.
+
 ---
 
 ## Issue Tracker

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -138,7 +138,7 @@ __weak FlycastGameCore *_current;
 
     config::RendererType = RenderType::OpenGL;
     config::AudioBackend.set("openemu");
-    config::DynarecEnabled = true;
+    config::DynarecEnabled.override(false); // interpreter — JIT has stability issues on ARM64 macOS
 
     if (!addrspace::reserve()) {
         NSLog(@"[Flycast] Failed to reserve Dreamcast address space");
@@ -152,6 +152,18 @@ __weak FlycastGameCore *_current;
 - (void)startEmulation
 {
     [super startEmulation];
+}
+
+- (void)stopEmulationWithCompletionHandler:(void(^)(void))completionHandler
+{
+    // In threaded rendering mode, the OE game loop thread is blocked inside
+    // rend_single_frame() waiting for the next frame from the SH4 thread.
+    // emu.stop() calls rend_cancel_emu_wait() which unblocks it, freeing the
+    // thread to execute the completion handler. Safe to call twice — emu.stop()
+    // checks state != Running and returns immediately on the second call.
+    if (_isInitialized)
+        emu.stop();
+    [super stopEmulationWithCompletionHandler:completionHandler];
 }
 
 - (void)stopEmulation
@@ -187,10 +199,9 @@ __weak FlycastGameCore *_current;
             gui_init();
             theGLContext.init();
             emu.loadGame(_romPath.fileSystemRepresentation);
-            // loadGame resets all settings — re-apply overrides after it returns.
-            config::ThreadedRendering.override(false);
-            config::UseReios.override(true); // HLE BIOS: avoids slow GD-ROM loading under interpreter
-            config::AudioBackend.set("openemu"); // loadGame resets this to "auto"; restore before InitAudio()
+            // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
+            config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
+            config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);
@@ -205,7 +216,6 @@ __weak FlycastGameCore *_current;
     }
 
     emu.render();
-    [self.renderDelegate presentDoubleBufferedFBO];
 }
 
 #pragma mark - Video
@@ -217,7 +227,7 @@ __weak FlycastGameCore *_current;
 
 - (BOOL)needsDoubleBufferedFBO
 {
-    return YES;
+    return NO;
 }
 
 - (OEIntSize)bufferSize

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -84,7 +84,8 @@ static OpenEmuAudioBackend openEmuAudioBackend;
     NSString *_romPath;
     int _videoWidth;
     int _videoHeight;
-    BOOL _isInitialized;
+    BOOL _isInitialized;   // emu.start() succeeded — render loop is live
+    BOOL _emuInitialized;  // emu.init() succeeded — safe to call emu.term()
     double _frameInterval;
 }
 @end
@@ -144,6 +145,7 @@ __weak FlycastGameCore *_current;
     os_InstallFaultHandler();
 
     emu.init();
+    _emuInitialized = YES;
 }
 
 - (void)startEmulation
@@ -153,8 +155,8 @@ __weak FlycastGameCore *_current;
 
 - (void)stopEmulationWithCompletionHandler:(void(^)(void))completionHandler
 {
-    if (_isInitialized)
-        emu.stop();
+    // Do not call emu.stop() here — stopEmulation handles full teardown.
+    // Calling stop() twice races with the SH4 thread and causes hangs.
     [super stopEmulationWithCompletionHandler:completionHandler];
 }
 
@@ -168,7 +170,12 @@ __weak FlycastGameCore *_current;
         _isInitialized = NO;
     }
     os_UninstallFaultHandler();
-    emu.term();
+    // Only call emu.term() if emu.init() was called — term() calls
+    // addrspace::release() which crashes if the address space was never set up.
+    if (_emuInitialized) {
+        emu.term();
+        _emuInitialized = NO;
+    }
     [super stopEmulation];
 }
 

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -190,6 +190,7 @@ __weak FlycastGameCore *_current;
             // loadGame resets all settings — re-apply overrides after it returns.
             config::ThreadedRendering.override(false);
             config::UseReios.override(true); // HLE BIOS: avoids slow GD-ROM loading under interpreter
+            config::AudioBackend.set("openemu"); // loadGame resets this to "auto"; restore before InitAudio()
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -84,8 +84,8 @@ static OpenEmuAudioBackend openEmuAudioBackend;
     NSString *_romPath;
     int _videoWidth;
     int _videoHeight;
-    BOOL _isInitialized;   // emu.start() succeeded — render loop is live
-    BOOL _emuInitialized;  // emu.init() succeeded — safe to call emu.term()
+    BOOL _isInitialized;
+    BOOL _emuInitialized;
     double _frameInterval;
 }
 @end
@@ -138,10 +138,11 @@ __weak FlycastGameCore *_current;
 
     config::RendererType = RenderType::OpenGL;
     config::AudioBackend.set("openemu");
-    config::DynarecEnabled = false;
-    config::UseReios.override(true); // HLE BIOS: skips animated swirl, boots instantly on first launch
+    config::DynarecEnabled = true;
 
-    addrspace::reserve();
+    if (!addrspace::reserve()) {
+        NSLog(@"[Flycast] Failed to reserve Dreamcast address space");
+    }
     os_InstallFaultHandler();
 
     emu.init();
@@ -151,13 +152,6 @@ __weak FlycastGameCore *_current;
 - (void)startEmulation
 {
     [super startEmulation];
-}
-
-- (void)stopEmulationWithCompletionHandler:(void(^)(void))completionHandler
-{
-    // Do not call emu.stop() here — stopEmulation handles full teardown.
-    // Calling stop() twice races with the SH4 thread and causes hangs.
-    [super stopEmulationWithCompletionHandler:completionHandler];
 }
 
 - (void)stopEmulation
@@ -170,8 +164,6 @@ __weak FlycastGameCore *_current;
         _isInitialized = NO;
     }
     os_UninstallFaultHandler();
-    // Only call emu.term() if emu.init() was called — term() calls
-    // addrspace::release() which crashes if the address space was never set up.
     if (_emuInitialized) {
         emu.term();
         _emuInitialized = NO;
@@ -195,15 +187,12 @@ __weak FlycastGameCore *_current;
             gui_init();
             theGLContext.init();
             emu.loadGame(_romPath.fileSystemRepresentation);
-            // loadGame calls config::Settings::instance().reset() then load(), both of
-            // which clear any override set before loadGame. Re-apply after loadGame so
-            // the JIT stays disabled when emu.start() launches the SH4 thread.
-            config::DynarecEnabled.override(false);
+            // loadGame resets all settings — re-apply overrides after it returns.
+            config::ThreadedRendering.override(false);
+            config::UseReios.override(true); // HLE BIOS: avoids slow GD-ROM loading under interpreter
             rend_init_renderer();
-            settings.display.width  = _videoWidth;
-            settings.display.height = _videoHeight;
-            gui_setState(GuiState::Closed);
             emu.start();
+            gui_setState(GuiState::Closed);
             _isInitialized = YES;
         } catch (const std::exception &e) {
             NSLog(@"[Flycast] Error loading game: %s", e.what());
@@ -214,13 +203,8 @@ __weak FlycastGameCore *_current;
         }
     }
 
-    try {
-        emu.render();
-    } catch (const std::exception &e) {
-        NSLog(@"[Flycast] emu.render() exception: %s", e.what());
-    } catch (...) {
-        NSLog(@"[Flycast] emu.render() unknown exception");
-    }
+    emu.render();
+    [self.renderDelegate presentDoubleBufferedFBO];
 }
 
 #pragma mark - Video
@@ -232,7 +216,7 @@ __weak FlycastGameCore *_current;
 
 - (BOOL)needsDoubleBufferedFBO
 {
-    return NO;
+    return YES;
 }
 
 - (OEIntSize)bufferSize
@@ -268,39 +252,40 @@ __weak FlycastGameCore *_current;
 {
     if (!_isInitialized) { block(NO, nil); return; }
 
-    // Schedule on the emulator thread — dc_savestate modifies emulator state
-    // and must not race with the SH4 thread.
-    NSString *fileCopy = [fileName copy];
-    emu.run([fileCopy, block]() {
+    @try {
         dc_savestate(0);
         std::string srcPath = hostfs::getSavestatePath(0, false);
         NSString *src = [NSString stringWithUTF8String:srcPath.c_str()];
         NSError *err = nil;
-        [[NSFileManager defaultManager] removeItemAtPath:fileCopy error:nil];
-        [[NSFileManager defaultManager] copyItemAtPath:src toPath:fileCopy error:&err];
+        [[NSFileManager defaultManager] removeItemAtPath:fileName error:nil];
+        [[NSFileManager defaultManager] copyItemAtPath:src toPath:fileName error:&err];
         block(err == nil, err);
-    });
+    } @catch (NSException *e) {
+        NSError *error = [NSError errorWithDomain:OEGameCoreErrorDomain
+                                             code:OEGameCoreCouldNotSaveStateError
+                                         userInfo:@{NSLocalizedDescriptionKey: e.reason ?: @"Failed to save state"}];
+        block(NO, error);
+    }
 }
 
 - (void)loadStateFromFileAtPath:(NSString *)fileName completionHandler:(void (^)(BOOL, NSError *))block
 {
     if (!_isInitialized) { block(NO, nil); return; }
 
-    // Copy OE's file into Flycast's slot path first (safe to do on any thread),
-    // then schedule dc_loadstate on the emulator thread to avoid racing the SH4.
-    std::string dstPath = hostfs::getSavestatePath(0, true);
-    NSString *dst = [NSString stringWithUTF8String:dstPath.c_str()];
-    NSError *err = nil;
-    [[NSFileManager defaultManager] removeItemAtPath:dst error:nil];
-    [[NSFileManager defaultManager] copyItemAtPath:fileName toPath:dst error:&err];
-    if (err) {
-        block(NO, err);
-        return;
+    @try {
+        std::string dstPath = hostfs::getSavestatePath(0, true);
+        NSString *dst = [NSString stringWithUTF8String:dstPath.c_str()];
+        NSError *err = nil;
+        [[NSFileManager defaultManager] removeItemAtPath:dst error:nil];
+        [[NSFileManager defaultManager] copyItemAtPath:fileName toPath:dst error:&err];
+        if (!err) dc_loadstate(0);
+        block(err == nil, err);
+    } @catch (NSException *e) {
+        NSError *error = [NSError errorWithDomain:OEGameCoreErrorDomain
+                                             code:OEGameCoreCouldNotLoadStateError
+                                         userInfo:@{NSLocalizedDescriptionKey: e.reason ?: @"Failed to load state"}];
+        block(NO, error);
     }
-    emu.run([block]() {
-        dc_loadstate(0);
-        block(YES, nil);
-    });
 }
 
 #pragma mark - Input

--- a/Flycast/flycast/core/audio/audiobackend_coreaudio.cpp
+++ b/Flycast/flycast/core/audio/audiobackend_coreaudio.cpp
@@ -173,10 +173,10 @@ public:
 			int avail = (samples_rptr - samples_wptr - 4 + BUFSIZE) % BUFSIZE;
 			if (avail == 0)
 			{
-				if (!wait)
-					break;
-				bufferEmpty.Wait();
-				continue;
+				// Never block the caller thread — in OpenEmu the SH4 runs on the
+				// core thread and a blocking wait here deadlocks the game loop.
+				// Drop samples instead of waiting for the buffer to drain.
+				break;
 			}
 			avail = std::min(avail, size);
 			avail = std::min(avail, (int)BUFSIZE - samples_wptr);

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,7 +1077,7 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	return rend_single_frame(true); // FIXME stop flag?
+	return rend_single_frame(true, 14); // 14ms: return quickly if no frame ready so OE game loop stays responsive
 }
 
 void Emulator::vblank()

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,14 +1077,16 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	// The SH4 interpreter runs at ~10-20% of real speed on ARM64. A Dreamcast
-	// frame takes ~16ms of emulated time but up to ~500ms+ of real time during
-	// heavy workloads (GD-ROM loading, scene transitions). Use 2000ms when the
-	// interpreter is active so the game loop thread waits long enough.
+	// The SH4 interpreter runs at ~10-20% of real speed on ARM64. GD-ROM loading
+	// can take arbitrarily long under the interpreter, so we wait indefinitely
+	// (-1) rather than using a fixed timeout. rend_cancel_emu_wait() unblocks
+	// the render thread on quit via cancelEnqueue(), preventing a deadlock.
+	// With JIT/dynarec the emulator runs at full speed so the default per-field
+	// timeout (-1 passed to rend_single_frame uses its own default) is fine.
 #if FEAT_SHREC != DYNAREC_NONE
-	const int frameTimeout = config::DynarecEnabled ? -1 : 2000;
+	const int frameTimeout = config::DynarecEnabled ? 0 : -1;
 #else
-	const int frameTimeout = 2000;
+	const int frameTimeout = -1;
 #endif
 	return rend_single_frame(true, frameTimeout);
 }

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,18 +1077,14 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	// The SH4 interpreter runs at ~10-20% of real speed on ARM64. GD-ROM loading
-	// can take arbitrarily long under the interpreter, so we wait indefinitely
-	// (-1) rather than using a fixed timeout. rend_cancel_emu_wait() unblocks
-	// the render thread on quit via cancelEnqueue(), preventing a deadlock.
-	// With JIT/dynarec the emulator runs at full speed so the default per-field
-	// timeout (-1 passed to rend_single_frame uses its own default) is fine.
-#if FEAT_SHREC != DYNAREC_NONE
-	const int frameTimeout = config::DynarecEnabled ? 0 : -1;
-#else
-	const int frameTimeout = -1;
-#endif
-	return rend_single_frame(true, frameTimeout);
+	// OpenEmu drives the render loop by calling executeFrame() once per display
+	// frame (~16ms). rend_single_frame() must return within that budget so OE's
+	// game loop thread doesn't stall. We use a short timeout: if no Flycast frame
+	// is ready within the window, return false and let OE call again next tick.
+	// The SH4 interpreter runs at ~10-20% of real speed on ARM64, so during
+	// heavy phases (GD-ROM loading) many OE ticks will return false before a
+	// frame arrives — that is correct and expected behaviour.
+	return rend_single_frame(true, 14);
 }
 
 void Emulator::vblank()

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1000,22 +1000,22 @@ void Emulator::start()
 				ThreadName _("Flycast-emu");
 				InitAudio();
 
-			try {
-				while (state == Running || singleStep || stepRangeTo != 0)
-				{
-					startTime = sh4_sched_now64();
-					renderTimeout = false;
-					runInternal();
-					if (!ggpo::nextFrame())
-						break;
+				try {
+					while (state == Running || singleStep || stepRangeTo != 0)
+					{
+						startTime = sh4_sched_now64();
+						renderTimeout = false;
+						runInternal();
+						if (!ggpo::nextFrame())
+							break;
+					}
+					TermAudio();
+				} catch (...) {
+					setNetworkState(false);
+					getSh4Executor()->Stop();
+					TermAudio();
+					throw;
 				}
-				TermAudio();
-			} catch (...) {
-				setNetworkState(false);
-				getSh4Executor()->Stop();
-				TermAudio();
-				throw;
-			}
 		});
 	}
 	else
@@ -1077,14 +1077,7 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	// OpenEmu drives the render loop by calling executeFrame() once per display
-	// frame (~16ms). rend_single_frame() must return within that budget so OE's
-	// game loop thread doesn't stall. We use a short timeout: if no Flycast frame
-	// is ready within the window, return false and let OE call again next tick.
-	// The SH4 interpreter runs at ~10-20% of real speed on ARM64, so during
-	// heavy phases (GD-ROM loading) many OE ticks will return false before a
-	// frame arrives — that is correct and expected behaviour.
-	return rend_single_frame(true, 14);
+	return rend_single_frame(true); // FIXME stop flag?
 }
 
 void Emulator::vblank()

--- a/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
+++ b/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
@@ -265,8 +265,12 @@ bool rend_single_frame(const bool& enabled, int timeoutMs)
 {
 	FC_PROFILE_SCOPE;
 
+	// timeoutMs == -1: wait indefinitely (interpreter mode — GD-ROM loading can
+	// take arbitrarily long). rend_cancel_emu_wait() unblocks via cancelEnqueue()
+	// so there is no deadlock risk on quit.
+	// timeoutMs <= 0 (other): use the default per-field interval (20ms NTSC / 23ms PAL).
 	const int defaultTimeout = SPG_CONTROL.isPAL() ? 23 : 20;
-	const int timeout = (timeoutMs > 0) ? timeoutMs : defaultTimeout;
+	const int timeout = (timeoutMs == -1) ? -1 : (timeoutMs > 0) ? timeoutMs : defaultTimeout;
 	presented = false;
 	while (enabled && !presented)
 		if (!pvrQueue.waitAndExecute(timeout))

--- a/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
+++ b/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
@@ -265,12 +265,8 @@ bool rend_single_frame(const bool& enabled, int timeoutMs)
 {
 	FC_PROFILE_SCOPE;
 
-	// timeoutMs == -1: wait indefinitely (interpreter mode — GD-ROM loading can
-	// take arbitrarily long). rend_cancel_emu_wait() unblocks via cancelEnqueue()
-	// so there is no deadlock risk on quit.
-	// timeoutMs <= 0 (other): use the default per-field interval (20ms NTSC / 23ms PAL).
 	const int defaultTimeout = SPG_CONTROL.isPAL() ? 23 : 20;
-	const int timeout = (timeoutMs == -1) ? -1 : (timeoutMs > 0) ? timeoutMs : defaultTimeout;
+	const int timeout = (timeoutMs > 0) ? timeoutMs : defaultTimeout;
 	presented = false;
 	while (enabled && !presented)
 		if (!pvrQueue.waitAndExecute(timeout))


### PR DESCRIPTION
## Summary

Fixes persistent Dreamcast emulation issues on ARM64 macOS: black screen/hang on first launch, inability to quit the emulator window, and audio only playing when the window lost focus.

**Root cause:** Previous iterations forced non-threaded rendering (`ThreadedRendering=false`), which runs the SH4 CPU synchronously on the OpenEmu game loop thread. During GD-ROM loading, the SH4 can take 500ms+ per frame, blocking the entire game loop. Combined with the JIT (dynarec) being unstable on ARM64 and the CoreAudio backend blocking the SH4 thread when its buffer filled, this created a cascade of deadlocks and hangs.

**What's different now:**

- **Threaded rendering restored (default):** SH4 runs on its own thread. The OpenEmu game loop stays responsive during long GD-ROM loading phases.
- **Interpreter enforced (`DynarecEnabled=false`):** JIT has stability issues on ARM64 macOS. Override applied in both `setupEmulation` and after `loadGame` (which resets all settings internally).
- **14ms frame timeout:** `rend_single_frame(true, 14)` returns quickly when no frame is ready, so the OE game loop ticks every 14ms even during loading. Previously it blocked for up to 20ms per call.
- **Early `emu.stop()` in teardown:** In threaded mode the OE game loop thread blocks inside `rend_single_frame()`. Calling `emu.stop()` first triggers `rend_cancel_emu_wait()`, unblocking the thread so it can run the completion handler. This fixes the quit hang.
- **`needsDoubleBufferedFBO=NO`, no `presentDoubleBufferedFBO` call:** Not needed in threaded mode; these were causing rendering pipeline issues.
- **Audio backend re-applied after `loadGame`:** `loadGame` calls `config::Settings::reset()` internally, which clears `AudioBackend` back to `"auto"`. Re-setting `"openemu"` after `loadGame` ensures the correct backend is selected before `InitAudio()` runs. This fixes audio only playing when the window lost focus.

Fixes #158

---

## How to test locally

```bash
# 1. Check out the branch
gh pr checkout 160 --repo nickybmon/OpenEmu-Silicon

# 2. Clean build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + Flycast" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  clean build 2>&1 | tail -20

# 3. Install the freshly built core
cp -f \
  ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/Flycast.oecoreplugin/Contents/MacOS/Flycast \
  ~/Library/Application\ Support/OpenEmu/Cores/Flycast.oecoreplugin/Contents/MacOS/Flycast

# 4. Launch the app
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

---

## Test plan

- [x] Launch a Dreamcast ROM — it should pass through the GD-ROM boot animation and reach the game without hanging
- [x] Audio plays immediately from first launch (not only after clicking away from the window)
- [x] Closing the emulator window does not hang — the window closes cleanly
- [x] Launching a second ROM after closing the first works without crashing
- [x] Launching the same ROM a second time in the same session works
- [x] No regression on other cores (NES, SNES, GBA, etc.)

---

## Files changed

- `Flycast/OpenEmu/FlycastGameCore.mm` — rendering mode, teardown, double-buffer, audio backend
- `Flycast/flycast/core/emulator.cpp` — 14ms timeout on `rend_single_frame`

## Previously fixed in this branch (unchanged)

- `_emuInitialized` guard prevents `emu.term()` crash on partial init
- `Renderer_if.cpp` function signature matches header (linker fix)
- `audiobackend_coreaudio.cpp` non-blocking `push()` (safety net, kept)