### PR TITLE
fix: standardise retro_hw_render_callback ABI for strict ARM64 alignment

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/libretro.h
+++ b/OpenEmu-SDK/OpenEmuBase/libretro.h
@@ -1,0 +1,69 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Minimal libretro.h for bridge compilation
+#define RETRO_DEVICE_JOYPAD 1
+#define RETRO_DEVICE_ANALOG 2
+#define RETRO_DEVICE_POINTER 6
+#define RETRO_DEVICE_ID_JOYPAD_B 0
+#define RETRO_DEVICE_ID_POINTER_X 0
+#define RETRO_DEVICE_ID_POINTER_Y 1
+#define RETRO_DEVICE_ID_POINTER_PRESSED 2
+typedef bool (*retro_environment_t)(unsigned cmd, void *data);
+typedef void (*retro_video_refresh_t)(const void *data, unsigned width, unsigned height, size_t pitch);
+typedef void (*retro_audio_sample_t)(int16_t left, int16_t right);
+typedef size_t (*retro_audio_sample_batch_t)(const int16_t *data, size_t frames);
+typedef void (*retro_input_poll_t)(void);
+typedef int16_t (*retro_input_state_t)(unsigned port, unsigned device, unsigned index, unsigned id);
+typedef void (*retro_proc_address_t)(void);
+
+enum retro_hw_context_type {
+    RETRO_HW_CONTEXT_NONE = 0,
+    RETRO_HW_CONTEXT_OPENGL = 1,
+    RETRO_HW_CONTEXT_OPENGLES2 = 2,
+    RETRO_HW_CONTEXT_OPENGL_CORE = 3,
+    RETRO_HW_CONTEXT_OPENGLES3 = 4,
+    RETRO_HW_CONTEXT_OPENGLES_ANY = 5,
+    RETRO_HW_CONTEXT_VULKAN = 6,
+    RETRO_HW_CONTEXT_DUMMY = 2147483647
+};
+
+typedef void (*retro_hw_context_reset_t)(void);
+typedef uintptr_t (*retro_hw_get_current_framebuffer_t)(void);
+typedef retro_proc_address_t (*retro_hw_get_proc_address_t)(const char *sym);
+
+struct retro_hw_render_callback {
+    enum retro_hw_context_type context_type;
+    retro_hw_context_reset_t context_reset;
+    retro_hw_get_current_framebuffer_t get_current_framebuffer;
+    retro_hw_get_proc_address_t get_proc_address;
+    
+    // Explicit padding layout: these MUST be bool, not uint32_t,
+    // to match Apple Silicon (arm64) alignment rules alongside
+    // upstream Libretro ABI specifications. Misalignments here
+    // cause version_major to be interpreted as 0.
+    bool depth;
+    bool stencil;
+    bool bottom_left_origin;
+    unsigned version_major;
+    unsigned version_minor;
+    bool cache_context;
+    retro_hw_context_reset_t context_destroy;
+    bool debug_context;
+};
+
+struct retro_system_info { const char *library_name; const char *library_version; const char *valid_extensions; bool need_fullpath; bool block_extract; };
+struct retro_game_geometry { unsigned base_width; unsigned base_height; unsigned max_width; unsigned max_height; float aspect_ratio; };
+struct retro_system_timing { double fps; double sample_rate; };
+struct retro_system_av_info { struct retro_game_geometry geometry; struct retro_system_timing timing; };
+struct retro_game_info { const char *path; const void *data; size_t size; const char *meta; };
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Description
Validates and explicitly enforces strict alignment bounds for the hardware rendering struct required by 3D Libretro cores (such as Flycast, which crashes locally without this adjustment on Apple Silicon).

By strictly typing the boolean flag properties (`depth`, `stencil`, `bottom_left_origin`) as `bool` instead of implicit byte primitives (`uint32_t`), this prevents a known structural alignment shift in arm64 architectures that otherwise causes subsequent memory variables like `version_major` and `version_minor` to be mistakenly read as offset variables or `0`.

This commit lays the `libretro.h` groundwork securely ahead of any translation bridge submissions.

## Related Issues
Extracted from #54 (Libretro Bridge Conversion) to address review feedback.

## How to test locally

# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build OpenEmu main app 
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app