### PR TITLE
chore: bump Homebrew cask to v1.0.4

### DIFF
--- a/Casks/openemu-silicon.rb
+++ b/Casks/openemu-silicon.rb
@@ -1,6 +1,6 @@
 cask "openemu-silicon" do
-  version "1.0.3"
-  sha256 "70c4000259c5e8f0433fd6d81c85118871fce18ed1695099260472f2d48c1bdf"
+  version "1.0.4"
+  sha256 "3bfee455fe5839467e055c152537009857245e80732d1347a1ab233cd92d8e86"
 
   url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
   name "OpenEmu Silicon"


### PR DESCRIPTION
## Summary

- Updates `Casks/openemu-silicon.rb` version from `1.0.3` → `1.0.4`
- Updates SHA256 to match the v1.0.4 DMG release asset
- Fixes users getting a stale or failed install when tapping the cask

Related to #163.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Tap the local cask formula directly
brew install --cask ./Casks/openemu-silicon.rb

# 3. Verify OpenEmu.app launches and shows v1.0.4 in About screen
open /Applications/OpenEmu.app
```

## QA Spec
- [ ] `brew install --cask openemu-silicon` succeeds after tapping `nickybmon/openemu-silicon`
- [ ] Installed app version matches v1.0.4
- [ ] SHA256 verification passes (no checksum mismatch error from brew)
- [ ] No regression for users already on v1.0.3 (brew upgrade works)

Made with [Cursor](https://cursor.com)