### PR TITLE
chore: add install-core.sh and document correct core plugin install process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,9 @@ These rules exist because AI-assisted sessions have previously created orphaned 
 - Reference the issue with `Fixes #N` in the commit body (auto-closes on merge) or `Related to #N` (soft link)
 - For core-specific fixes, note which systems are affected
 
-**Every PR description must include a "How to test locally" section** with exact copy-paste commands:
+**Every PR description must include a "How to test locally" section** with exact copy-paste commands.
+
+**If the PR only touches main app code** (`OpenEmu/`, `OpenEmuKit/`, `OpenEmu-SDK/`):
 
 ```
 ## How to test locally
@@ -148,10 +150,35 @@ xcodebuild \
   build 2>&1 | tail -20
 
 # 3. Launch
-open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
+open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
 ```
 
-Replace `<N>` with the actual PR number. Add any PR-specific setup steps below the commands — for example: which ROM or system to test, any BIOS files required, any permissions to revoke first, or specific behaviors to verify from the QA spec.
+**If the PR touches a core plugin** (anything inside `Dolphin/`, `Flycast/`, etc.):
+
+```
+## How to test locally
+
+# 1. Check out this PR
+gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon
+
+# 2. Build the core scheme (the main OpenEmu scheme does not build core plugins)
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme <CoreName> \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -20
+
+# 3. Install the core (quits OpenEmu automatically, then copies binary + Info.plist)
+./Scripts/install-core.sh <CoreName>
+
+# 4. Launch
+open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
+```
+
+**Never use `cp -Rf` to install a core plugin.** macOS merges bundle directories rather than replacing them — old files silently stay in place. Always use `./Scripts/install-core.sh` or `cp -f` on individual files. Always quit OpenEmu before installing — the helper process holds the binary open while running.
+
+Replace `<N>` with the actual PR number and `<CoreName>` with the scheme name (e.g. `Dolphin`, `Flycast`). Add any PR-specific setup steps below — which ROM or system to test, any BIOS files required, any permissions to revoke first, or specific behaviors to verify from the QA spec.
 
 ---
 
@@ -234,6 +261,8 @@ gh pr checkout 54 --repo nickybmon/OpenEmu-Silicon
 
 ### Build
 
+For main app changes:
+
 ```bash
 xcodebuild \
   -workspace OpenEmu-metal.xcworkspace \
@@ -243,10 +272,33 @@ xcodebuild \
   build 2>&1 | tail -30
 ```
 
+For core plugin changes, use the core's own scheme (e.g. `Dolphin`, `Flycast`):
+
+```bash
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme Dolphin \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -30
+```
+
+The main `OpenEmu` scheme does not build core plugins. Building the wrong scheme means you're testing old code.
+
+### Install a core plugin after building
+
+Use the install script — it quits OpenEmu first and copies files correctly:
+
+```bash
+./Scripts/install-core.sh Dolphin
+```
+
+**Never use `cp -Rf` to install a core plugin.** macOS merges bundle directories rather than replacing them, so old files silently stay in place. Always use the script or `cp -f` on individual files. Always quit OpenEmu before installing — the helper process holds the binary open while running and `cp` will silently fail to replace it.
+
 ### Launch the built app
 
 ```bash
-open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app
+open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
 ```
 
 Or launch from Spotlight — after a Debug build the app is registered and findable by name.

--- a/Scripts/install-core.sh
+++ b/Scripts/install-core.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# install-core.sh — install a built core plugin into the OE cores directory
+#
+# Usage:
+#   ./Scripts/install-core.sh <CoreName>
+#
+# Example:
+#   ./Scripts/install-core.sh Dolphin
+#   ./Scripts/install-core.sh Flycast
+#
+# Why this script exists:
+#   - cp -Rf on an existing .oecoreplugin bundle silently skips files that
+#     already exist at the destination — the old binary stays in place.
+#   - If OpenEmu is running, the helper process holds the binary open and
+#     cp will silently fail to replace it.
+#   This script quits OpenEmu first, then copies the binary and Info.plist
+#   individually with -f so the destination is always fully updated.
+
+set -euo pipefail
+
+CORE="${1:?Usage: $0 <CoreName> (e.g. Dolphin, Flycast)}"
+DEST="$HOME/Library/Application Support/OpenEmu/Cores/${CORE}.oecoreplugin"
+DERIVED=$(ls -dt "$HOME/Library/Developer/Xcode/DerivedData/OpenEmu-metal-"*/Build/Products/Debug/"${CORE}.oecoreplugin" 2>/dev/null | head -1)
+
+if [ -z "$DERIVED" ]; then
+  echo "error: ${CORE}.oecoreplugin not found in DerivedData."
+  echo "       Build the '${CORE}' scheme first:"
+  echo "       xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme ${CORE} \\"
+  echo "         -configuration Debug -destination 'platform=macOS,arch=arm64' build"
+  exit 1
+fi
+
+if [ ! -d "$DEST" ]; then
+  echo "error: ${CORE}.oecoreplugin not found at:"
+  echo "       $DEST"
+  echo "       Is the core installed? Launch OpenEmu once to install it."
+  exit 1
+fi
+
+if pgrep -xq "OpenEmu"; then
+  echo "Quitting OpenEmu..."
+  osascript -e 'tell application "OpenEmu" to quit'
+  sleep 2
+  if pgrep -xq "OpenEmu"; then
+    echo "error: OpenEmu is still running. Quit it manually and try again."
+    exit 1
+  fi
+fi
+
+echo "Installing ${CORE}.oecoreplugin from DerivedData..."
+cp -f "${DERIVED}/Contents/MacOS/${CORE}" "${DEST}/Contents/MacOS/${CORE}"
+cp -f "${DERIVED}/Contents/Info.plist"    "${DEST}/Contents/Info.plist"
+
+INSTALLED_DATE=$(stat -f "%Sm" -t "%b %d %H:%M" "${DEST}/Contents/MacOS/${CORE}")
+echo "Done. Binary timestamp: ${INSTALLED_DATE}"


### PR DESCRIPTION
## Summary

Adds `Scripts/install-core.sh` and updates `AGENTS.md` with the correct process for building and installing core plugins during local testing.

**The problem this fixes:** `cp -Rf` on an existing `.oecoreplugin` bundle silently skips files that already exist at the destination — the old binary stays in place. If OpenEmu is running, the helper process holds the binary open and `cp` silently fails to replace it. This caused several wasted debugging sessions where the wrong build was being tested.

**What's new:**

- `Scripts/install-core.sh <CoreName>` — quits OpenEmu automatically, then copies the binary and `Info.plist` individually with `-f`. Safe to run every time.
- `AGENTS.md` updated in two places:
  - PR template now has separate "How to test locally" instructions for main app PRs vs core plugin PRs
  - "Testing PRs Locally" section explains why `cp -Rf` is wrong, documents the correct scheme to build (core scheme, not `OpenEmu`), and references the install script

## How to test locally

```bash
gh pr checkout 167 --repo nickybmon/OpenEmu-Silicon

# Verify the script exists and is executable
ls -la Scripts/install-core.sh

# Verify AGENTS.md has the new core plugin install section
grep -A5 "install-core.sh" AGENTS.md
```

## QA Spec

- [ ] `Scripts/install-core.sh Dolphin` runs without error when OpenEmu is quit
- [ ] `Scripts/install-core.sh Dolphin` quits OpenEmu automatically if it's running
- [ ] `Scripts/install-core.sh BadName` exits with a clear error message
- [ ] AGENTS.md PR template shows separate instructions for app vs core plugin PRs
- [ ] AGENTS.md "Testing PRs" section documents the correct scheme and install steps

Made with [Cursor](https://cursor.com)