### PR TITLE
feat: add libretro-thumbnails as third-tier box art fallback

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -69,6 +69,13 @@ final class GameInfoHelper {
                     if let title = ss.gameTitle   { fallback["gameTitle"] = title }
                     if let desc  = ss.gameDescription { fallback["gameDescription"] = desc }
                 }
+
+                // Tier 3: libretro-thumbnails — no credentials, best-effort name match
+                if fallback["boxImageURL"] == nil, let title = fallback["gameTitle"] as? String {
+                    if let ltURL = LibretroThumbnailsClient.shared.fetchBoxArtURL(gameName: title, systemIdentifier: systemIdentifier) {
+                        fallback["boxImageURL"] = ltURL
+                    }
+                }
                 return fallback
             }
 
@@ -208,7 +215,16 @@ final class GameInfoHelper {
                         resultDict["gameDescription"] = desc
                     }
                 }
-                // ScreenScraper handled it; no need for fuzzy fallback.
+
+                // Tier 3: libretro-thumbnails — runs when ScreenScraper found no box art
+                if resultDict["boxImageURL"] == nil,
+                   let title = resultDict["gameTitle"] as? String {
+                    if let ltURL = LibretroThumbnailsClient.shared.fetchBoxArtURL(gameName: title, systemIdentifier: systemIdentifier) {
+                        resultDict["boxImageURL"] = ltURL
+                    }
+                }
+
+                // ScreenScraper (+ libretro fallback) handled it; no need for fuzzy fallback.
                 return resultDict
             }
 
@@ -308,6 +324,15 @@ final class GameInfoHelper {
                     var picked = best
                     picked.removeValue(forKey: "region")
                     resultDict.merge(picked) { (existing, _) in existing }
+                }
+
+                // Tier 3: libretro-thumbnails — runs when OpenVGDB fuzzy matching found no box art
+                let stillMissingArt = resultDict["boxImageURL"] == nil
+                                   || (resultDict["boxImageURL"] as? String)?.isEmpty == true
+                if stillMissingArt, let title = resultDict["gameTitle"] as? String {
+                    if let ltURL = LibretroThumbnailsClient.shared.fetchBoxArtURL(gameName: title, systemIdentifier: systemIdentifier) {
+                        resultDict["boxImageURL"] = ltURL
+                    }
                 }
             }
 

--- a/OpenEmu/LibretroThumbnailsClient.swift
+++ b/OpenEmu/LibretroThumbnailsClient.swift
@@ -128,6 +128,9 @@ final class LibretroThumbnailsClient {
         task.resume()
         semaphore.wait()
 
+        if found {
+            os_log(.debug, log: .default, "LibretroThumbnails: found art for '%{public}@' (%{public}@)", gameName, systemIdentifier)
+        }
         return found ? urlString : nil
     }
 

--- a/OpenEmu/LibretroThumbnailsClient.swift
+++ b/OpenEmu/LibretroThumbnailsClient.swift
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import os.log
+
+/// Fetches box art from the public libretro-thumbnails server as a last-resort fallback.
+///
+/// URL pattern: https://thumbnails.libretro.com/<System_Name>/Named_Boxarts/<Game_Name>.png
+///
+/// Name matching is title-based (No-Intro/Redump conventions). This is best-effort —
+/// the server is undocumented and could change, and name matching is imprecise.
+/// No credentials or rate limits apply.
+final class LibretroThumbnailsClient {
+
+    static let shared = LibretroThumbnailsClient()
+
+    private static let baseURL = "https://thumbnails.libretro.com"
+
+    // Maps OpenEmu system identifiers to libretro playlist/folder names on the thumbnail server.
+    // Verified against https://thumbnails.libretro.com/ directory listing (April 2026).
+    static let systemNames: [String: String] = [
+        "openemu.system.2600":         "Atari - 2600",
+        "openemu.system.5200":         "Atari - 5200",
+        "openemu.system.7800":         "Atari - 7800",
+        "openemu.system.atari8bit":    "Atari - 8-bit",
+        "openemu.system.lynx":         "Atari - Lynx",
+        "openemu.system.jaguar":       "Atari - Jaguar",
+        "openemu.system.ws":           "Bandai - WonderSwan",
+        "openemu.system.colecovision": "Coleco - ColecoVision",
+        "openemu.system.c64":          "Commodore - 64",
+        "openemu.system.vectrex":      "GCE - Vectrex",
+        "openemu.system.intellivision":"Mattel - Intellivision",
+        "openemu.system.msx":          "Microsoft - MSX",
+        "openemu.system.pcfx":         "NEC - PC-FX",
+        "openemu.system.pce":          "NEC - PC Engine - TurboGrafx 16",
+        "openemu.system.pcecd":        "NEC - PC Engine CD - TurboGrafx-CD",
+        "openemu.system.fds":          "Nintendo - Family Computer Disk System",
+        "openemu.system.gb":           "Nintendo - Game Boy",
+        "openemu.system.gba":          "Nintendo - Game Boy Advance",
+        "openemu.system.gc":           "Nintendo - GameCube",
+        "openemu.system.n64":          "Nintendo - Nintendo 64",
+        "openemu.system.nds":          "Nintendo - Nintendo DS",
+        "openemu.system.nes":          "Nintendo - Nintendo Entertainment System",
+        "openemu.system.pokemonmini":  "Nintendo - Pokemon Mini",
+        "openemu.system.snes":         "Nintendo - Super Nintendo Entertainment System",
+        "openemu.system.vb":           "Nintendo - Virtual Boy",
+        "openemu.system.wii":          "Nintendo - Wii",
+        "openemu.system.odyssey2":     "Magnavox - Odyssey2",
+        "openemu.system.ngp":          "SNK - Neo Geo Pocket",
+        "openemu.system.32x":          "Sega - 32X",
+        "openemu.system.dc":           "Sega - Dreamcast",
+        "openemu.system.gg":           "Sega - Game Gear",
+        "openemu.system.sms":          "Sega - Master System - Mark III",
+        "openemu.system.scd":          "Sega - Mega-CD - Sega CD",
+        "openemu.system.sg":           "Sega - Mega Drive - Genesis",
+        "openemu.system.sg1000":       "Sega - SG-1000",
+        "openemu.system.saturn":       "Sega - Saturn",
+        "openemu.system.psx":          "Sony - PlayStation",
+        "openemu.system.ps2":          "Sony - PlayStation 2",
+        "openemu.system.psp":          "Sony - PlayStation Portable",
+        "openemu.system.3do":          "The 3DO Company - 3DO",
+        "openemu.system.sv":           "Watara - Supervision",
+    ]
+
+    /// Synchronous fetch suitable for calling from a background DispatchQueue.sync block.
+    /// Returns a box art URL string, or nil if the system is unmapped or the image is not found.
+    ///
+    /// `gameName` should be the full game title as it appears in the library (e.g. from OpenVGDB
+    /// or the ROM filename). The method normalizes it to match libretro's naming convention.
+    func fetchBoxArtURL(gameName: String, systemIdentifier: String) -> String? {
+        guard let systemFolder = LibretroThumbnailsClient.systemNames[systemIdentifier] else {
+            return nil
+        }
+
+        let normalized = normalizeGameName(gameName)
+        guard !normalized.isEmpty else { return nil }
+
+        // Percent-encode each path component separately so spaces become %20 and
+        // special chars are handled, but slashes between components are preserved.
+        guard
+            let encodedSystem = systemFolder.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+            let encodedName   = normalized.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+        else { return nil }
+
+        let urlString = "\(LibretroThumbnailsClient.baseURL)/\(encodedSystem)/Named_Boxarts/\(encodedName).png"
+        guard let url = URL(string: urlString) else { return nil }
+
+        var found = false
+        let semaphore = DispatchSemaphore(value: 0)
+
+        // HEAD request — we only need to confirm the image exists, not download it.
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 8
+
+        let task = URLSession.shared.dataTask(with: request) { _, response, error in
+            defer { semaphore.signal() }
+            if let error = error {
+                os_log(.debug, log: .default, "LibretroThumbnails HEAD error: %{public}@", error.localizedDescription)
+                return
+            }
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                found = true
+            }
+        }
+        task.resume()
+        semaphore.wait()
+
+        return found ? urlString : nil
+    }
+
+    // MARK: - Name normalization
+
+    /// Converts a game title to the format libretro-thumbnails expects.
+    ///
+    /// Rules (from libretro docs and empirical testing):
+    ///   - Characters  & * / : ` < > ? \ | "  are replaced with _
+    ///   - No other transformations (case, spaces, punctuation are preserved)
+    func normalizeGameName(_ name: String) -> String {
+        // Characters that libretro replaces with underscores in filenames
+        let forbidden = CharacterSet(charactersIn: "&*/:`<>?\\|\"")
+        return name.unicodeScalars.map { scalar in
+            forbidden.contains(scalar) ? "_" : String(scalar)
+        }.joined()
+    }
+}

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		C6F696C01648F64B00B243DB /* Controller-Database.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6F696BF1648F64B00B243DB /* Controller-Database.plist */; };
 		C6F697D6164E0EFD00B243DB /* Keyboard-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6F697D5164E0EFD00B243DB /* Keyboard-Mappings.plist */; };
 		CC0011223344556701900001 /* ScreenScraperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556601900001 /* ScreenScraperClient.swift */; };
+		CC0011223344556B01900001 /* LibretroThumbnailsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */; };
 		CC0011223344556901900001 /* PrefScreenScraperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556801900001 /* PrefScreenScraperController.swift */; };
 		CC0011223344557101900001 /* ScreenScraperDevCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */; };
 		DEAAB8E598494A97A260F43C84A6B563 /* Dreamcast.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 87DF04FE1BCE2D100060E2C2 /* Dreamcast.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -2063,6 +2064,7 @@
 		C6F696BF1648F64B00B243DB /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		C6F697D5164E0EFD00B243DB /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
 		CC0011223344556601900001 /* ScreenScraperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScraperClient.swift; sourceTree = "<group>"; };
+		CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibretroThumbnailsClient.swift; sourceTree = "<group>"; };
 		CC0011223344556801900001 /* PrefScreenScraperController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefScreenScraperController.swift; sourceTree = "<group>"; };
 		CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScraperDevCredentials.swift; sourceTree = "<group>"; };
 		CC0011223344557201900001 /* ScreenScraperDevCredentials.template.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenScraperDevCredentials.template.swift; sourceTree = "<group>"; };
@@ -3322,6 +3324,7 @@
 			children = (
 				8FBD79182736A17B00E455FC /* GameInfoHelper.swift */,
 				CC0011223344556601900001 /* ScreenScraperClient.swift */,
+				CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */,
 				8F4AEAC0273594E6005C6246 /* OpenVGDB.swift */,
 				836BC9561853815A00B6AF26 /* SQLiteDatabase.swift */,
 			);
@@ -6519,6 +6522,7 @@
 				0570B85725449E4C008EC8A6 /* ImageCollectionViewController.swift in Sources */,
 				01E2A2F323E60F7E00194150 /* PrefCoresController.swift in Sources */,
 				CC0011223344556701900001 /* ScreenScraperClient.swift in Sources */,
+				CC0011223344556B01900001 /* LibretroThumbnailsClient.swift in Sources */,
 				CC0011223344556901900001 /* PrefScreenScraperController.swift in Sources */,
 				CC0011223344557101900001 /* ScreenScraperDevCredentials.swift in Sources */,
 				8FBD79192736A17B00E455FC /* GameInfoHelper.swift in Sources */,

--- a/OpenEmu/PrefScreenScraperController.swift
+++ b/OpenEmu/PrefScreenScraperController.swift
@@ -44,7 +44,7 @@ final class PrefScreenScraperController: NSViewController {
     // MARK: - Lifecycle
 
     override func loadView() {
-        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 340))
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 360))
         buildUI()
     }
 
@@ -58,13 +58,13 @@ final class PrefScreenScraperController: NSViewController {
 
     private func buildUI() {
         // Header
-        headerLabel.stringValue = "ScreenScraper Cover Art"
+        headerLabel.stringValue = "Cover Art"
         headerLabel.font = .boldSystemFont(ofSize: 15)
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(headerLabel)
 
         // Description
-        descLabel.stringValue = "Enter your screenscraper.fr credentials to fetch cover art and game metadata. Anonymous use works without an account but is heavily rate-limited. Registration is free."
+        descLabel.stringValue = "OpenEmu looks up cover art in three places: first the built-in OpenVGDB database, then ScreenScraper (if you're signed in below), and finally libretro-thumbnails as a last resort. Signing in to ScreenScraper gives the best coverage — registration is free."
         descLabel.font = .systemFont(ofSize: 12)
         descLabel.textColor = .secondaryLabelColor
         descLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -188,7 +188,7 @@ final class PrefScreenScraperController: NSViewController {
             statusLabel.stringValue = "✓  Signed in as \(username)"
             statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
         } else {
-            statusLabel.stringValue = "No credentials saved — using anonymous access (rate-limited)"
+            statusLabel.stringValue = "Not signed in — ScreenScraper will be skipped. OpenVGDB and libretro-thumbnails are still active."
             statusLabel.textColor = .secondaryLabelColor
         }
     }
@@ -240,7 +240,7 @@ extension PrefScreenScraperController: PreferencePane {
 
     var panelTitle: String { "Cover Art" }
 
-    var viewSize: NSSize { NSSize(width: 468, height: 340) }
+    var viewSize: NSSize { NSSize(width: 468, height: 360) }
 }
 
 // MARK: - Keychain Helper


### PR DESCRIPTION
## Summary
- Adds `LibretroThumbnailsClient.swift` — fetches box art from [thumbnails.libretro.com](https://thumbnails.libretro.com) when both OpenVGDB and ScreenScraper come up empty
- Wires the fallback into all three lookup paths in `GameInfoHelper`
- Updates the Cover Art preferences pane to accurately describe the full three-tier pipeline and fix the misleading "anonymous access" status message when not signed in to ScreenScraper

Closes #155

## How it works

Lookup order: **OpenVGDB → ScreenScraper (if signed in) → libretro-thumbnails**

The libretro fallback only fires when `boxImageURL` is still nil after the higher tiers run — it never overwrites art that was already found. Uses a HEAD request to confirm the image exists before returning the URL. No credentials or rate limits apply.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
```

- Sign out of ScreenScraper in Preferences → Cover Art
- Import a ROM for any supported system
- Open Console.app, filter by `LibretroThumbnails` — a hit logs the game title and system
- Verify the Cover Art pane description and status message look correct

## QA Spec
- [ ] Box art appears for a ROM that OpenVGDB doesn't cover
- [ ] Console.app shows `LibretroThumbnails: found art for...` when fallback fires
- [ ] Cover Art pane shows correct description and "ScreenScraper will be skipped" status when logged out
- [ ] Signing in to ScreenScraper shows the normal "Signed in as..." status
- [ ] No regressions — ROMs that already had art from OpenVGDB or ScreenScraper are unaffected

Made with [Cursor](https://cursor.com)