### PR TITLE
fix: stabilize OEGameCore with thread locks and Metal sizing fixes

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -24,6 +24,7 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <TargetConditionals.h>
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #if TARGET_OS_OSX
@@ -61,6 +62,9 @@
 #define OE_EXPORTED_CLASS     __attribute__((visibility("default")))
 #define OE_DEPRECATED(reason) __attribute__((deprecated(reason)))
 #define OE_DEPRECATED_WITH_REPLACEMENT(reason, replacement) __attribute__((deprecated(reason, replacement)))
+
+#define OEGameCoreDefaultRealtimeConstraint 0.007
+#define OEGameCoreDefaultRealtimeLimit      0.03
 
 #pragma mark -
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -34,6 +34,7 @@
 #import "OETimingUtils.h"
 #import "OELogging.h"
 #import <os/signpost.h>
+#import <os/lock.h>
 
 #ifndef BOOL_STR
 #define BOOL_STR(b) ((b) ? "YES" : "NO")
@@ -61,6 +62,8 @@ NSString *const OEGameCoreErrorDomain = @"org.openemu.GameCore.ErrorDomain";
 
     NSTimeInterval          lastRate;
 
+    os_unfair_lock          _ringBufferLock;
+
     NSUInteger frameCounter;
 }
 
@@ -81,6 +84,7 @@ static Class GameCoreClass = Nil;
     self = [super init];
     if(self != nil)
     {
+        _ringBufferLock = OS_UNFAIR_LOCK_INIT;
         NSUInteger count = [self audioBufferCount];
         ringBuffers = (__strong OERingBuffer **)calloc(count, sizeof(OERingBuffer *));
     }
@@ -93,6 +97,8 @@ static Class GameCoreClass = Nil;
         ringBuffers[i] = nil;
 
     free(ringBuffers);
+    _stopEmulationHandler = nil;
+    _frameCallback = nil;
 }
 
 - (NSString *)pluginName
@@ -160,6 +166,7 @@ static Class GameCoreClass = Nil;
     }
 
     CFRunLoopPerformBlock(_gameCoreRunLoop, kCFRunLoopCommonModes, block);
+    CFRunLoopWakeUp(_gameCoreRunLoop);
 }
 
 - (void)_gameCoreThreadWithStartEmulationCompletionHandler:(void (^)(void))startCompletionHandler
@@ -233,7 +240,7 @@ static Class GameCoreClass = Nil;
     __block int wasZero=1;
 #endif
 
-    OESetThreadRealtime(1. / (_rate * [self frameInterval]), .007, .03); // guessed from bsnes
+    OESetThreadRealtime(1. / (_rate * [self frameInterval]), OEGameCoreDefaultRealtimeConstraint, OEGameCoreDefaultRealtimeLimit); // guessed from bsnes
     nextFrameTime = OEMonotonicTime();
 
     while(!shouldStop)
@@ -326,8 +333,12 @@ static Class GameCoreClass = Nil;
             _frameCallback(1.0 / frameRate);
 
         // Service the event loop, which may now contain HID events, exactly once.
-        // TODO: If paused, this burns CPU waiting to unpause, because it still runs at 1x rate.
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, 0);
+        if (!executing) {
+            [NSThread sleepForTimeInterval:0.016];
+            nextFrameTime = OEMonotonicTime() + advance;
+        }
+        
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, true);
     }
     }
 
@@ -526,10 +537,11 @@ static Class GameCoreClass = Nil;
 - (void)createMetalTextureWithDevice:(id<MTLDevice>)device
 {
     _metalDevice = device;
+    OEIntSize size = self.bufferSize;
     MTLTextureDescriptor* desc = [MTLTextureDescriptor
         texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                     width:self.screenRect.size.width
-                                    height:self.screenRect.size.height
+                                     width:size.width
+                                    height:size.height
                                  mipmapped:false];
     [desc setUsage:MTLTextureUsageShaderRead];
     [desc setStorageMode:MTLStorageModePrivate];
@@ -639,7 +651,7 @@ static Class GameCoreClass = Nil;
 
     _rate = rate;
     if (_rate > 0.001)
-      OESetThreadRealtime(1./(_rate * [self frameInterval]), .007, .03);
+      OESetThreadRealtime(1./(_rate * [self frameInterval]), OEGameCoreDefaultRealtimeConstraint, OEGameCoreDefaultRealtimeLimit);
 }
 
 - (void)beginPausedExecution
@@ -676,11 +688,15 @@ static Class GameCoreClass = Nil;
 {
     NSAssert1(index < [self audioBufferCount], @"The index %lu is too high", index);
     
+    os_unfair_lock_lock(&_ringBufferLock);
     OERingBuffer *result = ringBuffers[index];
     if(result == nil) {
-        /* ring buffer is 0.05 seconds
+        /* ring buffer is 0.1 seconds
          * the larger the buffer, the higher the maximum possible audio lag */
-        double frameSampleCount = [self audioSampleRateForBuffer:index] * 0.1;
+        double sampleRate = [self audioSampleRateForBuffer:index];
+        NSAssert(sampleRate > 0, @"Sample rate must be greater than 0 for buffer %lu", index);
+        
+        double frameSampleCount = sampleRate * 0.1;
         NSUInteger channelCount = [self channelCountForBuffer:index];
         NSUInteger bytesPerSample = [self audioBitDepth] / 8;
         NSAssert(frameSampleCount, @"frameSampleCount is 0");
@@ -693,6 +709,7 @@ static Class GameCoreClass = Nil;
         [result setAnticipatesUnderflow:YES];
         ringBuffers[index] = result;
     }
+    os_unfair_lock_unlock(&_ringBufferLock);
 
     return result;
 }


### PR DESCRIPTION
## Description
Applies foundational stability and performance fixes to the `OEGameCore` base class:
- Resolves race conditions during concurrent ringbuffer allocation by protecting the initialization with `os_unfair_lock`.
- Prevents 100% CPU spinning when core execution is paused by introducing a 16ms sleep backoff in the run loop.
- Resolves `MTLTextureDescriptor` creation failures by correctly fetching the sizing requirements via `self.bufferSize`.
- Explicitly binds `nextFrameTime` logic.

These fixes are structurally decoupled from the Libretro bridge and act as safe, preemptive stability patches for all native cores.

## Related Issues
Extracted from #54 (Libretro Bridge Conversion) to address review feedback.

## How to test locally

# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app