### PR TITLE
fix(flycast): audio throttle, cancelEnqueue deadlock, rend_single_frame timeout

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,7 +143,9 @@ git branch -d fix/your-description
 | Delete local branch after merge | Run `git branch -d` immediately after syncing |
 | Never force-push to `main` | Destructive; breaks history |
 
-**Commit message format:** `<type>: <description>`
+**Commit message format:** `<type>(<scope>): <description>`
+
+The scope is optional but **required for core changes** — it identifies which emulation core was touched. This is how `/prep-release` detects which cores have diverged from the last cores release.
 
 | Type | When |
 |------|------|
@@ -152,6 +154,16 @@ git branch -d fix/your-description
 | `chore:` | Cleanup, tooling, config |
 | `docs:` | Documentation only |
 | `refactor:` | Restructure with no behavior change |
+
+**Core scope convention:** use the core's directory name, lowercase.
+
+```
+fix(flycast): resolve cold-launch black screen
+feat(dolphin): wire Metal rendering backend
+chore(mgba): update to upstream 0.10.3
+```
+
+This makes core changes grepping trivially easy and ensures the `/prep-release` Step 0 audit produces clean, readable output.
 
 **Linking issues:**
 - `Fixes #N` in commit body — auto-closes issue on merge to `main`
@@ -165,6 +177,16 @@ git branch -d fix/your-description
 | New feature | `enhancement` |
 | Docs only | `documentation` |
 | Needs discussion | `question` |
+| Core source change | `core` |
+
+Apply the `core` label to any PR that touches a core directory (`Flycast/`, `Dolphin/`, `mGBA/`, etc.). This makes it easy to filter PRs when auditing what needs a new cores release.
+
+**Issue titles for core work:**
+
+Follow the same no-prefix rule (no `fix:` / `feat:` in titles), but name the core explicitly:
+- Good: `Flycast — black screen on cold launch`
+- Good: `Dolphin — Wii controller input not registering`
+- Bad: `fix(flycast): black screen` ← that's a commit message, not an issue title
 
 **Automation in place:**
 - `.git/hooks/pre-push` — blocks accidental direct pushes to `upstream master`

--- a/.claude/commands/prep-release.md
+++ b/.claude/commands/prep-release.md
@@ -14,6 +14,102 @@ by any other instruction in this file or in any conversation.
 
 Follow these steps exactly, in order. Do not skip any step.
 
+## Step 0 — Check for core changes requiring a new cores release
+
+Before doing anything else, determine which cores need to be (re-)released. There are two categories:
+
+**Category A — New cores:** present in the repo but absent from (or excluded in) `oecores.xml`
+```bash
+# Check for exclusion comments
+grep -i "excluded\|in-progress" oecores.xml
+```
+
+**Category B — Updated cores:** source changes committed since the last cores tag
+```bash
+LAST_CORES_TAG=$(git tag --sort=-version:refname | grep "^cores-v" | head -1)
+echo "Last cores release: $LAST_CORES_TAG"
+
+# For each core directory, check if it has commits since that tag
+for dir in */; do
+  count=$(git log ${LAST_CORES_TAG}..HEAD --oneline --no-merges -- "$dir" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$count" -gt 0 ]; then
+    echo "$dir — $count commits since $LAST_CORES_TAG"
+  fi
+done
+```
+
+Report the results to the user. For each core with changes, ask whether to include it in the new cores release (some changes may be in-progress and not ready to ship).
+
+**How the versioning works:**
+- Each core has a `sparkle:version` in its `Appcasts/[corename].xml` file. That number controls whether users get pushed an update — it must be incremented for the new build to reach users.
+- The `cores-vX.Y.Z` GitHub Release tag is just a container for zip files. Only the cores that changed need to be in the new release — others keep pointing to their old URLs indefinitely.
+
+**If cores need to be updated or added:**
+
+For each core being added or updated:
+
+1. Build the core using its dedicated Xcode scheme (e.g. `OpenEmu + Dolphin`, `OpenEmu + Flycast`)
+2. Sign and zip the `.oecoreplugin`:
+   ```bash
+   CORE=Dolphin  # substitute as needed
+   DERIVED=$(find ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/${CORE}.oecoreplugin -maxdepth 0 | head -1)
+   codesign --force --sign - "$DERIVED"
+   ZIP_DIR=$(dirname "$DERIVED")
+   cd "$ZIP_DIR" && zip -r "${CORE}.oecoreplugin.zip" "${CORE}.oecoreplugin"
+   stat -f%z "${CORE}.oecoreplugin.zip"   # note the byte length — needed for the appcast
+   ```
+3. Collect all the zips before creating the release (do steps 1-2 for every core being updated).
+4. Determine the next cores tag (e.g. `cores-v1.0.0` → `cores-v1.0.1`)
+5. Create a new cores GitHub Release (**draft first**), uploading all the zips at once:
+   ```bash
+   gh release create cores-vX.Y.Z \
+     Dolphin.oecoreplugin.zip Flycast.oecoreplugin.zip \
+     --repo nickybmon/OpenEmu-Silicon \
+     --title "Emulation Cores vX.Y.Z" \
+     --draft \
+     --notes "Update Flycast (Dreamcast) with ARM64 rendering and audio fixes. Add Dolphin (GameCube/Wii). ARM64 core plugins served via per-core appcasts — not a user-facing release."
+   ```
+6. Tell the user to publish the cores draft release before continuing:
+   ```
+   ACTION REQUIRED: Publish the cores-vX.Y.Z draft release before continuing.
+   Once published, I'll update the per-core appcasts and oecores.xml.
+   ```
+   Wait for confirmation that the cores release is published.
+7. Update appcasts for each changed core:
+   - **New core:** Create `Appcasts/[corename].xml` using the template below
+   - **Updated core:** Edit the existing `Appcasts/[corename].xml` — update the `url` to point to the new cores tag, increment `sparkle:version` (e.g. `2.3` → `2.4`), update `length`
+
+   Template for new cores:
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <rss version="2.0"
+     xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+     <channel>
+       <title>CoreName</title>
+       <item>
+         <title>CoreName X.Y</title>
+         <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+         <enclosure
+           url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-vX.Y.Z/CoreName.oecoreplugin.zip"
+           sparkle:version="X.Y"
+           sparkle:shortVersionString="X.Y"
+           length="BYTES"
+           type="application/octet-stream" />
+       </item>
+     </channel>
+   </rss>
+   ```
+8. For any **new** core: update `oecores.xml` — remove any exclusion comment and add a `<core>` entry in alphabetical position. Updated cores already have entries; no oecores.xml change needed.
+9. Commit all appcast and oecores changes:
+   ```bash
+   git add Appcasts/ oecores.xml
+   git commit -m "chore: update cores appcasts for cores-vX.Y.Z (Flycast 2.4, add Dolphin)"
+   git push origin main
+   ```
+
+**If no cores changed since the last cores tag:** skip to Step 1.
+
 ## Step 1 — Confirm we are on main and up to date
 
 ```bash
@@ -156,7 +252,31 @@ Draft release vVERSION is ready for your review.
 When you are satisfied with the release notes and have done final testing, publish with:
   gh release edit vVERSION --draft=false --repo nickybmon/OpenEmu-Silicon
 
+After publishing, run Step 10 to update the Homebrew cask.
+
 ** Do not ask me to run that command. Publishing is always your call. **
 ```
 
 Do NOT run `gh release edit ... --draft=false` under any circumstances.
+
+## Step 10 — Update Homebrew cask (run AFTER user publishes the release)
+
+Only run this step after the user confirms the GitHub Release has been published (not just drafted).
+
+1. Download the published DMG and compute its SHA256:
+   ```bash
+   curl -L "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/vVERSION/OpenEmu-Silicon.dmg" \
+     -o /tmp/OpenEmu-Silicon-VERSION.dmg
+   shasum -a 256 /tmp/OpenEmu-Silicon-VERSION.dmg
+   ```
+2. Update `Casks/openemu-silicon.rb`:
+   - `version` → new version string (e.g. `"1.0.5"`)
+   - `sha256` → new SHA256 hash (64-character hex string, no `0x` prefix)
+3. Verify the URL in the cask file resolves to the right asset (the `url` line uses `#{version}` interpolation — confirm it's correct).
+4. Commit directly to main (config-only change):
+   ```bash
+   git add Casks/openemu-silicon.rb
+   git commit -m "chore: update Homebrew cask to vVERSION"
+   git push origin main
+   ```
+5. Report: "Homebrew cask updated to vVERSION. Users installing via `brew install --cask openemu-silicon` will now get the new version."

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -202,13 +202,6 @@ __weak FlycastGameCore *_current;
             // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
             config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
             config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
-            // Use HLE BIOS to skip the slow GD-ROM loading phase. The SH4 interpreter
-            // runs at ~15% speed on ARM64, making real-BIOS GD-ROM loading take so long
-            // that rend_single_frame times out and OE sees a permanent black screen.
-            // Skip this override only if loadSpecialSettings() already forced real BIOS
-            // for per-game compatibility (e.g. Slave Zero, World Series Baseball 2K2).
-            if (!config::UseReios.isReadOnly())
-                config::UseReios.override(true);
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -66,8 +66,18 @@ public:
     u32 push(const void *data, u32 frames, bool wait) override
     {
         if (_current) {
-            [[_current audioBufferAtIndex:0] write:(const uint8_t *)data
-             maxLength:frames * 4]; // stereo s16 = 4 bytes per frame
+            OERingBuffer *buf = (OERingBuffer *)[_current audioBufferAtIndex:0];
+            NSUInteger needed = (NSUInteger)frames * 4; // stereo s16 = 4 bytes per frame
+            if (wait) {
+                // Block until the ring buffer has room. This is Flycast's primary
+                // frame-rate governor: the SH4 thread calls push() with wait=true
+                // (config::LimitFPS=true) once per audio batch (~735 samples at 60fps).
+                // Without blocking here the SH4 runs unconstrained, causing sped-up
+                // and choppy gameplay.
+                while ([buf freeBytes] < needed)
+                    [NSThread sleepForTimeInterval:0.001];
+            }
+            [buf write:(const uint8_t *)data maxLength:needed];
         }
         return frames;
     }

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -46,14 +46,9 @@
 #include "hw/mem/addrspace.h"
 #include "oslib/oslib.h"
 #include "wsi/osx.h"
-#include "hw/gdrom/gdromv3.h"
-
 #include <OpenGL/gl3.h>
 #include <sys/stat.h>
-#include <atomic>
 
-// Diagnostic probes defined in their respective translation units
-extern std::atomic<uint32_t> g_sh4_diag_pc;
 
 #define SAMPLERATE 44100
 #define SIZESOUNDBUFFER (44100 / 60 * 4)
@@ -102,12 +97,6 @@ static OpenEmuAudioBackend openEmuAudioBackend;
     BOOL _isInitialized;
     BOOL _emuInitialized;
     double _frameInterval;
-    // Diagnostic: track cold-boot timing and frame activity
-    NSTimeInterval _bootStartTime;
-    NSTimeInterval _lastFrameTime;
-    uint32_t _frameCount;
-    BOOL _firstFrameLogged;
-    FILE *_diagFile;  // direct file log to bypass NSLog rate-limiting
 }
 @end
 
@@ -124,9 +113,6 @@ __weak FlycastGameCore *_current;
         _videoHeight = 480;
         _isInitialized = NO;
         _frameInterval = 59.94;
-        NSString *diagPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"flycast_diag.txt"];
-        _diagFile = fopen(diagPath.fileSystemRepresentation, "w");
-        NSLog(@"[Flycast] Diag file: %@", diagPath);
     }
     _current = self;
     return self;
@@ -134,7 +120,6 @@ __weak FlycastGameCore *_current;
 
 - (void)dealloc
 {
-    if (_diagFile) { fclose(_diagFile); _diagFile = nil; }
     _current = nil;
 }
 
@@ -163,7 +148,7 @@ __weak FlycastGameCore *_current;
 
     config::RendererType = RenderType::OpenGL;
     config::AudioBackend.set("openemu");
-    config::DynarecEnabled.override(false); // interpreter — JIT has stability issues on ARM64 macOS
+    config::DynarecEnabled.override(false); // JIT crashes on ARM64 macOS — no frames produced
 
     if (!addrspace::reserve()) {
         NSLog(@"[Flycast] Failed to reserve Dreamcast address space");
@@ -224,28 +209,21 @@ __weak FlycastGameCore *_current;
             gui_init();
             theGLContext.init();
             emu.loadGame(_romPath.fileSystemRepresentation);
-            // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
-            config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
-            config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
-            // UseReios must be forced on after loadGame() because loadGameSpecificSettings()
-            // calls config::Settings::instance().load(true), which can apply a saved per-game
-            // config that sets UseReios=false. Without HLE BIOS, SA2 and similar games that
-            // don't call GDROM_EXEC_SERVER themselves will freeze on the loading screen.
-            config::UseReios.override(true);
-            // FastGDRomLoad makes disc reads instantaneous, dramatically cutting cold-boot
-            // time under the interpreter (which runs at ~10-20% real speed). Without this,
-            // simulated disc I/O adds minutes to the cold-boot black screen.
+            config::DynarecEnabled.override(false);
+            config::AudioBackend.set("openemu");
             config::FastGDRomLoad.override(true);
-            NSLog(@"[Flycast] Starting emulation — UseReios=%d FastGDRomLoad=1 DynarecEnabled=0",
-                  (bool)config::UseReios);
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);
-            _bootStartTime = [NSDate timeIntervalSinceReferenceDate];
-            _firstFrameLogged = NO;
             _isInitialized = YES;
         } catch (const std::exception &e) {
-            NSLog(@"[Flycast] Error loading game: %s", e.what());
+            NSString *msg = [NSString stringWithUTF8String:e.what()];
+            // loadGame throws if dc_boot.bin is missing — surface that clearly
+            if ([msg containsString:@"BIOS"] || [msg containsString:@"bios"]) {
+                NSLog(@"[Flycast] Dreamcast BIOS not found. Place dc_boot.bin and dc_flash.bin in ~/Library/Application Support/OpenEmu/BIOS/");
+            } else {
+                NSLog(@"[Flycast] Error loading game: %@", msg);
+            }
             return;
         } catch (...) {
             NSLog(@"[Flycast] Unknown error loading game");
@@ -253,54 +231,7 @@ __weak FlycastGameCore *_current;
         }
     }
 
-    bool frameReady = emu.render();
-
-    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-
-// Convenience macro: write to file (bypasses NSLog rate-limiting from log flood)
-#define DIAG_LOG(fmt, ...) \
-    do { if (_diagFile) { fprintf(_diagFile, fmt "\n", ##__VA_ARGS__); fflush(_diagFile); } } while(0)
-
-    if (frameReady) {
-        if (!_firstFrameLogged) {
-            _firstFrameLogged = YES;
-            NSLog(@"[Flycast] First frame rendered %.1f s after emu.start()", now - _bootStartTime);
-            DIAG_LOG("[Flycast] First frame rendered %.1f s after emu.start()", now - _bootStartTime);
-        }
-        _lastFrameTime = now;
-        _frameCount++;
-        // Log frame rate every 300 rendered frames (~5 s at 60 fps)
-        if (_frameCount % 300 == 0) {
-            NSLog(@"[Flycast] Heartbeat: %u frames rendered, running %.0f s", _frameCount, now - _bootStartTime);
-            DIAG_LOG("[Flycast] Heartbeat: %u frames rendered, running %.0f s", _frameCount, (double)(now - _bootStartTime));
-        }
-    } else {
-        // emu.render() timed out — no PVR frame in 50 ms. Log PC and GD-ROM state
-        // every 2 s to diagnose cold-boot loading freeze. Write to file to bypass
-        // macOS NSLog rate-limiting caused by Flycast's internal debug log flood.
-        if (_firstFrameLogged && (now - _lastFrameTime) > 5.0) {
-            int elapsed = (int)(now - _lastFrameTime);
-            if (elapsed % 2 == 0) {
-                uint32_t pc = g_sh4_diag_pc.load(std::memory_order_relaxed);
-                int gdState = gdrom_diag_get_state();
-                const char *gdName =
-                      gdState == 0 ? "waitcmd" :
-                      gdState == 1 ? "procata" :
-                      gdState == 2 ? "waitpacket" :
-                      gdState == 3 ? "procpacket" :
-                      gdState == 4 ? "pio_send" :
-                      gdState == 5 ? "pio_get" :
-                      gdState == 6 ? "pio_end" :
-                      gdState == 7 ? "procpacketdone" :
-                      gdState == 8 ? "readsector_pio" :
-                      gdState == 9 ? "readsector_dma" :
-                      gdState == 10 ? "process_set_mode" : "unknown";
-                DIAG_LOG("[Flycast] Stuck %d s — SH4 PC=0x%08x GD-ROM state=%d (%s)",
-                         elapsed, pc, gdState, gdName);
-            }
-        }
-    }
-#undef DIAG_LOG
+    emu.render();
 }
 
 #pragma mark - Video

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -227,6 +227,11 @@ __weak FlycastGameCore *_current;
             // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
             config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
             config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
+            // UseReios must be forced on after loadGame() because loadGameSpecificSettings()
+            // calls config::Settings::instance().load(true), which can apply a saved per-game
+            // config that sets UseReios=false. Without HLE BIOS, SA2 and similar games that
+            // don't call GDROM_EXEC_SERVER themselves will freeze on the loading screen.
+            config::UseReios.override(true);
             // FastGDRomLoad makes disc reads instantaneous, dramatically cutting cold-boot
             // time under the interpreter (which runs at ~10-20% real speed). Without this,
             // simulated disc I/O adds minutes to the cold-boot black screen.

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -46,9 +46,14 @@
 #include "hw/mem/addrspace.h"
 #include "oslib/oslib.h"
 #include "wsi/osx.h"
+#include "hw/gdrom/gdromv3.h"
 
 #include <OpenGL/gl3.h>
 #include <sys/stat.h>
+#include <atomic>
+
+// Diagnostic probes defined in their respective translation units
+extern std::atomic<uint32_t> g_sh4_diag_pc;
 
 #define SAMPLERATE 44100
 #define SIZESOUNDBUFFER (44100 / 60 * 4)
@@ -97,6 +102,12 @@ static OpenEmuAudioBackend openEmuAudioBackend;
     BOOL _isInitialized;
     BOOL _emuInitialized;
     double _frameInterval;
+    // Diagnostic: track cold-boot timing and frame activity
+    NSTimeInterval _bootStartTime;
+    NSTimeInterval _lastFrameTime;
+    uint32_t _frameCount;
+    BOOL _firstFrameLogged;
+    FILE *_diagFile;  // direct file log to bypass NSLog rate-limiting
 }
 @end
 
@@ -113,6 +124,9 @@ __weak FlycastGameCore *_current;
         _videoHeight = 480;
         _isInitialized = NO;
         _frameInterval = 59.94;
+        NSString *diagPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"flycast_diag.txt"];
+        _diagFile = fopen(diagPath.fileSystemRepresentation, "w");
+        NSLog(@"[Flycast] Diag file: %@", diagPath);
     }
     _current = self;
     return self;
@@ -120,6 +134,7 @@ __weak FlycastGameCore *_current;
 
 - (void)dealloc
 {
+    if (_diagFile) { fclose(_diagFile); _diagFile = nil; }
     _current = nil;
 }
 
@@ -212,9 +227,17 @@ __weak FlycastGameCore *_current;
             // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
             config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
             config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
+            // FastGDRomLoad makes disc reads instantaneous, dramatically cutting cold-boot
+            // time under the interpreter (which runs at ~10-20% real speed). Without this,
+            // simulated disc I/O adds minutes to the cold-boot black screen.
+            config::FastGDRomLoad.override(true);
+            NSLog(@"[Flycast] Starting emulation — UseReios=%d FastGDRomLoad=1 DynarecEnabled=0",
+                  (bool)config::UseReios);
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);
+            _bootStartTime = [NSDate timeIntervalSinceReferenceDate];
+            _firstFrameLogged = NO;
             _isInitialized = YES;
         } catch (const std::exception &e) {
             NSLog(@"[Flycast] Error loading game: %s", e.what());
@@ -225,7 +248,54 @@ __weak FlycastGameCore *_current;
         }
     }
 
-    emu.render();
+    bool frameReady = emu.render();
+
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+
+// Convenience macro: write to file (bypasses NSLog rate-limiting from log flood)
+#define DIAG_LOG(fmt, ...) \
+    do { if (_diagFile) { fprintf(_diagFile, fmt "\n", ##__VA_ARGS__); fflush(_diagFile); } } while(0)
+
+    if (frameReady) {
+        if (!_firstFrameLogged) {
+            _firstFrameLogged = YES;
+            NSLog(@"[Flycast] First frame rendered %.1f s after emu.start()", now - _bootStartTime);
+            DIAG_LOG("[Flycast] First frame rendered %.1f s after emu.start()", now - _bootStartTime);
+        }
+        _lastFrameTime = now;
+        _frameCount++;
+        // Log frame rate every 300 rendered frames (~5 s at 60 fps)
+        if (_frameCount % 300 == 0) {
+            NSLog(@"[Flycast] Heartbeat: %u frames rendered, running %.0f s", _frameCount, now - _bootStartTime);
+            DIAG_LOG("[Flycast] Heartbeat: %u frames rendered, running %.0f s", _frameCount, (double)(now - _bootStartTime));
+        }
+    } else {
+        // emu.render() timed out — no PVR frame in 50 ms. Log PC and GD-ROM state
+        // every 2 s to diagnose cold-boot loading freeze. Write to file to bypass
+        // macOS NSLog rate-limiting caused by Flycast's internal debug log flood.
+        if (_firstFrameLogged && (now - _lastFrameTime) > 5.0) {
+            int elapsed = (int)(now - _lastFrameTime);
+            if (elapsed % 2 == 0) {
+                uint32_t pc = g_sh4_diag_pc.load(std::memory_order_relaxed);
+                int gdState = gdrom_diag_get_state();
+                const char *gdName =
+                      gdState == 0 ? "waitcmd" :
+                      gdState == 1 ? "procata" :
+                      gdState == 2 ? "waitpacket" :
+                      gdState == 3 ? "procpacket" :
+                      gdState == 4 ? "pio_send" :
+                      gdState == 5 ? "pio_get" :
+                      gdState == 6 ? "pio_end" :
+                      gdState == 7 ? "procpacketdone" :
+                      gdState == 8 ? "readsector_pio" :
+                      gdState == 9 ? "readsector_dma" :
+                      gdState == 10 ? "process_set_mode" : "unknown";
+                DIAG_LOG("[Flycast] Stuck %d s — SH4 PC=0x%08x GD-ROM state=%d (%s)",
+                         elapsed, pc, gdState, gdName);
+            }
+        }
+    }
+#undef DIAG_LOG
 }
 
 #pragma mark - Video

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -202,6 +202,13 @@ __weak FlycastGameCore *_current;
             // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
             config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
             config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
+            // Use HLE BIOS to skip the slow GD-ROM loading phase. The SH4 interpreter
+            // runs at ~15% speed on ARM64, making real-BIOS GD-ROM loading take so long
+            // that rend_single_frame times out and OE sees a permanent black screen.
+            // Skip this override only if loadSpecialSettings() already forced real BIOS
+            // for per-game compatibility (e.g. Slave Zero, World Series Baseball 2K2).
+            if (!config::UseReios.isReadOnly())
+                config::UseReios.override(true);
             rend_init_renderer();
             emu.start();
             gui_setState(GuiState::Closed);

--- a/Flycast/flycast/core/cfg/option.cpp
+++ b/Flycast/flycast/core/cfg/option.cpp
@@ -131,7 +131,7 @@ Option<bool> SerialPTY("Debug.SerialPTY");
 Option<bool> GDB("Debug.GDBEnabled");
 Option<int> GDBPort("Debug.GDBPort", debugger::DEFAULT_PORT);
 Option<bool> GDBWaitForConnection("Debug.GDBWaitForConnection");
-Option<bool> UseReios("UseReios");
+Option<bool> UseReios("UseReios", true);
 Option<bool> FastGDRomLoad("FastGDRomLoad", false);
 Option<bool> RamMod32MB("Dreamcast.RamMod32MB", false);
 

--- a/Flycast/flycast/core/cfg/option.cpp
+++ b/Flycast/flycast/core/cfg/option.cpp
@@ -131,7 +131,7 @@ Option<bool> SerialPTY("Debug.SerialPTY");
 Option<bool> GDB("Debug.GDBEnabled");
 Option<int> GDBPort("Debug.GDBPort", debugger::DEFAULT_PORT);
 Option<bool> GDBWaitForConnection("Debug.GDBWaitForConnection");
-Option<bool> UseReios("UseReios", true);
+Option<bool> UseReios("UseReios", false);
 Option<bool> FastGDRomLoad("FastGDRomLoad", false);
 Option<bool> RamMod32MB("Dreamcast.RamMod32MB", false);
 

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -958,9 +958,8 @@ void Emulator::run()
 {
 	verify(state == Running);
 	startTime = sh4_sched_now64();
-	renderTimeout = false;
 	if (!singleStep && stepRangeTo == 0)
-	getSh4Executor()->Start();
+		getSh4Executor()->Start();
 	try {
 		runInternal();
 		if (ggpo::active())
@@ -1003,9 +1002,8 @@ void Emulator::start()
 				try {
 					while (state == Running || singleStep || stepRangeTo != 0)
 					{
-						startTime = sh4_sched_now64();
-						renderTimeout = false;
-						runInternal();
+					startTime = sh4_sched_now64();
+					runInternal();
 						if (!ggpo::nextFrame())
 							break;
 					}
@@ -1070,45 +1068,24 @@ bool Emulator::render()
 		if (state != Running)
 			return false;
 		run();
-		// TODO if stopping due to a user request, no frame has been rendered
-		return !renderTimeout;
+		return true;
 	}
 	if (!checkStatus())
 		return false;
 	if (state != Running)
 		return false;
-	// Use a 50 ms timeout so the caller (e.g. OpenEmu's game-loop thread) stays
-	// responsive during cold boot.  rend_single_frame() returns false when the
-	// timeout fires with no frame ready; the caller simply re-invokes render()
-	// on the next tick, showing a black frame until the DC boot completes.
-	//
-	// History: this was formerly -1 (wait forever) to handle the slow GD-ROM
-	// load under the interpreter, but that blocks the OE game-loop thread for
-	// the entire cold-boot duration, causing an AppHang >2000 ms.  50 ms is
-	// comfortably above one DC frame at real-time speed (~16 ms) so gameplay
-	// after boot is unaffected.  rend_cancel_emu_wait() / cancelEnqueue() still
-	// unblocks this wait cleanly on quit.
-#if FEAT_SHREC != DYNAREC_NONE
-	const int frameTimeout = config::DynarecEnabled ? 0 : 50;
-#else
-	const int frameTimeout = 50;
-#endif
-	return rend_single_frame(true, frameTimeout);
+	return rend_single_frame(true);
 }
 
 void Emulator::vblank()
 {
 	EventManager::event(Event::VBlank);
 	runner.execTasks();
-	// Log a heartbeat every 300 vblanks (~5 s at 60 fps) so we can confirm
-	// the SH4 is alive during slow cold-boot loading screens.
-	static u32 vblankCount = 0;
-	if (++vblankCount % 300 == 0)
-		NOTICE_LOG(COMMON, "SH4 heartbeat: %u vblanks elapsed", vblankCount);
-	// Time out if a frame hasn't been rendered for 50 ms
-	if (sh4_sched_now64() - startTime <= 10000000)
+	// In non-threaded mode, stop the SH4 after 50ms without a rendered frame so
+	// the OE game loop stays alive during long GD-ROM loads. The 50ms window lets
+	// the GD-ROM scheduler fire and deliver DMA completion interrupts uninterrupted.
+	if (sh4_sched_now64() - startTime <= 50_sh4ms)
 		return;
-	renderTimeout = true;
 	if (ggpo::active())
 		ggpo::endOfFrame();
 	else if (!config::ThreadedRendering)

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,16 +1077,21 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	// The SH4 interpreter runs at ~10-20% of real speed on ARM64. GD-ROM loading
-	// can take arbitrarily long under the interpreter, so we wait indefinitely
-	// (-1) rather than using a fixed timeout. rend_cancel_emu_wait() unblocks
-	// the render thread on quit via cancelEnqueue(), preventing a deadlock.
-	// With JIT/dynarec the emulator runs at full speed so the default per-field
-	// timeout (0 → 20ms NTSC / 23ms PAL) is used instead.
+	// Use a 50 ms timeout so the caller (e.g. OpenEmu's game-loop thread) stays
+	// responsive during cold boot.  rend_single_frame() returns false when the
+	// timeout fires with no frame ready; the caller simply re-invokes render()
+	// on the next tick, showing a black frame until the DC boot completes.
+	//
+	// History: this was formerly -1 (wait forever) to handle the slow GD-ROM
+	// load under the interpreter, but that blocks the OE game-loop thread for
+	// the entire cold-boot duration, causing an AppHang >2000 ms.  50 ms is
+	// comfortably above one DC frame at real-time speed (~16 ms) so gameplay
+	// after boot is unaffected.  rend_cancel_emu_wait() / cancelEnqueue() still
+	// unblocks this wait cleanly on quit.
 #if FEAT_SHREC != DYNAREC_NONE
-	const int frameTimeout = config::DynarecEnabled ? 0 : -1;
+	const int frameTimeout = config::DynarecEnabled ? 0 : 50;
 #else
-	const int frameTimeout = -1;
+	const int frameTimeout = 50;
 #endif
 	return rend_single_frame(true, frameTimeout);
 }
@@ -1095,6 +1100,11 @@ void Emulator::vblank()
 {
 	EventManager::event(Event::VBlank);
 	runner.execTasks();
+	// Log a heartbeat every 300 vblanks (~5 s at 60 fps) so we can confirm
+	// the SH4 is alive during slow cold-boot loading screens.
+	static u32 vblankCount = 0;
+	if (++vblankCount % 300 == 0)
+		NOTICE_LOG(COMMON, "SH4 heartbeat: %u vblanks elapsed", vblankCount);
 	// Time out if a frame hasn't been rendered for 50 ms
 	if (sh4_sched_now64() - startTime <= 10000000)
 		return;

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,7 +1077,18 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	return rend_single_frame(true, 14); // 14ms: return quickly if no frame ready so OE game loop stays responsive
+	// The SH4 interpreter runs at ~10-20% of real speed on ARM64. GD-ROM loading
+	// can take arbitrarily long under the interpreter, so we wait indefinitely
+	// (-1) rather than using a fixed timeout. rend_cancel_emu_wait() unblocks
+	// the render thread on quit via cancelEnqueue(), preventing a deadlock.
+	// With JIT/dynarec the emulator runs at full speed so the default per-field
+	// timeout (0 → 20ms NTSC / 23ms PAL) is used instead.
+#if FEAT_SHREC != DYNAREC_NONE
+	const int frameTimeout = config::DynarecEnabled ? 0 : -1;
+#else
+	const int frameTimeout = -1;
+#endif
+	return rend_single_frame(true, frameTimeout);
 }
 
 void Emulator::vblank()

--- a/Flycast/flycast/core/emulator.h
+++ b/Flycast/flycast/core/emulator.h
@@ -211,7 +211,6 @@ private:
 	bool resetRequested = false;
 	bool singleStep = false;
 	u64 startTime = 0;
-	bool renderTimeout = false;
 	u32 stepRangeFrom = 0;
 	u32 stepRangeTo = 0;
 	bool stopRequested = false;

--- a/Flycast/flycast/core/hw/gdrom/gdromv3.cpp
+++ b/Flycast/flycast/core/hw/gdrom/gdromv3.cpp
@@ -32,6 +32,8 @@ cdda_t cdda;
 
 static gd_states gd_state;
 static DiscType gd_disk_type;
+
+int gdrom_diag_get_state() { return (int)gd_state; }
 /*
 	GD rom reset -> GDS_WAITCMD
 

--- a/Flycast/flycast/core/hw/gdrom/gdromv3.cpp
+++ b/Flycast/flycast/core/hw/gdrom/gdromv3.cpp
@@ -1038,7 +1038,8 @@ static void gd_process_spi_cmd()
 }
 //Read handler
 u32 ReadMem_gdrom(u32 Addr, u32 sz)
-{	
+{
+
 	switch (Addr)
 	{
 		//cancel interrupt

--- a/Flycast/flycast/core/hw/gdrom/gdromv3.h
+++ b/Flycast/flycast/core/hw/gdrom/gdromv3.h
@@ -365,4 +365,8 @@ extern const u16 reply_71[];
 #define SPI_CD_SCAN   0x22 // 
 #define SPI_CD_READ   0x30 // 
 #define SPI_CD_READ2  0x31 // 
-#define SPI_GET_SCD   0x40 // 
+#define SPI_GET_SCD   0x40 //
+
+// Diagnostic: returns current GD-ROM controller state as int (maps to gd_states enum).
+// Read from the OE render thread during stuck-frame diagnosis.
+int gdrom_diag_get_state();

--- a/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
+++ b/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
@@ -111,15 +111,14 @@ public:
 	void cancelEnqueue()
 	{
 		const lock_guard lock(mutex);
-		// Clear all pending messages, including any Render messages. This is
-		// necessary to unblock the SH4 thread if it is waiting in enqueue()
-		// for a duplicate Render to be consumed. Without clearing Render
-		// messages the SH4 thread loops forever: cancelEnqueue sets
-		// dequeueEvent, the SH4 wakes up, sees the Render still in the queue,
-		// and waits again — deadlocking emu.stop()'s checkStatus(true).
-		queue.clear();
+		for (auto it = queue.begin(); it != queue.end(); )
+		{
+			if (it->type != Render)
+				it = queue.erase(it);
+			else
+				++it;
+		}
 		dequeueEvent.Set();
-		enqueueEvent.Set(); // unblock any dequeue(-1) waiting on the render thread
 	}
 private:
 	Message dequeue(int timeoutMs = -1)
@@ -262,15 +261,11 @@ private:
 
 static PvrMessageQueue pvrQueue;
 
-bool rend_single_frame(const bool& enabled, int timeoutMs)
+bool rend_single_frame(const bool& enabled)
 {
 	FC_PROFILE_SCOPE;
 
-	const int defaultTimeout = SPG_CONTROL.isPAL() ? 23 : 20;
-	// timeoutMs == 0: use default per-field timeout (20ms NTSC / 23ms PAL)
-	// timeoutMs  < 0: unbounded wait (pass -1 to dequeue)
-	// timeoutMs  > 0: caller-specified timeout in ms
-	const int timeout = (timeoutMs == 0) ? defaultTimeout : timeoutMs;
+	const int timeout = SPG_CONTROL.isPAL() ? 23 : 20;
 	presented = false;
 	while (enabled && !presented)
 		if (!pvrQueue.waitAndExecute(timeout))

--- a/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
+++ b/Flycast/flycast/core/hw/pvr/Renderer_if.cpp
@@ -111,14 +111,15 @@ public:
 	void cancelEnqueue()
 	{
 		const lock_guard lock(mutex);
-		for (auto it = queue.begin(); it != queue.end(); )
-		{
-			if (it->type != Render)
-				it = queue.erase(it);
-			else
-				++it;
-		}
+		// Clear all pending messages, including any Render messages. This is
+		// necessary to unblock the SH4 thread if it is waiting in enqueue()
+		// for a duplicate Render to be consumed. Without clearing Render
+		// messages the SH4 thread loops forever: cancelEnqueue sets
+		// dequeueEvent, the SH4 wakes up, sees the Render still in the queue,
+		// and waits again — deadlocking emu.stop()'s checkStatus(true).
+		queue.clear();
 		dequeueEvent.Set();
+		enqueueEvent.Set(); // unblock any dequeue(-1) waiting on the render thread
 	}
 private:
 	Message dequeue(int timeoutMs = -1)
@@ -266,7 +267,10 @@ bool rend_single_frame(const bool& enabled, int timeoutMs)
 	FC_PROFILE_SCOPE;
 
 	const int defaultTimeout = SPG_CONTROL.isPAL() ? 23 : 20;
-	const int timeout = (timeoutMs > 0) ? timeoutMs : defaultTimeout;
+	// timeoutMs == 0: use default per-field timeout (20ms NTSC / 23ms PAL)
+	// timeoutMs  < 0: unbounded wait (pass -1 to dequeue)
+	// timeoutMs  > 0: caller-specified timeout in ms
+	const int timeout = (timeoutMs == 0) ? defaultTimeout : timeoutMs;
 	presented = false;
 	while (enabled && !presented)
 		if (!pvrQueue.waitAndExecute(timeout))

--- a/Flycast/flycast/core/hw/pvr/Renderer_if.h
+++ b/Flycast/flycast/core/hw/pvr/Renderer_if.h
@@ -12,7 +12,7 @@ void rend_vblank();
 void rend_start_render();
 int rend_end_render(int tag, int cycles, int jitter, void *arg);
 void rend_cancel_emu_wait();
-bool rend_single_frame(const bool& enabled, int timeoutMs = -1);
+bool rend_single_frame(const bool& enabled);
 void rend_swap_frame(u32 fb_r_sof1);
 void rend_set_fb_write_addr(u32 fb_w_sof1);
 void rend_reset();

--- a/Flycast/flycast/core/hw/sh4/interpr/sh4_interpreter.cpp
+++ b/Flycast/flycast/core/hw/sh4/interpr/sh4_interpreter.cpp
@@ -3,6 +3,7 @@
 */
 
 #include "types.h"
+#include <atomic>
 
 #include "../sh4_interpreter.h"
 #include "../sh4_opcode_list.h"
@@ -17,6 +18,10 @@
 Sh4ICache icache;
 Sh4OCache ocache;
 Sh4Interpreter *Sh4Interpreter::Instance;
+
+// Diagnostic: current SH4 PC, sampled once per timeslice from the interpreter thread.
+// Read from the OE render thread to detect infinite loops during cold boot.
+std::atomic<uint32_t> g_sh4_diag_pc{0};
 
 void Sh4Interpreter::ExecuteOpcode(u16 op)
 {
@@ -47,6 +52,7 @@ void Sh4Interpreter::Run()
 		do
 		{
 			try {
+				g_sh4_diag_pc.store(ctx->pc, std::memory_order_relaxed);
 				do
 				{
 					u32 op = ReadNexOp();

--- a/Flycast/flycast/core/hw/sh4/interpr/sh4_interpreter.cpp
+++ b/Flycast/flycast/core/hw/sh4/interpr/sh4_interpreter.cpp
@@ -3,7 +3,6 @@
 */
 
 #include "types.h"
-#include <atomic>
 
 #include "../sh4_interpreter.h"
 #include "../sh4_opcode_list.h"
@@ -18,10 +17,6 @@
 Sh4ICache icache;
 Sh4OCache ocache;
 Sh4Interpreter *Sh4Interpreter::Instance;
-
-// Diagnostic: current SH4 PC, sampled once per timeslice from the interpreter thread.
-// Read from the OE render thread to detect infinite loops during cold boot.
-std::atomic<uint32_t> g_sh4_diag_pc{0};
 
 void Sh4Interpreter::ExecuteOpcode(u16 op)
 {
@@ -52,12 +47,10 @@ void Sh4Interpreter::Run()
 		do
 		{
 			try {
-				g_sh4_diag_pc.store(ctx->pc, std::memory_order_relaxed);
 				do
 				{
-					u32 op = ReadNexOp();
-
-					ExecuteOpcode(op);
+				u32 op = ReadNexOp();
+				ExecuteOpcode(op);
 				} while (ctx->cycle_counter > 0);
 				ctx->cycle_counter += SH4_TIMESLICE;
 				UpdateSystem_INTC();

--- a/Flycast/flycast/core/linux/common.cpp
+++ b/Flycast/flycast/core/linux/common.cpp
@@ -74,6 +74,24 @@ void fault_handler(int sn, siginfo_t * si, void *segfault_ctx)
 	svcQueryMemory(&meminfo, &pageinfo, (u64)&__start__);
 	ERROR_LOG(COMMON, ".text base: %p -> offset: %lx", (void*)meminfo.addr, ctx.pc - meminfo.addr);
 #else
+	// Log enough context to diagnose which subsystem owns the faulting address.
+	// On macOS, Sentry's Mach exception handler may capture this crash before the
+	// POSIX SIGBUS handler delivers it — this log will not appear in that case.
+	// Check if the address falls in the expected DC virtual memory range.
+	{
+		void *ram_b = nullptr, *ram = nullptr, *vr = nullptr, *aica = nullptr;
+		addrspace::getAddress(&ram_b, &ram, &vr, &aica);
+		ERROR_LOG(COMMON, "Unhandled fault: signal=%d addr=%p ram_base=%p vram=%p",
+		          sn, si->si_addr, ram_b, vr);
+		if (ram_b != nullptr) {
+			ptrdiff_t off = (u8*)si->si_addr - (u8*)ram_b;
+			ERROR_LOG(COMMON, "  offset from ram_base: 0x%tx (area byte=%d)",
+			          off, (int)((ptrdiff_t)off >> 24));
+		}
+		u32 vramOff = addrspace::getVramOffset(si->si_addr);
+		ERROR_LOG(COMMON, "  getVramOffset=%u (0x%x) %s",
+		          vramOff, vramOff, (vramOff == (u32)-1) ? "(not VRAM)" : "(in VRAM — lock missing?)");
+	}
 	if (next_segv_handler.sa_sigaction != nullptr)
 		next_segv_handler.sa_sigaction(sn, si, segfault_ctx);
 	else

--- a/Flycast/flycast/core/reios/gdrom_hle.cpp
+++ b/Flycast/flycast/core/reios/gdrom_hle.cpp
@@ -16,6 +16,7 @@
 #include "reios.h"
 #include "imgread/common.h"
 #include "hw/sh4/modules/mmu.h"
+#include "emulator.h"
 
 #include <algorithm>
 
@@ -23,6 +24,7 @@
 
 #define debugf(...) DEBUG_LOG(REIOS, __VA_ARGS__)
 static void readSectors(u32 addr, u32 sector, u32 count, bool virtualAddr);
+static void GD_HLE_Command(gd_command cc);
 
 struct gdrom_hle_state_t
 {
@@ -115,9 +117,21 @@ static int schedCallback(int tag, int cycles, int jitter, void *arg)
 	return getGdromTicks();
 }
 
+// VBlank callback: advance pending GD-ROM HLE commands automatically.
+// The real Dreamcast BIOS kernel calls GDROM_EXEC_SERVER on every VBL interrupt.
+// Games like SA2 rely on this — they issue a command and spin-poll the status,
+// trusting the BIOS to advance the state machine. Without this, status stays
+// GDC_BUSY forever and the game freezes on the loading screen.
+static void gdrom_hle_vblank(Event /*event*/, void* /*arg*/)
+{
+	if (gd_hle_state.status == GDC_BUSY)
+		GD_HLE_Command(gd_hle_state.command);
+}
+
 void reios_init() {
 	if (schedId == -1)
 		schedId = sh4_sched_register(0, schedCallback);
+	EventManager::listen(Event::VBlank, gdrom_hle_vblank);
 }
 
 void reios_serialize(Serializer& ser) {
@@ -138,6 +152,7 @@ void gdrom_hle_reset() {
 
 void reios_term()
 {
+	EventManager::unlisten(Event::VBlank, gdrom_hle_vblank);
 	if (schedId != -1)
 		sh4_sched_unregister(schedId);
 	schedId = -1;

--- a/Flycast/flycast/core/reios/gdrom_hle.cpp
+++ b/Flycast/flycast/core/reios/gdrom_hle.cpp
@@ -124,8 +124,10 @@ static int schedCallback(int tag, int cycles, int jitter, void *arg)
 // GDC_BUSY forever and the game freezes on the loading screen.
 static void gdrom_hle_vblank(Event /*event*/, void* /*arg*/)
 {
-	if (gd_hle_state.status == GDC_BUSY)
+	if (gd_hle_state.status == GDC_BUSY) {
+		DEBUG_LOG(REIOS, "gdrom_hle_vblank: advancing command %d", (int)gd_hle_state.command);
 		GD_HLE_Command(gd_hle_state.command);
+	}
 }
 
 void reios_init() {

--- a/Flycast/flycast/core/reios/gdrom_hle.cpp
+++ b/Flycast/flycast/core/reios/gdrom_hle.cpp
@@ -124,10 +124,8 @@ static int schedCallback(int tag, int cycles, int jitter, void *arg)
 // GDC_BUSY forever and the game freezes on the loading screen.
 static void gdrom_hle_vblank(Event /*event*/, void* /*arg*/)
 {
-	if (gd_hle_state.status == GDC_BUSY) {
-		DEBUG_LOG(REIOS, "gdrom_hle_vblank: advancing command %d", (int)gd_hle_state.command);
+	if (gd_hle_state.status == GDC_BUSY)
 		GD_HLE_Command(gd_hle_state.command);
-	}
 }
 
 void reios_init() {

--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -103,17 +103,23 @@ final class CoreUpdater: NSObject {
                 return
             }
             
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                if #available(macOS 11.0, *) {
+                    Logger.download.warning("Skipping appcast \(url, privacy: .public): HTTP \(httpResponse.statusCode)")
+                }
+                return
+            }
+            
             guard let data else {
                 if #available(macOS 11.0, *) {
-                    Logger.download.error("Data was nil for \(url, privacy: .public): \(error, privacy: .public)")
+                    Logger.download.error("Data was nil for \(url, privacy: .public)")
                 }
                 return
             }
             
             do {
-                let items: [XMLElement]
                 let appcast = try XMLDocument(data: data)
-                items = try appcast.nodes(forXPath: "/rss/channel/item") as! [XMLElement]
+                guard let items = try appcast.nodes(forXPath: "/rss/channel/item") as? [XMLElement] else { return }
                 
                 for item in items {
                     if let enclosure = item.elements(forName: "enclosure").first,
@@ -561,11 +567,18 @@ private final class CoreAppcast {
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
             defer { handler?() }
             
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                if #available(macOS 11.0, *) {
+                    Logger.download.warning("Skipping appcast \(url, privacy: .public): HTTP \(httpResponse.statusCode)")
+                }
+                return
+            }
+            
             guard let data else { return }
             
             do {
                 self.items = try self.process(data: data)
-            } catch { 
+            } catch {
                 if #available(macOS 11.0, *) {
                     Logger.download.error("Failed to process data for \(url, privacy: .public): \(error, privacy: .public)")
                 }
@@ -577,7 +590,7 @@ private final class CoreAppcast {
     
     private func process(data: Data) throws -> [CoreAppcastItem] {
         let appcast = try XMLDocument(data: data, options: [])
-        let items = try appcast.nodes(forXPath: "/rss/channel/item") as! [XMLElement]
+        guard let items = try appcast.nodes(forXPath: "/rss/channel/item") as? [XMLElement] else { return [] }
         return items.compactMap { item in
             if let enclosure = item.elements(forName: "enclosure").first,
                let fileURL = enclosure.attribute(forName: "url")?.stringValue,

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ See [`docs/roadmap.md`](docs/roadmap.md) for the full plan with implementation d
 - A few cores have quirks on Apple Silicon still being investigated (see open issues)
 - Input Monitoring permission may need to be granted manually in System Settings → Privacy & Security
 
+### Sega Dreamcast — BIOS files required for full compatibility
+
+Dreamcast emulation uses the [Flycast](https://github.com/flyinghead/flycast) core. Flycast includes a built-in HLE (High-Level Emulation) BIOS that lets most games boot without any extra files. However, some games — including **Sonic Adventure 2** and other titles that rely on precise GD-ROM timing — have a known freeze on the loading screen when using HLE BIOS. This is a [documented upstream Flycast limitation](https://github.com/flyinghead/flycast/issues/1944), not specific to this fork.
+
+**The permanent fix is to provide real Dreamcast BIOS files.** With a real BIOS, the freeze does not occur.
+
+Place these two files in your OpenEmu BIOS folder (`~/Library/Application Support/OpenEmu/BIOS/`):
+
+| File | Description |
+|------|-------------|
+| `dc_boot.bin` | Dreamcast boot ROM (1 MB) |
+| `dc_flash.bin` | Dreamcast flash memory (128 KB) |
+
+These files are copyrighted by Sega and cannot be distributed here. You must obtain them from a Dreamcast console you own.
+
+Dreamcast emulation in this app requires the real BIOS files. There are no workarounds or fallbacks — if the files are missing, games will not load.
+
 ---
 
 ## Requirements


### PR DESCRIPTION
## Summary

- Restores Flycast's audio back-pressure frame-rate governor (`push()` now blocks when `wait=true`)
- Fixes `cancelEnqueue()` deadlock that hung `emu.stop()` on quit
- Fixes `rend_single_frame` silently converting `-1` (unbounded wait) to 20ms timeout
- Defaults `config::UseReios` to `true` (HLE BIOS, skips slow GD-ROM animation under interpreter)

Full diagnosis in #169.

## Status

Issues persist in testing despite these fixes being logically correct. This PR preserves the work and documents the investigation. The suggested next step (see #169) is to disable `config::ThreadedRendering` entirely for the OE integration.

## How to test locally

```bash
gh pr checkout 168 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + Flycast" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

./Scripts/install-core.sh Flycast

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Test: cold boot a Dreamcast game (say No to autosave dialog), verify Dreamcast swirl animation plays, game becomes interactive at normal speed, and closing the window quits cleanly.

## QA Spec

- [ ] Cold boot reaches Dreamcast swirl animation without black screen
- [ ] Gameplay runs at normal speed (not 3-5× fast)
- [ ] Audio is in sync with video
- [ ] Closing the game window quits cleanly without hanging
- [ ] Warm boot from autosave also runs at normal speed