### PR TITLE
PR Split 3: Universal Bridge and Stability Foundation

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -30,11 +30,20 @@
 #if TARGET_OS_OSX
 #import <Cocoa/Cocoa.h>
 #endif
+#import <OpenEmuBase/OEGameCoreController.h>
 #import <OpenEmuBase/OESystemResponderClient.h>
 #import <OpenEmuBase/OEGeometry.h>
 #import <OpenEmuBase/OEDiffQueue.h>
 
-@class OEGameCoreController, OEGameCore;
+/// Primary bridge input protocol — used by all system responders.
+@protocol OEBridgeInputTranslation <NSObject>
+- (void)receiveLibretroButton:(uint8_t)buttonID forPort:(NSUInteger)port pressed:(BOOL)pressed;
+- (void)receiveLibretroAnalogIndex:(uint8_t)index axis:(uint8_t)axis value:(int16_t)value forPort:(NSUInteger)port;
+@end
+
+/// Preferred alias for new code — extends OEBridgeInputTranslation.
+@protocol OELibretroInputReceiver <OEBridgeInputTranslation>
+@end
 
 #ifndef DLog
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -30,10 +30,11 @@
 #if TARGET_OS_OSX
 #import <Cocoa/Cocoa.h>
 #endif
-#import <OpenEmuBase/OEGameCoreController.h>
 #import <OpenEmuBase/OESystemResponderClient.h>
 #import <OpenEmuBase/OEGeometry.h>
 #import <OpenEmuBase/OEDiffQueue.h>
+
+@class OEGameCoreController, OEGameCore;
 
 /// Primary bridge input protocol — used by all system responders.
 @protocol OEBridgeInputTranslation <NSObject>

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.h
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.h
@@ -1,5 +1,28 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #import <OpenEmuBase/OEGameCore.h>
-@interface OELibretroCoreTranslator : OEGameCore
+@interface OELibretroCoreTranslator : OEGameCore <OELibretroInputReceiver>
 /// Extracts the internal 'library_version' from a Libretro dylib without full initialization.
 + (nullable NSString *)libraryVersionForCoreAtURL:(nonnull NSURL *)url;
 @end

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -1152,7 +1152,7 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
         // Snap aspect to a small (num, den) pair with denominator ≤ 16.
         int bestNum = 4, bestDen = 3;
-        float bestErr = INFINITY;
+        float bestErr = FLT_MAX;
         for (int den = 1; den <= 16; den++) {
             int num = (int)lroundf(aspect * den);
             if (num <= 0) continue;

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -2,13 +2,28 @@
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// ...
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import <Foundation/Foundation.h>
-#import <AppKit/AppKit.h>
 #import <os/log.h>
 #import "OELibretroCoreTranslator.h"
-#import "OELibretroInputReceiver.h"
 #import "OEGameCore.h"
 #import "OERingBuffer.h"
 #import "OEGeometry.h"
@@ -17,49 +32,10 @@
 #import <dlfcn.h>
 #import "libretro.h"
 #import <Accelerate/Accelerate.h>
+#if __arm64__
 #import <arm_neon.h>
-
-#pragma mark - Pixel Conversion Helpers
-
-static inline uint32_t convert_0rgb1555_to_bgra8888(uint16_t pix) {
-    uint32_t r = (pix >> 10) & 0x1F;
-    uint32_t g = (pix >> 5) & 0x1F;
-    uint32_t b = (pix >> 0) & 0x1F;
-    r = (r << 3) | (r >> 2);
-    g = (g << 3) | (g >> 2);
-    b = (b << 3) | (b >> 2);
-    // On Little Endian: Byte 0:B, 1:G, 2:R, 3:A
-    return 0xFF000000 | (r << 16) | (g << 8) | b;
-}
-
-static inline uint32_t convert_rgb565_to_bgra8888(uint16_t pix) {
-    uint32_t r = (pix >> 11) & 0x1F;
-    uint32_t g = (pix >> 5) & 0x3F;
-    uint32_t b = (pix >> 0) & 0x1F;
-    r = (r << 3) | (r >> 2);
-    g = (g << 2) | (g >> 4);
-    b = (b << 3) | (b >> 2);
-    return 0xFF000000 | (r << 16) | (g << 8) | b;
-}
-
-// Environment defines — values must match the official libretro.h exactly.
-// See: https://github.com/libretro/libretro-common/blob/master/include/libretro.h
-#define RETRO_ENVIRONMENT_GET_CAN_DUPE 3
-#define RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY 9
-#define RETRO_ENVIRONMENT_SET_PIXEL_FORMAT 10
-#define RETRO_ENVIRONMENT_GET_VARIABLE 15
-#define RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE 17
-#define RETRO_ENVIRONMENT_GET_LOG_INTERFACE 27
-#define RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY 30
-#define RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY 31
-#define RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO 32
-#define RETRO_ENVIRONMENT_SET_GEOMETRY 37
-#define RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION 52
-#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
-#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
-#define RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS 11
-#define RETRO_ENVIRONMENT_SET_CONTROLLER_INFO 35
-#define RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE 26
+#endif
+#import <stdatomic.h>
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
 @property (nonatomic, strong) NSBundle *coreBundle;
@@ -70,6 +46,7 @@ static inline uint32_t convert_rgb565_to_bgra8888(uint16_t pix) {
 @property (nonatomic, assign) BOOL isHW;
 @property (nonatomic, assign) BOOL needsContextReset;
 @property (nonatomic, assign) int clearFramesRemaining;
+@property (nonatomic, assign) uint64_t serializationQuirks;
 @property (atomic, assign) int touchX;
 @property (atomic, assign) int touchY;
 @property (atomic, assign) BOOL isTouching;
@@ -81,90 +58,43 @@ static inline uint32_t convert_rgb565_to_bgra8888(uint16_t pix) {
 @property (nonatomic, assign) BOOL isDC;
 @property (nonatomic, assign) BOOL isSaturn;
 @property (nonatomic, assign) BOOL isN64;
+
+// Persistent path storage — NSString ivars keep the ObjC objects alive,
+// and the corresponding char* ivars (strdup'd) are what we hand to cores.
+// The libretro spec requires these pointers remain valid for the core's
+// lifetime, and [NSString UTF8String] is only autorelease-pool-scoped.
+@property (nonatomic, copy) NSString *biosPath;
+@property (nonatomic, copy) NSString *savesPath;
+@property (nonatomic, copy) NSString *supportPath;
 @end
 
-static __thread __unsafe_unretained OELibretroCoreTranslator *_current = nil;
+// C-string copies of the directory paths — allocated via strdup() in init,
+// freed in dealloc. These are the pointers actually returned to the core.
+static char *_biosPathCStr       = NULL;
+static char *_savesPathCStr      = NULL;
+static char *_supportPathCStr    = NULL;
+static char *_contentDirCStr     = NULL;
 
-struct retro_variable {
-    const char *key;
-    const char *value;
-};
-
-// Define Libretro log levels if missing
-#ifndef RETRO_LOG_DEBUG
-enum retro_log_level {
-    RETRO_LOG_DEBUG = 0,
-    RETRO_LOG_INFO  = 1,
-    RETRO_LOG_WARN  = 2,
-    RETRO_LOG_ERROR = 3,
-    RETRO_LOG_DUMMY = 0x7fffffff
-};
-#endif
-
-// HW Render Interface
-#define RETRO_ENVIRONMENT_SET_HW_RENDER 14
-#define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE 41
-#define RETRO_HW_FRAME_BUFFER_VALID ((void*)-1)
-
-enum retro_hw_context_type {
-    RETRO_HW_CONTEXT_NONE             = 0,
-    RETRO_HW_CONTEXT_OPENGL           = 1,
-    RETRO_HW_CONTEXT_OPENGLES2        = 2,
-    RETRO_HW_CONTEXT_OPENGL_CORE      = 3,
-    RETRO_HW_CONTEXT_OPENGLES3        = 4,
-    RETRO_HW_CONTEXT_OPENGLES_ANY     = 5,
-    RETRO_HW_CONTEXT_VULKAN           = 6,
-    RETRO_HW_CONTEXT_D3D9             = 7,
-    RETRO_HW_CONTEXT_D3D10            = 8,
-    RETRO_HW_CONTEXT_D3D11            = 9,
-    RETRO_HW_CONTEXT_D3D12            = 10,
-    RETRO_HW_CONTEXT_DUMMY            = 0x7fffffff
-};
-
-typedef void (*retro_hw_context_reset_t)(void);
-typedef uintptr_t (*retro_hw_get_current_framebuffer_t)(void);
-typedef void (*(*retro_hw_get_proc_address_t)(const char *sym))(void);
-
-struct retro_hw_render_callback {
-    enum retro_hw_context_type context_type;
-    retro_hw_context_reset_t context_reset;
-    retro_hw_get_current_framebuffer_t get_current_framebuffer;
-    retro_hw_get_proc_address_t get_proc_address;
-    
-    // These must be bool to match the official libretro.h struct layout.
-    // Using uint32_t shifted every field after them by 3 bytes each,
-    // causing version_major/minor to be read from wrong offsets.
-    bool depth;
-    bool stencil;
-    bool bottom_left_origin;
-    unsigned version_major;
-    unsigned version_minor;
-    bool cache_context;
-    retro_hw_context_reset_t context_destroy;
-    bool debug_context;
-};
-
-// Define Libretro pixel formats if missing
-#ifndef RETRO_PIXEL_FORMAT_0RGB1555
-enum retro_pixel_format {
-    RETRO_PIXEL_FORMAT_0RGB1555 = 0,
-    RETRO_PIXEL_FORMAT_XRGB8888 = 1,
-    RETRO_PIXEL_FORMAT_RGB565   = 2,
-    RETRO_PIXEL_FORMAT_UNKNOWN  = 0x7fffffff
-};
-#endif
-
-typedef void (*retro_log_printf_t)(enum retro_log_level level, const char *fmt, ...);
-struct retro_log_callback { retro_log_printf_t log; };
+// Single-instance bridge — guarded by the assertion in -init. Plain `static`
+// (not __thread) so libretro callbacks invoked from core-spawned worker
+// threads still resolve _current correctly. All env/video/audio/input
+// callbacks are written assuming this is shared across threads.
+static __unsafe_unretained OELibretroCoreTranslator *_current = nil;
 
 // HW Callbacks
-static void *_gl_handle = NULL;
 typedef void (*glGetIntegerv_t)(uint32_t pname, int *params);
 
+static void *_gl_handle = NULL;
+static glGetIntegerv_t _glGetIntegerv = NULL;
+
 static void* get_gl_handle(void) {
-    if (!_gl_handle) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
         _gl_handle = dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", RTLD_LAZY | RTLD_LOCAL);
-    }
+        if (_gl_handle) {
+            _glGetIntegerv = (glGetIntegerv_t)dlsym(_gl_handle, "glGetIntegerv");
+        }
+    });
     return _gl_handle;
 }
 
@@ -174,92 +104,86 @@ static uintptr_t libretro_get_current_framebuffer(void) {
         if (_current && _current.renderDelegate) {
             id fb = _current.renderDelegate.presentationFramebuffer;
             if (fb && [fb isKindOfClass:[NSNumber class]]) {
-                return (uintptr_t)[(NSNumber *)fb unsignedIntValue];
+                return (uintptr_t)[(NSNumber *)fb unsignedLongValue];
             }
         }
     }
-    
+
     // 2. Fall back to querying the active CGL context
-    void *gl = get_gl_handle();
-    if (gl) {
-        static glGetIntegerv_t _glGetIntegerv = NULL;
-        if (!_glGetIntegerv) _glGetIntegerv = (glGetIntegerv_t)dlsym(gl, "glGetIntegerv");
-        
-        if (_glGetIntegerv) {
-            int fbo = 0;
-            _glGetIntegerv(0x8CA6, &fbo); // GL_FRAMEBUFFER_BINDING
-            return (uintptr_t)fbo;
-        }
+    if (get_gl_handle() && _glGetIntegerv) {
+        int fbo = 0;
+        _glGetIntegerv(0x8CA6, &fbo); // GL_FRAMEBUFFER_BINDING
+        return (uintptr_t)fbo;
     }
     return 0;
 }
 
 static void (*libretro_get_proc_address(const char *sym))(void) {
     if (!_current || !_current.isHW) return NULL;
-    
+
     // First query actual OpenGL library, only fallback to global process symbols if missing
     void *gl = get_gl_handle();
     void *addr = NULL;
     if (gl) addr = dlsym(gl, sym);
-    
-    if (!addr) {
-        addr = dlsym(RTLD_DEFAULT, sym);
-    }
-    
-    if (addr) {
-        // Log removed for Release
-    } else {
-        // Silent failure for Release - the caller will handle NULL
-    }
-    
+    if (!addr) addr = dlsym(RTLD_DEFAULT, sym);
     return (void(*)(void))addr;
 }
 
 // BIOS Audit Check
-static BOOL verify_bios_files(NSString *biosPath, NSArray<NSString *> *files) {
+//
+// TODO: unify with `LibretroCore.requiredFiles` in OELibretroBuildbot.swift.
+// Today the registry stores BIOS metadata for download/install UX while
+// this table covers load-time verification. A future change should let the
+// translator query the registry by system identifier instead of duplicating.
+typedef struct {
+    const char *systemIDFragment;       // matched via -[NSString containsString:]
+    const char *files[6];               // NULL-terminated
+    const char *userMessage;
+} OELibretroBIOSRequirement;
+
+static const OELibretroBIOSRequirement kBIOSRequirements[] = {
+    { "dc",     { "dc_boot.bin", "dc_flash.bin", NULL },
+      "Dreamcast requires dc_boot.bin and dc_flash.bin in your BIOS folder." },
+    { "nds",    { "bios7.bin", "bios9.bin", "firmware.bin", NULL },
+      "Nintendo DS requires bios7.bin, bios9.bin, and firmware.bin in your BIOS folder." },
+    { "saturn", { "sat_bios.bin", NULL },
+      "Sega Saturn requires sat_bios.bin (or a regional variant) in your BIOS folder." },
+    { "psx",    { "scph5500.bin", "scph5501.bin", "scph5502.bin", NULL },
+      "PlayStation requires at least one of scph5500.bin (JP), scph5501.bin (US), or scph5502.bin (EU) in your BIOS folder." },
+    { "msx",    { "MSX.ROM", "MSX2.ROM", NULL },
+      "MSX requires MSX.ROM and MSX2.ROM in your BIOS folder." },
+};
+
+static const OELibretroBIOSRequirement *bios_requirement_for_system(NSString *systemID) {
+    for (size_t i = 0; i < sizeof(kBIOSRequirements) / sizeof(kBIOSRequirements[0]); i++) {
+        NSString *fragment = [NSString stringWithUTF8String:kBIOSRequirements[i].systemIDFragment];
+        if ([systemID containsString:fragment]) {
+            return &kBIOSRequirements[i];
+        }
+    }
+    return NULL;
+}
+
+// PSX is satisfied by ANY ONE of the regional BIOS files; everything else
+// requires ALL listed files. Returns YES if the requirement is satisfied.
+static BOOL bios_requirement_satisfied(NSString *biosPath, const OELibretroBIOSRequirement *req) {
     NSFileManager *fm = [NSFileManager defaultManager];
-    for (NSString *file in files) {
-        NSString *fullPath = [biosPath stringByAppendingPathComponent:file];
-        if (![fm fileExistsAtPath:fullPath]) {
+    BOOL anyOf = (strcmp(req->systemIDFragment, "psx") == 0);
+    BOOL foundAny = NO;
+    for (size_t i = 0; req->files[i] != NULL; i++) {
+        NSString *file = [NSString stringWithUTF8String:req->files[i]];
+        BOOL exists = [fm fileExistsAtPath:[biosPath stringByAppendingPathComponent:file]];
+        if (anyOf) {
+            if (exists) { foundAny = YES; break; }
+        } else if (!exists) {
             return NO;
         }
     }
-    return YES;
+    return anyOf ? foundAny : YES;
 }
 
 static void libretro_log_cb(enum retro_log_level level, const char *fmt, ...) {
-#if DEBUG
-    va_list args;
-    va_start(args, fmt);
-    char buffer[4096];
-    vsnprintf(buffer, sizeof(buffer), fmt, args);
-    va_end(args);
-    
-    os_log_type_t logType = OS_LOG_TYPE_DEFAULT;
-    const char *prefix = "[OELibretro]";
-    
-    switch (level) {
-        case RETRO_LOG_DEBUG: 
-            logType = OS_LOG_TYPE_DEBUG; 
-            break;
-        case RETRO_LOG_INFO:  
-            logType = OS_LOG_TYPE_INFO;  
-            prefix = "[OELibretro Core]";
-            break;
-        case RETRO_LOG_WARN:  
-            logType = OS_LOG_TYPE_ERROR; 
-            prefix = "[OELibretro Core Warning]";
-            break;
-        case RETRO_LOG_ERROR: 
-            logType = OS_LOG_TYPE_FAULT; 
-            prefix = "!!! [OELibretro Core Error]";
-            break;
-        default: 
-            break;
-    }
-    
-    os_log_with_type(OE_LOG_DEFAULT, logType, "%{public}s %{public}s", prefix, buffer);
-#endif
+    // Hardened: Absolute Silence
 }
 
 @implementation OELibretroCoreTranslator
@@ -278,6 +202,8 @@ static void libretro_log_cb(enum retro_log_level level, const char *fmt, ...) {
     void (*_retro_run)(void);
     bool (*_retro_load_game)(const struct retro_game_info *game);
     void (*_retro_unload_game)(void);
+    
+    // Serialization
     size_t (*_retro_serialize_size)(void);
     bool (*_retro_serialize)(void *data, size_t size);
     bool (*_retro_unserialize)(const void *data, size_t size);
@@ -294,10 +220,13 @@ static void libretro_log_cb(enum retro_log_level level, const char *fmt, ...) {
     size_t _cachedMaxWidth;
     size_t _cachedMaxHeight;
     
-    // Input state: 4 ports × 16 buttons (RETRO_DEVICE_JOYPAD)
-    int16_t _buttonStates[4][16];
+    // Input state: 4 ports × 16 buttons (RETRO_DEVICE_JOYPAD).
+    // Atomic relaxed because writers (input thread) and readers (emu thread)
+    // are unsynchronised; aligned int16_t is naturally atomic on arm64 but
+    // without _Atomic the compiler may elide reloads or reorder writes.
+    _Atomic(int16_t) _buttonStates[4][16];
     // Analog state: 4 ports × 2 sticks (index) × 2 axes
-    int16_t _analogStates[4][2][2];
+    _Atomic(int16_t) _analogStates[4][2][2];
     
     // Logging: Resolution tracking
     unsigned _lastWidth;
@@ -307,25 +236,20 @@ static void libretro_log_cb(enum retro_log_level level, const char *fmt, ...) {
 + (NSString *)libraryVersionForCoreAtURL:(NSURL *)url {
     void *handle = dlopen(url.path.UTF8String, RTLD_LAZY | RTLD_LOCAL);
     if (!handle) return nil;
-    
-    typedef struct {
-        const char *library_name;
-        const char *library_version;
-        const char *valid_extensions;
-        bool need_fullpath;
-        bool block_extract;
-    } retro_system_info;
-    
-    void (*get_info)(retro_system_info*) = dlsym(handle, "retro_get_system_info");
+
+    // Use the canonical struct from libretro.h. Defining a private copy here
+    // would risk drifting out of sync with the bridge's actual ABI — the
+    // exact failure mode the libretro.h header comment warns about.
+    void (*get_info)(struct retro_system_info *) = dlsym(handle, "retro_get_system_info");
     NSString *version = nil;
     if (get_info) {
-        retro_system_info info = {0};
+        struct retro_system_info info = {0};
         get_info(&info);
         if (info.library_version) {
             version = [NSString stringWithUTF8String:info.library_version];
         }
     }
-    
+
     dlclose(handle);
     return version;
 }
@@ -335,21 +259,24 @@ static void libretro_log_cb(enum retro_log_level level, const char *fmt, ...) {
 static bool libretro_environment_cb(unsigned cmd, void *data) {
     switch (cmd) {
         case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
-            // This is used for BIOS/Firmware
-            if (data && _current) {
-                const char *path = [[_current biosDirectoryPath] UTF8String];
-                *(const char **)data = path;
-                NSLog(@"[OELibretro] Core requested System/BIOS directory: %s", path);
-                fprintf(stderr, "[OELibretro] Providing System/BIOS: %s\n", path);
+            // This is used for BIOS/Firmware.
+            // We return the strdup'd C-string that lives until dealloc —
+            // the libretro spec requires this pointer to remain valid for
+            // the lifetime of the core.
+            if (data && _current && _biosPathCStr) {
+                *(const char **)data = _biosPathCStr;
+#if DEBUG
+                NSLog(@"[OELibretro] Core requested System/BIOS directory: %s", _biosPathCStr);
+#endif
                 return true;
             }
             break;
         case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
-            if (data && _current) {
-                const char *path = [[_current batterySavesDirectoryPath] UTF8String];
-                *(const char **)data = path;
-                NSLog(@"[OELibretro] Core requested Save/Battery directory: %s", path);
-                fprintf(stderr, "[OELibretro] Providing Save/Battery: %s\n", path);
+            if (data && _current && _savesPathCStr) {
+                *(const char **)data = _savesPathCStr;
+#if DEBUG
+                NSLog(@"[OELibretro] Core requested Save/Battery directory: %s", _savesPathCStr);
+#endif
                 return true;
             }
             break;
@@ -364,11 +291,11 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
             }
             break;
         case RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY:
-            if (data && _current) {
-                *(const char **)data = [[_current supportDirectoryPath] UTF8String];
-                return true;
-            }
-            break;
+            // Return the directory containing the loaded ROM, not the generic
+            // support dir. _contentDirCStr is set in loadFileAtPath: from the
+            // ROM file path's parent directory.
+            *(const char **)data = _contentDirCStr;
+            return _contentDirCStr != NULL;
         case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
             if (data) {
                 *(unsigned *)data = 2; // Support V2
@@ -387,14 +314,17 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 // Many PPSSPP builds default to 0RGB1555 which can cause black screens if not 
                 // explicitly handled by the Metal shaders.
                 if (_current.isPSP && format != RETRO_PIXEL_FORMAT_XRGB8888) {
+#if DEBUG
                     NSLog(@"[OELibretro] PSP requested format %d, but bridge is forcing XRGB8888 for stability.", format);
+#endif
                     format = RETRO_PIXEL_FORMAT_XRGB8888;
                 }
 
                 _current.retroPixelFormat = format;
                 _current.didExplicitlySetPixelFormat = YES;
+#if DEBUG
                 NSLog(@"[OELibretro] Core requested Pixel Format: %d", _current.retroPixelFormat);
-                fprintf(stderr, "[OELibretro] Pixel Format: %d\n", _current.retroPixelFormat);
+#endif
                 return true;
             }
             return false;
@@ -405,7 +335,9 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                     _current->_avInfo.geometry = *geom;
                 }
                 _current.didClearSaturnBuffer = NO; 
+#if DEBUG
                 NSLog(@"[OELibretro] Geometry updated: %dx%d (Aspect: %.2f)", geom->base_width, geom->base_height, geom->aspect_ratio);
+#endif
                 return true;
             }
             break;
@@ -415,7 +347,9 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 @synchronized(_current) {
                     _current->_avInfo = *info;
                 }
+#if DEBUG
                 NSLog(@"[OELibretro] AV Info updated: %dx%d @ %.2f fps", info->geometry.base_width, info->geometry.base_height, info->timing.fps);
+#endif
                 return true;
             }
             break;
@@ -428,7 +362,9 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 // macOS OpenGL on Apple Silicon, leading to crashes in 'EmuThread'.
                 // Returning false here forces the core to use its software renderer.
                 if (_current.isPSP) {
+#if DEBUG
                     NSLog(@"[OELibretro] PSP requested HW rendering, but the bridge is REJECTING it to force stable software mode.");
+#endif
                     return false;
                 }
                 
@@ -442,8 +378,9 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                     case RETRO_HW_CONTEXT_OPENGLES_ANY:
                         break; // Accepted — fall through to setup
                     default:
+#if DEBUG
                         NSLog(@"[OELibretro] REJECTED HW context type %d (Vulkan/D3D not supported). Core should fall back to GL.", hw->context_type);
-                        fprintf(stderr, "[OELibretro] REJECTED HW context type %d\n", hw->context_type);
+#endif
                         return false;
                 }
                 
@@ -451,7 +388,9 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 hw->get_proc_address = libretro_get_proc_address;
                 _current->_hw_callback = *hw;
                 _current.isHW = YES;
+#if DEBUG
                 NSLog(@"[OELibretro] Accepted HW Rendering (Type: %d, Version: %u.%u)", hw->context_type, hw->version_major, hw->version_minor);
+#endif
                 return true;
             }
             break;
@@ -460,10 +399,13 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
             // We don't implement a render interface — return false so the core uses fallbacks.
             return false;
         case RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE:
-            // Modern cores use this to request specific OpenGL versions.
-            // We acknowledge it but let the existing context handle it.
-            NSLog(@"[OELibretro] Core requested context negotiation interface.");
-            return true;
+            // This bridge does not implement the context negotiation interface.
+            // Returning true would be a lie that tells the core the frontend will
+            // honour the interface; returning false lets the core use its own fallback.
+#if DEBUG
+            NSLog(@"[OELibretro] Core requested context negotiation interface — returning false (not implemented).");
+#endif
+            return false;
         case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
         case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO:
             // Acknowledge but ignore — OpenEmu has its own input system.
@@ -503,15 +445,6 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                         var->value = "False";
                         return true;
                     }
-                    // For MelonDS: Fix white screen when booting with FreeBIOS by forcing direct boot
-                    if (strcmp(var->key, "melonds_boot_directly") == 0) {
-                        var->value = "true";
-                        return true;
-                    }
-                    if (strcmp(var->key, "melonds_threaded_renderer") == 0) {
-                        var->value = "false";
-                        return true;
-                    }
                     if (strcmp(var->key, "mupen64plus-EnableTextureCache") == 0) {
                         var->value = "False";
                         return true;
@@ -526,17 +459,56 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                     }
                 }
                 
-                // DeSmuME Defaults
+                // NDS (MelonDS/DeSmuME) Defaults
                 if ([systemID containsString:@"nds"]) {
+                    if (strcmp(var->key, "melonds_boot_directly") == 0) {
+                        var->value = "true";
+                        return true;
+                    }
+                    if (strcmp(var->key, "melonds_threaded_renderer") == 0) {
+                        var->value = "false";
+                        return true;
+                    }
                     if (strcmp(var->key, "desmume_jit_trust_unit") == 0) {
                         var->value = "enabled";
                         return true;
                     }
                 }
                 
-                // Flycast/Reicast Defaults (core uses 'reicast_' prefix)
+                // Flycast/Reicast Defaults (core uses 'reicast_' prefix for legacy vars)
                 if ([systemID containsString:@"dc"]) {
                     if (strcmp(var->key, "reicast_hle_bios") == 0) {
+                        var->value = "disabled";
+                        return true;
+                    }
+                    if (strcmp(var->key, "reicast_fast_gd_rom_load") == 0 ||
+                        strcmp(var->key, "flycast_fast_gd_rom_load") == 0) {
+                        var->value = "enabled";
+                        return true;
+                    }
+                    // 2x native resolution (640x480 -> 1280x960) — good default for M-series Macs
+                    if (strcmp(var->key, "reicast_internal_resolution") == 0 ||
+                        strcmp(var->key, "flycast_internal_resolution") == 0) {
+                        var->value = "1280x960";
+                        return true;
+                    }
+                    // Disable threaded rendering — our bridge provides a single GL context;
+                    // Flycast's threaded renderer spawns a second thread that needs a shared
+                    // context we don't provide, which causes black screens on Apple Silicon.
+                    if (strcmp(var->key, "reicast_threaded_rendering") == 0 ||
+                        strcmp(var->key, "flycast_threaded_rendering") == 0) {
+                        var->value = "disabled";
+                        return true;
+                    }
+                    // Disable frame-swap delay — this variable makes retro_run block waiting
+                    // for audio to be consumed, causing a deadlock with CoreAudio's IO thread.
+                    if (strcmp(var->key, "reicast_delay_frame_swapping") == 0) {
+                        var->value = "disabled";
+                        return true;
+                    }
+                    // Disable DSP — reduces audio thread pressure and avoids secondary
+                    // audio sync points that can contribute to the CoreAudio deadlock.
+                    if (strcmp(var->key, "reicast_enable_dsp") == 0) {
                         var->value = "disabled";
                         return true;
                     }
@@ -578,12 +550,35 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                     }
                 }
                 
-                NSLog(@"[OELibretro] Core queried variable: %s (System: %s)", var->key, [systemID UTF8String]);
+                // No override matched — set value to NULL and return true.
+                // Spec: returning true means the frontend supports variables;
+                // NULL value tells the core to use its own built-in default.
+                var->value = NULL;
+#if DEBUG
+                NSLog(@"[OELibretro] Core queried variable: %s (System: %s) — no override", var->key, [systemID UTF8String]);
+#endif
             }
-            break;
+            return true;
         case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
             if (data) *(bool *)data = false;
             return true;
+        case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+            // Cores write a uint64_t bitmask declaring how their save-state
+            // serialization deviates from the spec. We acknowledge it and
+            // record it so -saveStateToFileAtPath: can adapt.
+            if (data && _current) {
+                uint64_t quirks = *(uint64_t *)data;
+                _current.serializationQuirks = quirks;
+#if DEBUG
+                NSLog(@"[OELibretro] Core declared serialization quirks: 0x%llx%@%@%@",
+                      quirks,
+                      (quirks & RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE)    ? @" MUST_INITIALIZE"    : @"",
+                      (quirks & RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE) ? @" CORE_VARIABLE_SIZE" : @"",
+                      (quirks & RETRO_SERIALIZATION_QUIRK_SINGLE_SESSION)     ? @" SINGLE_SESSION"     : @"");
+#endif
+                return true;
+            }
+            return false;
         default:
             break;
     }
@@ -592,30 +587,12 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
 
 #pragma mark - Optimised Video Copy Handlers (Hot Path)
 
-typedef void (*OEVideoCopyHandler)(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords, BOOL swap);
+// Each handler converts one libretro pixel format into BGRA8888 (the layout
+// OpenEmu's Metal renderer expects). The libretro spec only defines RGB
+// orderings — there is no BGR variant — so no byte-swap branch is needed.
+typedef void (*OEVideoCopyHandler)(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords);
 
-static inline uint32_t convert_0rgb1555_to_bgra8888_optimized(uint16_t pix) {
-    uint32_t r = (pix >> 10) & 0x1F;
-    uint32_t g = (pix >> 5) & 0x1F;
-    uint32_t b = (pix >> 0) & 0x1F;
-    r = (r << 3) | (r >> 2);
-    g = (g << 3) | (g >> 2);
-    b = (b << 3) | (b >> 2);
-    // BGRA Little Endian Memory: B, G, R, A
-    return 0xFF000000 | (r << 16) | (g << 8) | b;
-}
-
-static inline uint32_t convert_rgb565_to_bgra8888_optimized(uint16_t pix) {
-    uint32_t r = (pix >> 11) & 0x1F;
-    uint32_t g = (pix >> 5) & 0x3F;
-    uint32_t b = (pix >> 0) & 0x1F;
-    r = (r << 3) | (r >> 2);
-    g = (g << 2) | (g >> 4);
-    b = (b << 3) | (b >> 2);
-    return 0xFF000000 | (r << 16) | (g << 8) | b;
-}
-
-static void OEVideoCopy0RGB1555(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords, BOOL swap) {
+static void OEVideoCopy0RGB1555(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords) {
     const uint16_t *s_row = (const uint16_t *)src;
     uint32_t *d_row = dst;
 
@@ -624,34 +601,22 @@ static void OEVideoCopy0RGB1555(const uint8_t *src, uint32_t *dst, unsigned widt
         uint32_t *d = d_row;
         unsigned x = 0;
 
-        // NEON path: process 8 pixels at a time
+        // NEON path: process 8 pixels at a time.
+        // Source layout 0RGB1555:  0RRRRRGGGGGBBBBB
+        // Destination BGRA in little-endian memory: B, G, R, A
+#if __arm64__
         for (; x + 7 < width; x += 8) {
             uint16x8_t pixels = vld1q_u16(s + x);
-            
-            uint16x8_t r_16, g_16, b_16;
-            // Native 0RGB1555: 0RRRRRGGGGGBBBBB
-            // We want BGRA in memory (Little Endian): Byte 0:B, 1:G, 2:R, 3:A
-            
-            if (swap) {
-                // Core is providing BGR1555: 0BBBBBGGGGGRRRRR
-                // Extract R from bits 0-4, B from 10-14
-                r_16 = vandq_u16(pixels, vdupq_n_u16(0x1F));
-                g_16 = vandq_u16(vshrq_n_u16(pixels, 5), vdupq_n_u16(0x1F));
-                b_16 = vandq_u16(vshrq_n_u16(pixels, 10), vdupq_n_u16(0x1F));
-            } else {
-                // Extract R from bits 10-14, B from 0-4
-                r_16 = vandq_u16(vshrq_n_u16(pixels, 10), vdupq_n_u16(0x1F));
-                g_16 = vandq_u16(vshrq_n_u16(pixels, 5), vdupq_n_u16(0x1F));
-                b_16 = vandq_u16(pixels, vdupq_n_u16(0x1F));
-            }
 
-            // Expand 5-bit to 8-bit: (x << 3) | (x >> 2)
+            uint16x8_t r_16 = vandq_u16(vshrq_n_u16(pixels, 10), vdupq_n_u16(0x1F));
+            uint16x8_t g_16 = vandq_u16(vshrq_n_u16(pixels, 5),  vdupq_n_u16(0x1F));
+            uint16x8_t b_16 = vandq_u16(pixels,                  vdupq_n_u16(0x1F));
+
             uint8x8_t r = vmovn_u16(vorrq_u16(vshlq_n_u16(r_16, 3), vshrq_n_u16(r_16, 2)));
             uint8x8_t g = vmovn_u16(vorrq_u16(vshlq_n_u16(g_16, 3), vshrq_n_u16(g_16, 2)));
             uint8x8_t b = vmovn_u16(vorrq_u16(vshlq_n_u16(b_16, 3), vshrq_n_u16(b_16, 2)));
             uint8x8_t a = vdup_n_u8(0xFF);
 
-            // Interleave into BGRA pattern (Byte 0:B, 1:G, 2:R, 3:A)
             uint8x8x2_t bg = vzip_u8(b, g);
             uint8x8x2_t ra = vzip_u8(r, a);
 
@@ -661,26 +626,17 @@ static void OEVideoCopy0RGB1555(const uint8_t *src, uint32_t *dst, unsigned widt
             vst1q_u32(d + x + 0, vreinterpretq_u32_u16(vcombine_u16(bgra0.val[0], bgra0.val[1])));
             vst1q_u32(d + x + 4, vreinterpretq_u32_u16(vcombine_u16(bgra1.val[0], bgra1.val[1])));
         }
+#endif
 
-        // Scalar fallback
+        // Scalar tail (also handles all pixels on non-arm64)
         for (; x < width; x++) {
             uint16_t pix = s[x];
-            uint32_t r_val, g_val, b_val;
-            if (swap) {
-                // Treat input as BGR1555
-                b_val = (pix >> 10) & 0x1F;
-                g_val = (pix >> 5) & 0x1F;
-                r_val = pix & 0x1F;
-            } else {
-                // Treat input as RGB1555
-                r_val = (pix >> 10) & 0x1F;
-                g_val = (pix >> 5) & 0x1F;
-                b_val = pix & 0x1F;
-            }
+            uint32_t r_val = (pix >> 10) & 0x1F;
+            uint32_t g_val = (pix >> 5)  & 0x1F;
+            uint32_t b_val =  pix        & 0x1F;
             r_val = (r_val << 3) | (r_val >> 2);
             g_val = (g_val << 3) | (g_val >> 2);
             b_val = (b_val << 3) | (b_val >> 2);
-            // In little-endian d[x] is stored as Byte 0:B, 1:G, 2:R, 3:A
             d[x] = 0xFF000000 | (r_val << 16) | (g_val << 8) | b_val;
         }
 
@@ -689,7 +645,7 @@ static void OEVideoCopy0RGB1555(const uint8_t *src, uint32_t *dst, unsigned widt
     }
 }
 
-static void OEVideoCopyRGB565(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords, BOOL swap) {
+static void OEVideoCopyRGB565(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords) {
     const uint16_t *s_line = (const uint16_t *)src;
     uint32_t *d_line = dst;
 
@@ -698,34 +654,20 @@ static void OEVideoCopyRGB565(const uint8_t *src, uint32_t *dst, unsigned width,
         uint32_t *d = d_line;
         unsigned x = 0;
 
-        // NEON path: process 8 pixels at a time
+        // Source layout RGB565: RRRRRGGGGGGBBBBB
+#if __arm64__
         for (; x + 7 < width; x += 8) {
             uint16x8_t pixels = vld1q_u16(s + x);
-            
-            uint16x8_t r_16, g_16, b_16;
-            // Native RGB565: RRRRRGGGGGGBBBBB
-            
-            if (swap) {
-                // Core is providing BGR565: BBBBBGGGGGGRRRRR
-                b_16 = vandq_u16(vshrq_n_u16(pixels, 11), vdupq_n_u16(0x1F));
-                g_16 = vandq_u16(vshrq_n_u16(pixels, 5), vdupq_n_u16(0x3F));
-                r_16 = vandq_u16(pixels, vdupq_n_u16(0x1F));
-            } else {
-                r_16 = vandq_u16(vshrq_n_u16(pixels, 11), vdupq_n_u16(0x1F));
-                g_16 = vandq_u16(vshrq_n_u16(pixels, 5), vdupq_n_u16(0x3F));
-                b_16 = vandq_u16(pixels, vdupq_n_u16(0x1F));
-            }
 
-            // Expand components to 8-bit
-            // R: (x << 3) | (x >> 2)
+            uint16x8_t r_16 = vandq_u16(vshrq_n_u16(pixels, 11), vdupq_n_u16(0x1F));
+            uint16x8_t g_16 = vandq_u16(vshrq_n_u16(pixels, 5),  vdupq_n_u16(0x3F));
+            uint16x8_t b_16 = vandq_u16(pixels,                  vdupq_n_u16(0x1F));
+
             uint8x8_t r = vmovn_u16(vorrq_u16(vshlq_n_u16(r_16, 3), vshrq_n_u16(r_16, 2)));
-            // G: (x << 2) | (x >> 4) -- 6-bit to 8-bit
             uint8x8_t g = vmovn_u16(vorrq_u16(vshlq_n_u16(g_16, 2), vshrq_n_u16(g_16, 4)));
-            // B: (x << 3) | (x >> 2)
             uint8x8_t b = vmovn_u16(vorrq_u16(vshlq_n_u16(b_16, 3), vshrq_n_u16(b_16, 2)));
             uint8x8_t a = vdup_n_u8(0xFF);
 
-            // Interleave into BGRA pattern (Byte 0:B, 1:G, 2:R, 3:A)
             uint8x8x2_t bg = vzip_u8(b, g);
             uint8x8x2_t ra = vzip_u8(r, a);
 
@@ -735,20 +677,14 @@ static void OEVideoCopyRGB565(const uint8_t *src, uint32_t *dst, unsigned width,
             vst1q_u32(d + x + 0, vreinterpretq_u32_u16(vcombine_u16(bgra0.val[0], bgra0.val[1])));
             vst1q_u32(d + x + 4, vreinterpretq_u32_u16(vcombine_u16(bgra1.val[0], bgra1.val[1])));
         }
+#endif
 
-        // Scalar fallback
+        // Scalar tail (also handles all pixels on non-arm64)
         for (; x < width; x++) {
             uint16_t pix = s[x];
-            uint32_t r_val, g_val, b_val;
-            if (swap) {
-                b_val = (pix >> 11) & 0x1F;
-                g_val = (pix >> 5) & 0x3F;
-                r_val = pix & 0x1F;
-            } else {
-                r_val = (pix >> 11) & 0x1F;
-                g_val = (pix >> 5) & 0x3F;
-                b_val = pix & 0x1F;
-            }
+            uint32_t r_val = (pix >> 11) & 0x1F;
+            uint32_t g_val = (pix >> 5)  & 0x3F;
+            uint32_t b_val =  pix        & 0x1F;
             r_val = (r_val << 3) | (r_val >> 2);
             g_val = (g_val << 2) | (g_val >> 4);
             b_val = (b_val << 3) | (b_val >> 2);
@@ -760,9 +696,9 @@ static void OEVideoCopyRGB565(const uint8_t *src, uint32_t *dst, unsigned width,
     }
 }
 
-static void OEVideoCopyXRGB8888(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords, BOOL swap) {
-    // Libretro XRGB8888 (Little Endian words 0xRRGGBB) are natively identical to BGRA in memory (B, G, R, X).
-    // Row-by-row memcpy is the most stable and performant restoration path.
+static void OEVideoCopyXRGB8888(const uint8_t *src, uint32_t *dst, unsigned width, unsigned height, size_t srcPitch, size_t dstPitchWords) {
+    // Libretro XRGB8888 stored as a uint32_t 0x00RRGGBB is, in little-endian
+    // memory, the byte sequence (B, G, R, 0x00) — already identical to BGRA.
     for (unsigned y = 0; y < height; y++) {
         memcpy(dst + (y * dstPitchWords), src + (y * srcPitch), width * 4);
     }
@@ -771,8 +707,9 @@ static void OEVideoCopyXRGB8888(const uint8_t *src, uint32_t *dst, unsigned widt
 static void libretro_video_refresh_cb(const void *data, unsigned width, unsigned height, size_t pitch) {
     if (data && _current) {
         if (width != _current->_lastWidth || height != _current->_lastHeight) {
+#if DEBUG
             NSLog(@"[OELibretro] Resolution change detected: %ux%u (Pitch: %zu)", width, height, pitch);
-            fprintf(stderr, "[OELibretro] Resolution change: %ux%u (Pitch: %zu)\n", width, height, pitch);
+#endif
             _current->_lastWidth = width;
             _current->_lastHeight = height;
         }
@@ -798,7 +735,6 @@ static void libretro_video_refresh_cb(const void *data, unsigned width, unsigned
             
             // Safety Check: Avoid out-of-bounds writes if core resolution exceeds buffer
             if (width > destRowWords || height > bufferHeight) {
-                NSLog(@"[OELibretro] WARNING: Core resolution %dx%d exceeds window buffer %zux%zu. Clipping to safety.", width, height, destRowWords, bufferHeight);
                 width = (unsigned)MIN(width, destRowWords);
                 height = (unsigned)MIN(height, bufferHeight);
             }
@@ -808,13 +744,15 @@ static void libretro_video_refresh_cb(const void *data, unsigned width, unsigned
                 case RETRO_PIXEL_FORMAT_0RGB1555: handler = OEVideoCopy0RGB1555; break;
                 case RETRO_PIXEL_FORMAT_RGB565:   handler = OEVideoCopyRGB565;   break;
                 case RETRO_PIXEL_FORMAT_XRGB8888: handler = OEVideoCopyXRGB8888; break;
-                default: break;
+                default:
+                    NSLog(@"[OELibretro] WARNING: Unknown pixel format %d — frame will not be drawn.",
+                          _current.retroPixelFormat);
+                    break;
             }
-            
+
             if (handler) {
-                // Copy to (0,0) and let OpenEmu Metal handle centering of the viewport.
-                // No R/B swap — the pixel conversion functions handle format correctly.
-                handler((const uint8_t *)data, dst, width, height, pitch, destRowWords, NO);
+                // Copy to (0,0) and let OpenEmu Metal handle centring the viewport.
+                handler((const uint8_t *)data, dst, width, height, pitch, destRowWords);
             }
         }
     }
@@ -839,18 +777,18 @@ static void libretro_input_poll_cb(void) {
 }
 static int16_t libretro_input_state_cb(unsigned port, unsigned device, unsigned index, unsigned id) {
     if (!_current) return 0;
-    
+
     switch (device) {
         case RETRO_DEVICE_JOYPAD:
             // Standard digital buttons — up to 16 buttons per port.
             if (port < 4 && id < 16) {
-                return _current->_buttonStates[port][id];
+                return atomic_load_explicit(&_current->_buttonStates[port][id], memory_order_relaxed);
             }
             return 0;
         case RETRO_DEVICE_ANALOG:
             // Analog sticks: index 0 = left stick, 1 = right stick; id 0 = X, 1 = Y.
             if (port < 4 && index < 2 && id < 2) {
-                return _current->_analogStates[port][index][id];
+                return atomic_load_explicit(&_current->_analogStates[port][index][id], memory_order_relaxed);
             }
             return 0;
         case RETRO_DEVICE_POINTER:
@@ -880,18 +818,20 @@ static int16_t libretro_input_state_cb(unsigned port, unsigned device, unsigned 
 
 #pragma mark - Symbol Resolution Helper
 
+// dlsym already strips the Mach-O leading underscore, so passing
+// "retro_init" finds the "_retro_init" symbol. No additional mangling
+// fallback is needed (or correct) on macOS.
 static void* bridge_dlsym(void *handle, const char *symbol) {
-    void *ptr = dlsym(handle, symbol);
-    if (!ptr) {
-        // Try with leading underscore (fallback for some macOS builds)
-        char fallback[512];
-        snprintf(fallback, sizeof(fallback), "_%s", symbol);
-        ptr = dlsym(handle, fallback);
-    }
-    return ptr;
+    return dlsym(handle, symbol);
 }
 
 - (instancetype)init {
+    NSAssert(_current == nil, @"OELibretroCoreTranslator is designed as a single-instance bridge due to thread-local callback residency.");
+    if (_current != nil) {
+        // Release-build guard — NSAssert compiles out in Release.
+        NSLog(@"[OELibretro] FATAL: Attempted to create a second OELibretroCoreTranslator while one is active.");
+        return nil;
+    }
     self = [super init];
     if (self) {
         _current = self;
@@ -901,17 +841,34 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
         _cachedMaxWidth = 0;
         _cachedMaxHeight = 0;
         _isBufferSizeLocked = NO;
-        _clearFramesRemaining = 20; 
+        _clearFramesRemaining = 20;
         _retroPixelFormat = RETRO_PIXEL_FORMAT_0RGB1555; // Libretro spec default
+
+        // Retain NSString path objects and create strdup'd C-string copies.
+        // The C-strings are what we hand to libretro cores via the environment
+        // callback; they remain valid until dealloc.
+        self.biosPath = [self biosDirectoryPath];
+        self.savesPath = [self batterySavesDirectoryPath];
+        self.supportPath = [self supportDirectoryPath];
+
+        free(_biosPathCStr);    _biosPathCStr    = self.biosPath    ? strdup([self.biosPath UTF8String])    : NULL;
+        free(_savesPathCStr);   _savesPathCStr   = self.savesPath   ? strdup([self.savesPath UTF8String])   : NULL;
+        free(_supportPathCStr); _supportPathCStr = self.supportPath ? strdup([self.supportPath UTF8String]) : NULL;
     }
     return self;
 }
 
 - (void)dealloc {
     if (_current == self) _current = nil;
+    free(_biosPathCStr);    _biosPathCStr    = NULL;
+    free(_savesPathCStr);   _savesPathCStr   = NULL;
+    free(_supportPathCStr); _supportPathCStr = NULL;
+    free(_contentDirCStr);  _contentDirCStr  = NULL;
     if (_coreHandle) {
+        if (_retro_unload_game) _retro_unload_game();
         if (_retro_deinit) _retro_deinit();
         dlclose(_coreHandle);
+        _coreHandle = NULL;
     }
 }
 
@@ -920,8 +877,8 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError **)error {
     _current = self;
     self.coreBundle = [[self owner] bundle];
-    
-    // If owner didn't provide a bundle, find it by scanning all loaded bundles
+
+    // Fallback: if owner didn't provide a bundle, scan all loaded bundles
     // for one that declares OELibretroCoreTranslator as its game core class.
     if (!self.coreBundle) {
         for (NSBundle *b in [NSBundle allBundles]) {
@@ -931,15 +888,15 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
             }
         }
     }
-    
+
     NSString *corePath = [[self coreBundle] objectForInfoDictionaryKey:@"OELibretroCorePath"];
-    
+
     if (!corePath) {
         corePath = [self.coreBundle executablePath];
     }
-    
-    // If the path is relative, resolve it against the bundle's MacOS/ directory
-    // (where the dylib sits alongside the stub executable).
+
+    // If the plist value is a relative path, resolve it against the bundle's
+    // MacOS/ directory (where the dylib sits alongside the stub executable).
     if (corePath && ![corePath isAbsolutePath]) {
         NSString *bundleMacOSDir = [[self.coreBundle executablePath] stringByDeletingLastPathComponent];
         corePath = [bundleMacOSDir stringByAppendingPathComponent:corePath];
@@ -955,9 +912,14 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     _isSaturn = [systemID containsString:@"saturn"];
     _isN64    = [systemID containsString:@"n64"];
     _isHW     = NO;  // Reset — core will re-request via SET_HW_RENDER if needed
-    
-    NSLog(@"[OELibretro] System: %@ | Flags: PSP=%d NDS=%d DC=%d Saturn=%d N64=%d",
-          systemID, _isPSP, _isNDS, _isDC, _isSaturn, _isN64);
+
+    // Populate content directory (ROM's parent folder) for RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY.
+    // The libretro spec says this should be the directory that contains the loaded content.
+    {
+        NSString *romDir = [path stringByDeletingLastPathComponent];
+        free(_contentDirCStr);
+        _contentDirCStr = romDir ? strdup([romDir fileSystemRepresentation]) : NULL;
+    }
     
     // Trust the core to set its own pixel format via RETRO_ENVIRONMENT_SET_PIXEL_FORMAT.
     // The Libretro spec default (0RGB1555) is set in -init; the core overrides it
@@ -966,12 +928,7 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     _cachedMaxWidth = 0; 
     _cachedMaxHeight = 0;
 
-    NSLog(@"[OELibretro] Bundle path: %@", self.coreBundle.bundlePath);
-    NSLog(@"[OELibretro] corePath resolved: %@", corePath);
-    NSLog(@"[OELibretro] ROM path: %@", path);
-    
     if (![[NSFileManager defaultManager] fileExistsAtPath:corePath]) {
-        NSLog(@"[OELibretro] ERROR: Core dylib NOT found at path!");
         if (error) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadROMError userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Libretro core not found at %@", corePath]}];
         }
@@ -981,17 +938,14 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     _coreHandle = dlopen([corePath UTF8String], RTLD_LAZY | RTLD_LOCAL);
     if (!_coreHandle) {
         const char *err = dlerror();
-        NSLog(@"[OELibretro] dlopen FAILED: %s", err ?: "unknown error");
         if (error) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadROMError userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to load libretro core: %s", err ?: "unknown error"]}];
         }
         return NO;
     }
     
-    // Resolve all mandatory symbols with fallback and logging
-    #define RESOLVE(name) _##name = bridge_dlsym(_coreHandle, #name); \
-        if (!_##name) NSLog(@"[OELibretro] CRITICAL: Symbol %s not found!", #name); \
-        else NSLog(@"[OELibretro] Core symbol resolved: %s", #name);
+    // Resolve all mandatory symbols with fallback
+    #define RESOLVE(name) _##name = bridge_dlsym(_coreHandle, #name);
     
     RESOLVE(retro_init);
     RESOLVE(retro_deinit);
@@ -1006,13 +960,14 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     RESOLVE(retro_run);
     RESOLVE(retro_load_game);
     RESOLVE(retro_unload_game);
+    
+    // Optional (but highly recommended) Serialization
     RESOLVE(retro_serialize_size);
     RESOLVE(retro_serialize);
     RESOLVE(retro_unserialize);
     
     // Safety check for absolute minimum required to function
     if (!_retro_init || !_retro_run || !_retro_load_game) {
-        NSLog(@"[OELibretro] Aborting: Essential Libretro symbols are missing.");
         if (error) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadROMError userInfo:@{NSLocalizedDescriptionKey: @"Core is missing essential Libretro functions."}];
         }
@@ -1021,67 +976,60 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
         return NO;
     }
     
-    // Register callbacks
-    _retro_set_environment(libretro_environment_cb);
-    _retro_set_video_refresh(libretro_video_refresh_cb);
-    _retro_set_audio_sample(libretro_audio_sample_cb);
-    _retro_set_audio_sample_batch(libretro_audio_sample_batch_cb);
-    _retro_set_input_poll(libretro_input_poll_cb);
-    _retro_set_input_state(libretro_input_state_cb);
+    // Register callbacks — guard each with a nil-check in case the core
+    // is missing a non-mandatory setter (e.g. stripped or minimal builds).
+    if (_retro_set_environment)        _retro_set_environment(libretro_environment_cb);
+    if (_retro_set_video_refresh)      _retro_set_video_refresh(libretro_video_refresh_cb);
+    if (_retro_set_audio_sample)       _retro_set_audio_sample(libretro_audio_sample_cb);
+    if (_retro_set_audio_sample_batch) _retro_set_audio_sample_batch(libretro_audio_sample_batch_cb);
+    if (_retro_set_input_poll)         _retro_set_input_poll(libretro_input_poll_cb);
+    if (_retro_set_input_state)        _retro_set_input_state(libretro_input_state_cb);
     
-    NSLog(@"[OELibretro] Calling retro_init()...");
     _retro_init();
     
-    // BIOS Verification Stage
+    // BIOS Verification Stage — non-fatal: log only. The core's own
+    // retro_load_game will surface the canonical error if the BIOS is
+    // truly required and missing.
     NSString *biosPath = [self biosDirectoryPath];
+#if DEBUG
     NSLog(@"[OELibretro] BIOS Directory: %@", biosPath);
-    
+#endif
+
     NSString *errorMsg = nil;
-    if ([systemID containsString:@"dc"]) {
-        if (!verify_bios_files(biosPath, @[@"dc_boot.bin", @"dc_flash.bin"])) {
-             errorMsg = @"Dreamcast requires dc_boot.bin and dc_flash.bin in your BIOS folder.";
-        }
-    } else if ([systemID containsString:@"nds"]) {
-        if (!verify_bios_files(biosPath, @[@"bios7.bin", @"bios9.bin", @"firmware.bin"])) {
-             errorMsg = @"Nintendo DS (MelonDS) requires bios7.bin, bios9.bin, and firmware.bin in your BIOS folder.";
-        }
-    }
-    
-    if (errorMsg) {
+    const OELibretroBIOSRequirement *req = bios_requirement_for_system(systemID);
+    if (req && !bios_requirement_satisfied(biosPath, req)) {
+        errorMsg = [NSString stringWithUTF8String:req->userMessage];
+#if DEBUG
         NSLog(@"[OELibretro] BIOS DIAGNOSTIC: %@", errorMsg);
+#endif
     }
     
     struct retro_system_info sysInfo = {0};
     _retro_get_system_info(&sysInfo);
-    NSLog(@"[OELibretro] Core System Info: %s (Version: %s)", sysInfo.library_name ?: "Unknown", sysInfo.library_version ?: "Unknown");
     
     struct retro_game_info gameInfo = {0};
     gameInfo.path = [path UTF8String];
     
     if (sysInfo.need_fullpath) {
-        NSLog(@"[OELibretro] Core needs fullpath, skipping data buffer loading.");
         gameInfo.data = NULL;
         gameInfo.size = 0;
     } else {
         _romData = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedIfSafe error:nil];
         gameInfo.data = [_romData bytes];
         gameInfo.size = [_romData length];
-        NSLog(@"[OELibretro] ROM Mapped into memory: %zu bytes", [_romData length]);
     }
     
     _clearFramesRemaining = 20; // Warm-up: Clear buffer for 20 frames to avoid memory artifacts
 
-    NSLog(@"[OELibretro] Successfully prepared game info. Calling retro_load_game...");
     if (!_retro_load_game(&gameInfo)) {
         errorMsg = @"The core rejected the ROM load. This is usually due to missing BIOS or corrupted files.";
-        
-        // Comprehensive BIOS Dependency Diagnostic
-        if ([systemID containsString:@"dc"]) {
-             errorMsg = @"Dreamcast ROM load failed. Ensure you have dc_boot.bin and dc_flash.bin in a 'dc' subfolder inside your BIOS directory.";
-        } else if ([systemID containsString:@"nds"]) {
-             errorMsg = @"Nintendo DS load failed. Ensure bios7.bin, bios9.bin, firmware.bin are in your BIOS folder.";
+
+        // If we know this system requires specific BIOS files, surface that
+        // hint to the user instead of the generic message.
+        if (req) {
+            errorMsg = [NSString stringWithUTF8String:req->userMessage];
         }
-        
+
         NSLog(@"[OELibretro] !!! CRITICAL LOAD FAILURE: %@", errorMsg);
         if (error) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain 
@@ -1089,6 +1037,15 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                                      userInfo:@{NSLocalizedDescriptionKey: errorMsg}];
         }
         return NO;
+    }
+    
+    // Core is loaded — resolve serialization state size now.
+    // Spec: cores may only know their true state size after loading content.
+    if (_retro_serialize_size) {
+        size_t s = _retro_serialize_size();
+        #if DEBUG
+        os_log_info(OE_LOG_DEFAULT, "Libretro: Core reported serialization size: %zu bytes", s);
+        #endif
     }
     
     // Update geometry and log handshake
@@ -1100,8 +1057,6 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
             _cachedMaxWidth  = _avInfo.geometry.max_width ?: 640;
             _cachedMaxHeight = _avInfo.geometry.max_height ?: 480;
         }
-        
-        NSLog(@"[OELibretro] Core Handshake: %dx%d (max), Audio: %.0fHz", (int)_cachedMaxWidth, (int)_cachedMaxHeight, _avInfo.timing.sample_rate);
     }
     
     return YES;
@@ -1109,7 +1064,9 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
 - (void)stopEmulation {
     [super stopEmulation];
-    _current = self;
+    // Nil _current BEFORE dlclose so any callbacks that fire during shutdown
+    // see nil and return early (prevents use-after-free in C callbacks).
+    _current = nil;
     if (_coreHandle) {
         if (_retro_unload_game) _retro_unload_game();
         if (_retro_deinit) _retro_deinit();
@@ -1128,8 +1085,6 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
         self.needsContextReset = NO;
         
         if (self.isHW && _hw_callback.context_reset) {
-            NSLog(@"[OELibretro] Calling context_reset for Hardware Accelerated core (on thread with active context)...");
-            fprintf(stderr, "[OELibretro] Calling context_reset for HW core\n");
             _hw_callback.context_reset();
         }
     }
@@ -1175,20 +1130,40 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
 - (OEIntSize)aspectSize {
     @synchronized(self) {
-        // Senior Programmer Choice: Global 1:1 Scaling for maximum sharpness as requested.
-        // Returning base dimensions ensures pixel-perfect results in the Metal renderer.
-        int width  = _avInfo.geometry.base_width;
-        int height = _avInfo.geometry.base_height;
-        
-        // Fallback to max dimensions if base is invalid
-        if (width <= 0) width = (int)_avInfo.geometry.max_width;
-        if (height <= 0) height = (int)_avInfo.geometry.max_height;
-        
-        // Final safety: ensure we never return zero-size
-        if (width <= 0) width = 320;
-        if (height <= 0) height = 240;
-        
-        return OEIntSizeMake(width, height);
+        // OEGameCore.aspectSize is the *aspect ratio expressed as a size*
+        // (e.g. (8,7) for NES, (4,3) for SNES) — not the pixel resolution.
+        // Returning base_width × base_height directly produces incorrect
+        // aspect on any system with non-square pixels.
+        //
+        // Prefer the core-reported aspect_ratio and snap to a small integer
+        // pair via continued-fraction approximation. Fall back to base
+        // dimensions only when aspect_ratio is unset (0 or NaN).
+        float aspect = _avInfo.geometry.aspect_ratio;
+        int baseW = (int)_avInfo.geometry.base_width;
+        int baseH = (int)_avInfo.geometry.base_height;
+
+        if (!isfinite(aspect) || aspect <= 0.0f) {
+            if (baseW > 0 && baseH > 0) {
+                aspect = (float)baseW / (float)baseH;
+            } else {
+                return OEIntSizeMake(4, 3);
+            }
+        }
+
+        // Snap aspect to a small (num, den) pair with denominator ≤ 16.
+        int bestNum = 4, bestDen = 3;
+        float bestErr = INFINITY;
+        for (int den = 1; den <= 16; den++) {
+            int num = (int)lroundf(aspect * den);
+            if (num <= 0) continue;
+            float err = fabsf((float)num / (float)den - aspect);
+            if (err < bestErr) {
+                bestErr = err;
+                bestNum = num;
+                bestDen = den;
+            }
+        }
+        return OEIntSizeMake(bestNum, bestDen);
     }
 }
 
@@ -1204,111 +1179,6 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     }
 }
 
-- (uint32_t)pixelFormat {
-    return _oePixelFormat;
-}
-
-- (uint32_t)pixelType {
-    return _oePixelType;
-}
-
-- (NSInteger)bytesPerRow {
-    return self.bufferSize.width * _bpp;
-}
-
-- (NSUInteger)channelCount {
-    return 2;
-}
-
-- (const void *)getVideoBufferWithHint:(void *)hint {
-    _oeBufferHint = hint;
-    if (!hint && _videoBuffer) {
-        return _videoBuffer;
-    }
-    // For the Metal renderer, we MUST return the hint to satisfy the direct rendering assertion.
-    // We handle cores with internal buffers by copying the data in libretro_video_refresh_cb.
-    return hint;
-}
-
-#pragma mark - Input: OELibretroInputReceiver
-
-- (void)receiveLibretroButton:(uint8_t)buttonID forPort:(NSUInteger)port pressed:(BOOL)pressed {
-    if (port < 4 && buttonID < 16) {
-        _buttonStates[port][buttonID] = pressed ? 1 : 0;
-    }
-}
-
-- (void)receiveLibretroAnalogIndex:(uint8_t)index axis:(uint8_t)axis value:(int16_t)value forPort:(NSUInteger)port {
-    if (port < 4 && index < 2 && axis < 2) {
-        _analogStates[port][index][axis] = value;
-    }
-}
-
-#pragma mark - Input Stubs
-
-- (void)mouseMovedAtPoint:(OEIntPoint)aPoint {}
-- (void)leftMouseDownAtPoint:(OEIntPoint)aPoint {}
-- (void)leftMouseUpAtPoint:(OEIntPoint)aPoint {}
-- (void)rightMouseDownAtPoint:(OEIntPoint)aPoint {}
-- (void)rightMouseUpAtPoint:(OEIntPoint)aPoint {}
-- (void)keyDown:(unsigned short)keyCode characters:(NSString *)characters charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers flags:(NSEventModifierFlags)flags {}
-- (void)keyUp:(unsigned short)keyCode characters:(NSString *)characters charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers flags:(NSEventModifierFlags)flags {}
-- (void)didPushOEButton:(NSInteger)button forPlayer:(NSUInteger)player {}
-- (void)didReleaseOEButton:(NSInteger)button forPlayer:(NSUInteger)player {}
-
-#pragma mark - OEGBSystemResponderClient
-
-// OEGBButton enum values (must match OEGBSystemResponderClient.h):
-// Up=0, Down=1, Left=2, Right=3, A=4, B=5, Start=6, Select=7
-static const uint8_t OEGBButtonToLibretro[] = {
-    RETRO_DEVICE_ID_JOYPAD_UP,     // OEGBButtonUp    = 0
-    RETRO_DEVICE_ID_JOYPAD_DOWN,   // OEGBButtonDown  = 1
-    RETRO_DEVICE_ID_JOYPAD_LEFT,   // OEGBButtonLeft  = 2
-    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // OEGBButtonRight = 3
-    RETRO_DEVICE_ID_JOYPAD_A,      // OEGBButtonA     = 4
-    RETRO_DEVICE_ID_JOYPAD_B,      // OEGBButtonB     = 5
-    RETRO_DEVICE_ID_JOYPAD_START,  // OEGBButtonStart = 6
-    RETRO_DEVICE_ID_JOYPAD_SELECT, // OEGBButtonSelect= 7
-};
-static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(OEGBButtonToLibretro[0]);
-
-- (oneway void)didPushGBButton:(NSInteger)button {
-    if ((NSUInteger)button < OEGBButtonCount) {
-        [self receiveLibretroButton:OEGBButtonToLibretro[button] forPort:0 pressed:YES];
-    }
-}
-
-- (oneway void)didReleaseGBButton:(NSInteger)button {
-    if ((NSUInteger)button < OEGBButtonCount) {
-        [self receiveLibretroButton:OEGBButtonToLibretro[button] forPort:0 pressed:NO];
-    }
-}
-
-#pragma mark - Speed Control
-
-- (float)rate {
-    return _current == self ? [super rate] : 1.0f;
-}
-
-- (OEGameCoreRendering)gameCoreRendering {
-    if (self.isHW) {
-        return OEGameCoreRenderingOpenGL3;
-    }
-    return OEGameCoreRenderingBitmap;
-}
-
-- (void)fastForwardAtSpeed:(CGFloat)speed {
-    self.rate = (float)speed;
-}
-
-- (void)rewindAtSpeed:(CGFloat)speed {
-    self.rate = -(float)speed;
-}
-
-- (void)slowMotionAtSpeed:(CGFloat)speed {
-    self.rate = (float)speed;
-}
-
 #pragma mark - Save States
 
 - (void)saveStateToFileAtPath:(NSString *)fileName completionHandler:(void(^)(BOOL success, NSError *error))block {
@@ -1320,6 +1190,9 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
     }
     NSError *writeErr = nil;
     BOOL ok = [data writeToFile:fileName options:NSDataWritingAtomic error:&writeErr];
+    if (!ok) {
+        NSLog(@"[OELibretro] Failed to save state to %@: %@", fileName, writeErr);
+    }
     if (block) block(ok, writeErr);
 }
 
@@ -1344,7 +1217,21 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
         }
         return nil;
     }
-    
+
+    if (self.serializationQuirks & RETRO_SERIALIZATION_QUIRK_INCOMPLETE) {
+#if DEBUG
+        NSLog(@"[OELibretro] Refusing to save state: core declared INCOMPLETE serialization.");
+#endif
+        if (error) {
+            *error = [NSError errorWithDomain:OEGameCoreErrorDomain
+                                         code:OEGameCoreCouldNotSaveStateError
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Core declared incomplete serialization."}];
+        }
+        return nil;
+    }
+
+    // Cores that set CORE_VARIABLE_SIZE may report a different size between
+    // calls; query immediately before each serialize to get the current value.
     size_t size = _retro_serialize_size();
     if (size == 0) {
         if (error) {
@@ -1354,7 +1241,7 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
         }
         return nil;
     }
-    
+
     NSMutableData *data = [NSMutableData dataWithLength:size];
     if (!_retro_serialize(data.mutableBytes, size)) {
         if (error) {
@@ -1364,8 +1251,10 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
         }
         return nil;
     }
-    
+
+#if DEBUG
     NSLog(@"[OELibretro] Save state serialized: %zu bytes", size);
+#endif
     return data;
 }
 
@@ -1378,7 +1267,7 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
         }
         return NO;
     }
-    
+
     if (!_retro_unserialize(state.bytes, state.length)) {
         if (error) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain
@@ -1387,14 +1276,510 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
         }
         return NO;
     }
-    
+
+#if DEBUG
     NSLog(@"[OELibretro] Save state loaded: %lu bytes", (unsigned long)state.length);
+#endif
     return YES;
 }
 
-#pragma mark - NDS Specific Responder
-- (oneway void)didPushNDSButton:(NSInteger)button forPlayer:(NSUInteger)player {}
-- (oneway void)didReleaseNDSButton:(NSInteger)button forPlayer:(NSUInteger)player {}
+- (uint32_t)pixelFormat {
+    return _oePixelFormat;
+}
+
+- (uint32_t)pixelType {
+    return _oePixelType;
+}
+
+- (NSInteger)bytesPerRow {
+    return self.bufferSize.width * _bpp;
+}
+
+- (NSUInteger)channelCount {
+    return 2;
+}
+
+- (const void *)getVideoBufferWithHint:(void *)hint {
+    _oeBufferHint = hint;
+    if (!hint && _videoBuffer) {
+        // Hand back the core's most recent frame, then forget the pointer:
+        // it's only valid for the duration of the libretro callback that
+        // produced it, and OpenEmu mustn't read it twice.
+        const void *frame = _videoBuffer;
+        _videoBuffer = NULL;
+        return frame;
+    }
+    // For the Metal renderer, we MUST return the hint to satisfy the direct rendering assertion.
+    // We handle cores with internal buffers by copying the data in libretro_video_refresh_cb.
+    return hint;
+}
+
+#pragma mark - Input: OELibretroInputReceiver
+// These methods are the canonical input entry point for the bridge.
+// System responders (OEGBASystemResponder, etc.) call these directly via
+// the OEBridgeInputTranslation protocol. The per-system didPushXXXButton:
+// methods below are fallback stubs that also route here — they fire only
+// when a native (non-bridge) core somehow ends up loading through the
+// translator, which should not happen in practice. If you update the
+// button mapping in a system responder's kXXXLibretroMap[], verify the
+// corresponding translator-side table (if any) stays consistent.
+
+- (void)receiveLibretroButton:(uint8_t)buttonID forPort:(NSUInteger)port pressed:(BOOL)pressed {
+    if (port < 4 && buttonID < 16) {
+        atomic_store_explicit(&_buttonStates[port][buttonID], pressed ? 1 : 0, memory_order_relaxed);
+    }
+}
+
+- (void)receiveLibretroAnalogIndex:(uint8_t)index axis:(uint8_t)axis value:(int16_t)value forPort:(NSUInteger)port {
+    if (port < 4 && index < 2 && axis < 2) {
+        atomic_store_explicit(&_analogStates[port][index][axis], value, memory_order_relaxed);
+    }
+}
+
+#pragma mark - Input Stubs
+
+- (void)didPushOEButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    uint8_t retroID = [self _retroButtonForOEButton:button];
+    if (retroID != 0xFF) {
+        [self receiveLibretroButton:retroID forPort:(player > 0 ? player - 1 : 0) pressed:YES];
+    }
+}
+
+- (void)didReleaseOEButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    uint8_t retroID = [self _retroButtonForOEButton:button];
+    if (retroID != 0xFF) {
+        [self receiveLibretroButton:retroID forPort:(player > 0 ? player - 1 : 0) pressed:NO];
+    }
+}
+
+- (uint8_t)_retroButtonForOEButton:(NSInteger)button {
+    // Standard OpenEmu button order tends to match SNES-ish layout for simple digital pads.
+    // However, the cleanest way to support multiple cores is to map based on the current system.
+    
+    if (self.isPSP) {
+        // OEPSPButton mapping
+        switch (button) {
+            case 0:  return RETRO_DEVICE_ID_JOYPAD_UP;     // OEPSPButtonUp
+            case 1:  return RETRO_DEVICE_ID_JOYPAD_DOWN;   // OEPSPButtonDown
+            case 2:  return RETRO_DEVICE_ID_JOYPAD_LEFT;   // OEPSPButtonLeft
+            case 3:  return RETRO_DEVICE_ID_JOYPAD_RIGHT;  // OEPSPButtonRight
+            case 4:  return RETRO_DEVICE_ID_JOYPAD_X;      // OEPSPButtonTriangle
+            case 5:  return RETRO_DEVICE_ID_JOYPAD_A;      // OEPSPButtonCircle
+            case 6:  return RETRO_DEVICE_ID_JOYPAD_B;      // OEPSPButtonCross
+            case 7:  return RETRO_DEVICE_ID_JOYPAD_Y;      // OEPSPButtonSquare
+            case 8:  return RETRO_DEVICE_ID_JOYPAD_L;      // OEPSPButtonL1
+            case 11: return RETRO_DEVICE_ID_JOYPAD_R;      // OEPSPButtonR1
+            case 14: return RETRO_DEVICE_ID_JOYPAD_START;  // OEPSPButtonStart
+            case 15: return RETRO_DEVICE_ID_JOYPAD_SELECT; // OEPSPButtonSelect
+            default: return 0xFF;
+        }
+    }
+    
+    if (self.isSaturn) {
+        // OESaturnButton mapping
+        switch (button) {
+            case 0: return RETRO_DEVICE_ID_JOYPAD_UP;     // OESaturnButtonUp
+            case 1: return RETRO_DEVICE_ID_JOYPAD_DOWN;   // OESaturnButtonDown
+            case 2: return RETRO_DEVICE_ID_JOYPAD_LEFT;   // OESaturnButtonLeft
+            case 3: return RETRO_DEVICE_ID_JOYPAD_RIGHT;  // OESaturnButtonRight
+            case 4: return RETRO_DEVICE_ID_JOYPAD_Y;      // OESaturnButtonA -> Y (Libretro Saturn layout)
+            case 5: return RETRO_DEVICE_ID_JOYPAD_B;      // OESaturnButtonB -> B
+            case 6: return RETRO_DEVICE_ID_JOYPAD_A;      // OESaturnButtonC -> A
+            case 7: return RETRO_DEVICE_ID_JOYPAD_L;      // OESaturnButtonX -> L
+            case 8: return RETRO_DEVICE_ID_JOYPAD_X;      // OESaturnButtonY -> X
+            case 9: return RETRO_DEVICE_ID_JOYPAD_R;      // OESaturnButtonZ -> R
+            case 10: return RETRO_DEVICE_ID_JOYPAD_L2;    // OESaturnButtonL -> L2
+            case 11: return RETRO_DEVICE_ID_JOYPAD_R2;    // OESaturnButtonR -> R2
+            case 12: return RETRO_DEVICE_ID_JOYPAD_START; // OESaturnButtonStart
+            default: return 0xFF;
+        }
+    }
+
+    // Default Fallback (SNES/Generic)
+    switch (button) {
+        case 0: return RETRO_DEVICE_ID_JOYPAD_UP;
+        case 1: return RETRO_DEVICE_ID_JOYPAD_DOWN;
+        case 2: return RETRO_DEVICE_ID_JOYPAD_LEFT;
+        case 3: return RETRO_DEVICE_ID_JOYPAD_RIGHT;
+        case 4: return RETRO_DEVICE_ID_JOYPAD_A;
+        case 5: return RETRO_DEVICE_ID_JOYPAD_B;
+        case 6: return RETRO_DEVICE_ID_JOYPAD_X;
+        case 7: return RETRO_DEVICE_ID_JOYPAD_Y;
+        case 8: return RETRO_DEVICE_ID_JOYPAD_L;
+        case 9: return RETRO_DEVICE_ID_JOYPAD_R;
+        case 10: return RETRO_DEVICE_ID_JOYPAD_START;
+        case 11: return RETRO_DEVICE_ID_JOYPAD_SELECT;
+        default: return 0xFF;
+    }
+}
+
+#pragma mark - Speed Control
+
+- (float)rate {
+    return _current == self ? [super rate] : 1.0f;
+}
+
+- (OEGameCoreRendering)gameCoreRendering {
+    if (self.isHW) {
+        return OEGameCoreRenderingOpenGL3;
+    }
+    return OEGameCoreRenderingBitmap;
+}
+
+- (void)fastForwardAtSpeed:(CGFloat)speed {
+    self.rate = (float)speed;
+}
+
+- (void)rewindAtSpeed:(CGFloat)speed {
+    // Rewind is not implemented in the bridge; pause to avoid undefined negative rate.
+    self.rate = 0;
+}
+
+- (void)slowMotionAtSpeed:(CGFloat)speed {
+    self.rate = (float)speed;
+}
+
+#pragma mark - System Specific Responders
+// Most systems use generic didPushOEButton: routing through _retroButtonForOEButton:.
+// Systems with analog input or non-standard button orderings get dedicated lookup tables.
+
+- (oneway void)didPushNESButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseNESButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushSNESButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseSNESButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushSaturnButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseSaturnButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushPSPButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleasePSPButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPush7800Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didRelease7800Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushSMSButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseSMSButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushGGButton:(NSInteger)button {
+    [self didPushOEButton:button forPlayer:1];
+}
+- (oneway void)didReleaseGGButton:(NSInteger)button {
+    [self didReleaseOEButton:button forPlayer:1];
+}
+
+- (oneway void)didPushPSXButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleasePSXButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushColecoVisionButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseColecoVisionButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPush5200Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didRelease5200Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushA8Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseA8Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushSega32XButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseSega32XButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+- (oneway void)didPushSegaCDButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseSegaCDButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
+
+#pragma mark - OEGenesisSystemResponderClient (lookup table)
+
+// OEGenesisButton enum: Up=0, Down=1, Left=2, Right=3, A=4, B=5, C=6, X=7, Y=8, Z=9, Start=10, Mode=11
+static const uint8_t OEGenesisButtonToLibretro[] = {
+    RETRO_DEVICE_ID_JOYPAD_UP,     // 0 Up
+    RETRO_DEVICE_ID_JOYPAD_DOWN,   // 1 Down
+    RETRO_DEVICE_ID_JOYPAD_LEFT,   // 2 Left
+    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // 3 Right
+    RETRO_DEVICE_ID_JOYPAD_Y,      // 4 A → Y (genesis_plus_gx mapping)
+    RETRO_DEVICE_ID_JOYPAD_B,      // 5 B → B
+    RETRO_DEVICE_ID_JOYPAD_A,      // 6 C → A
+    RETRO_DEVICE_ID_JOYPAD_L,      // 7 X → L
+    RETRO_DEVICE_ID_JOYPAD_X,      // 8 Y → X
+    RETRO_DEVICE_ID_JOYPAD_R,      // 9 Z → R
+    RETRO_DEVICE_ID_JOYPAD_START,  // 10 Start
+    RETRO_DEVICE_ID_JOYPAD_SELECT, // 11 Mode → Select
+};
+static const NSUInteger OEGenesisButtonCount = sizeof(OEGenesisButtonToLibretro) / sizeof(OEGenesisButtonToLibretro[0]);
+
+- (oneway void)didPushGenesisButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEGenesisButtonCount) {
+        [self receiveLibretroButton:OEGenesisButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:YES];
+    }
+}
+- (oneway void)didReleaseGenesisButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEGenesisButtonCount) {
+        [self receiveLibretroButton:OEGenesisButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:NO];
+    }
+}
+
+#pragma mark - OEN64SystemResponderClient (lookup table + analog)
+
+// OEN64Button enum: DPadUp=0..DPadRight=3, CUp=4..CRight=7, A=8, B=9, L=10, R=11, Z=12, Start=13, AnalogUp=14..AnalogRight=17
+// Analog entries use 0xFF sentinel — handled separately in didMoveN64JoystickDirection:.
+static const uint8_t OEN64ButtonToLibretro[] = {
+    RETRO_DEVICE_ID_JOYPAD_UP,     // 0 DPadUp
+    RETRO_DEVICE_ID_JOYPAD_DOWN,   // 1 DPadDown
+    RETRO_DEVICE_ID_JOYPAD_LEFT,   // 2 DPadLeft
+    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // 3 DPadRight
+    0xFF,                          // 4 CUp    (mapped as right-stick up)
+    0xFF,                          // 5 CDown  (mapped as right-stick down)
+    0xFF,                          // 6 CLeft  (mapped as right-stick left)
+    0xFF,                          // 7 CRight (mapped as right-stick right)
+    RETRO_DEVICE_ID_JOYPAD_A,      // 8 A
+    RETRO_DEVICE_ID_JOYPAD_B,      // 9 B
+    RETRO_DEVICE_ID_JOYPAD_L,      // 10 L
+    RETRO_DEVICE_ID_JOYPAD_R,      // 11 R
+    RETRO_DEVICE_ID_JOYPAD_L2,     // 12 Z → L2 (mupen64plus-next mapping)
+    RETRO_DEVICE_ID_JOYPAD_START,  // 13 Start
+    0xFF,                          // 14 AnalogUp
+    0xFF,                          // 15 AnalogDown
+    0xFF,                          // 16 AnalogLeft
+    0xFF,                          // 17 AnalogRight
+};
+static const NSUInteger OEN64ButtonCount = sizeof(OEN64ButtonToLibretro) / sizeof(OEN64ButtonToLibretro[0]);
+
+- (oneway void)didPushN64Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEN64ButtonCount && OEN64ButtonToLibretro[button] != 0xFF) {
+        [self receiveLibretroButton:OEN64ButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:YES];
+    }
+    // C-buttons as right analog stick digital presses
+    NSUInteger port = player > 0 ? player - 1 : 0;
+    switch (button) {
+        case 4: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_Y value:-0x7FFF forPort:port]; break; // CUp
+        case 5: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_Y value: 0x7FFF forPort:port]; break; // CDown
+        case 6: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_X value:-0x7FFF forPort:port]; break; // CLeft
+        case 7: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_X value: 0x7FFF forPort:port]; break; // CRight
+        default: break;
+    }
+}
+- (oneway void)didReleaseN64Button:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEN64ButtonCount && OEN64ButtonToLibretro[button] != 0xFF) {
+        [self receiveLibretroButton:OEN64ButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:NO];
+    }
+    NSUInteger port = player > 0 ? player - 1 : 0;
+    switch (button) {
+        case 4: case 5: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_Y value:0 forPort:port]; break;
+        case 6: case 7: [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_RIGHT axis:RETRO_DEVICE_ID_ANALOG_X value:0 forPort:port]; break;
+        default: break;
+    }
+}
+
+- (oneway void)didMoveN64JoystickDirection:(NSInteger)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
+    NSUInteger port = player > 0 ? player - 1 : 0;
+    int16_t scaledValue = (int16_t)(value * 0x7FFF);
+    switch (button) {
+        case 14: // AnalogUp
+            [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_LEFT axis:RETRO_DEVICE_ID_ANALOG_Y value:-scaledValue forPort:port];
+            break;
+        case 15: // AnalogDown
+            [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_LEFT axis:RETRO_DEVICE_ID_ANALOG_Y value:scaledValue forPort:port];
+            break;
+        case 16: // AnalogLeft
+            [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_LEFT axis:RETRO_DEVICE_ID_ANALOG_X value:-scaledValue forPort:port];
+            break;
+        case 17: // AnalogRight
+            [self receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_LEFT axis:RETRO_DEVICE_ID_ANALOG_X value:scaledValue forPort:port];
+            break;
+        default:
+            break;
+    }
+}
+
+#pragma mark - OEGBASystemResponderClient (lookup table)
+
+// OEGBAButton enum: Up=0, Down=1, Left=2, Right=3, A=4, B=5, L=6, R=7, Start=8, Select=9
+static const uint8_t OEGBAButtonToLibretro[] = {
+    RETRO_DEVICE_ID_JOYPAD_UP,     // 0 Up
+    RETRO_DEVICE_ID_JOYPAD_DOWN,   // 1 Down
+    RETRO_DEVICE_ID_JOYPAD_LEFT,   // 2 Left
+    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // 3 Right
+    RETRO_DEVICE_ID_JOYPAD_A,      // 4 A
+    RETRO_DEVICE_ID_JOYPAD_B,      // 5 B
+    RETRO_DEVICE_ID_JOYPAD_L,      // 6 L
+    RETRO_DEVICE_ID_JOYPAD_R,      // 7 R
+    RETRO_DEVICE_ID_JOYPAD_START,  // 8 Start
+    RETRO_DEVICE_ID_JOYPAD_SELECT, // 9 Select
+};
+static const NSUInteger OEGBAButtonCount = sizeof(OEGBAButtonToLibretro) / sizeof(OEGBAButtonToLibretro[0]);
+
+- (oneway void)didPushGBAButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEGBAButtonCount) {
+        [self receiveLibretroButton:OEGBAButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:YES];
+    }
+}
+- (oneway void)didReleaseGBAButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button < OEGBAButtonCount) {
+        [self receiveLibretroButton:OEGBAButtonToLibretro[button] forPort:(player > 0 ? player - 1 : 0) pressed:NO];
+    }
+}
+
+#pragma mark - OEGBSystemResponderClient (lookup table)
+
+// OEGBButton enum: Up=0, Down=1, Left=2, Right=3, A=4, B=5, Start=6, Select=7
+static const uint8_t OEGBButtonToLibretro[] = {
+    RETRO_DEVICE_ID_JOYPAD_UP,     // 0
+    RETRO_DEVICE_ID_JOYPAD_DOWN,   // 1
+    RETRO_DEVICE_ID_JOYPAD_LEFT,   // 2
+    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // 3
+    RETRO_DEVICE_ID_JOYPAD_A,      // 4
+    RETRO_DEVICE_ID_JOYPAD_B,      // 5
+    RETRO_DEVICE_ID_JOYPAD_START,  // 6
+    RETRO_DEVICE_ID_JOYPAD_SELECT, // 7
+};
+static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(OEGBButtonToLibretro[0]);
+
+- (oneway void)didPushGBButton:(NSInteger)button {
+    if ((NSUInteger)button < OEGBButtonCount) {
+        [self receiveLibretroButton:OEGBButtonToLibretro[button] forPort:0 pressed:YES];
+    }
+}
+- (oneway void)didReleaseGBButton:(NSInteger)button {
+    if ((NSUInteger)button < OEGBButtonCount) {
+        [self receiveLibretroButton:OEGBButtonToLibretro[button] forPort:0 pressed:NO];
+    }
+}
+
+#pragma mark - OEDCSystemResponderClient (lookup table + analog)
+
+// OEDCButton enum: Up=0, Down=1, Left=2, Right=3, A=4, B=5, X=6, Y=7,
+// AnalogL=8, AnalogR=9, Start=10, AnalogUp=11, AnalogDown=12, AnalogLeft=13, AnalogRight=14
+// Analog entries use 0xFF sentinel — handled separately in didMoveDCJoystickDirection:.
+static const uint8_t OEDCButtonToLibretro[] = {
+    RETRO_DEVICE_ID_JOYPAD_UP,     // 0
+    RETRO_DEVICE_ID_JOYPAD_DOWN,   // 1
+    RETRO_DEVICE_ID_JOYPAD_LEFT,   // 2
+    RETRO_DEVICE_ID_JOYPAD_RIGHT,  // 3
+    RETRO_DEVICE_ID_JOYPAD_A,      // 4
+    RETRO_DEVICE_ID_JOYPAD_B,      // 5
+    RETRO_DEVICE_ID_JOYPAD_X,      // 6
+    RETRO_DEVICE_ID_JOYPAD_Y,      // 7
+    0xFF,                          // 8  AnalogL (analog)
+    0xFF,                          // 9  AnalogR (analog)
+    RETRO_DEVICE_ID_JOYPAD_START,  // 10
+    0xFF,                          // 11 AnalogUp (analog)
+    0xFF,                          // 12 AnalogDown (analog)
+    0xFF,                          // 13 AnalogLeft (analog)
+    0xFF,                          // 14 AnalogRight (analog)
+};
+static const NSUInteger OEDCButtonCount = sizeof(OEDCButtonToLibretro) / sizeof(OEDCButtonToLibretro[0]);
+
+- (oneway void)didPushDCButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button >= OEDCButtonCount) return;
+    uint8_t libretroID = OEDCButtonToLibretro[button];
+    if (libretroID != 0xFF) {
+        NSUInteger port = player > 0 ? player - 1 : 0;
+        [self receiveLibretroButton:libretroID forPort:port pressed:YES];
+    }
+}
+
+- (oneway void)didReleaseDCButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    if ((NSUInteger)button >= OEDCButtonCount) return;
+    uint8_t libretroID = OEDCButtonToLibretro[button];
+    if (libretroID != 0xFF) {
+        NSUInteger port = player > 0 ? player - 1 : 0;
+        [self receiveLibretroButton:libretroID forPort:port pressed:NO];
+    }
+}
+
+- (oneway void)didMoveDCJoystickDirection:(NSInteger)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
+    NSUInteger port = player > 0 ? player - 1 : 0;
+    if (port >= 4) return;
+
+    // Scale CGFloat value to libretro int16_t range.
+    // Sticks: OE sends [-1.0, 1.0] -> libretro [-32768, 32767]
+    // Triggers: OE sends [0.0, 1.0] -> libretro [0, 32767]
+    int16_t scaled = (int16_t)(value * 32767.0);
+
+    switch (button) {
+        case 13: // OEDCAnalogLeft  -> X axis
+            atomic_store_explicit(&_analogStates[port][RETRO_DEVICE_INDEX_ANALOG_LEFT][RETRO_DEVICE_ID_ANALOG_X], scaled, memory_order_relaxed);
+            break;
+        case 14: // OEDCAnalogRight -> X axis (right stick)
+            atomic_store_explicit(&_analogStates[port][RETRO_DEVICE_INDEX_ANALOG_RIGHT][RETRO_DEVICE_ID_ANALOG_X], scaled, memory_order_relaxed);
+            break;
+        case 11: // OEDCAnalogUp    -> Y axis
+            atomic_store_explicit(&_analogStates[port][RETRO_DEVICE_INDEX_ANALOG_LEFT][RETRO_DEVICE_ID_ANALOG_Y], scaled, memory_order_relaxed);
+            break;
+        case 12: // OEDCAnalogDown  -> Y axis
+            atomic_store_explicit(&_analogStates[port][RETRO_DEVICE_INDEX_ANALOG_LEFT][RETRO_DEVICE_ID_ANALOG_Y], scaled, memory_order_relaxed);
+            break;
+        // Analog triggers — Flycast's libretro core actually supports true analog
+        // L2/R2 via RETRO_DEVICE_ANALOG index 2, but our _analogStates array is
+        // [4][2][2] (left/right stick only). Expanding to index 3 just for DC
+        // triggers isn't worth the memory/complexity cost. Instead we digitize
+        // the trigger: >50% threshold = pressed. This loses analog granularity
+        // but is safe and functional for all bridge cores.
+        case 8:  // OEDCAnalogL
+            [self receiveLibretroButton:RETRO_DEVICE_ID_JOYPAD_L2 forPort:port pressed:(value > 0.5)];
+            break;
+        case 9:  // OEDCAnalogR
+            [self receiveLibretroButton:RETRO_DEVICE_ID_JOYPAD_R2 forPort:port pressed:(value > 0.5)];
+            break;
+        default:
+            break;
+    }
+}
+
+#pragma mark - NDS Touch Responder
+
+- (oneway void)didPushNDSButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didPushOEButton:button forPlayer:player];
+}
+- (oneway void)didReleaseNDSButton:(NSInteger)button forPlayer:(NSUInteger)player {
+    [self didReleaseOEButton:button forPlayer:player];
+}
 
 - (oneway void)didTouchScreenPoint:(OEIntPoint)point {
     _touchX = point.x;
@@ -1405,5 +1790,15 @@ static const NSUInteger OEGBButtonCount = sizeof(OEGBButtonToLibretro) / sizeof(
 - (oneway void)didReleaseTouch {
     _isTouching = NO;
 }
+
+#pragma mark - Mouse/Keyboard Stubs
+
+- (void)mouseMovedAtPoint:(OEIntPoint)aPoint {}
+- (void)leftMouseDownAtPoint:(OEIntPoint)aPoint {}
+- (void)leftMouseUpAtPoint:(OEIntPoint)aPoint {}
+- (void)rightMouseDownAtPoint:(OEIntPoint)aPoint {}
+- (void)rightMouseUpAtPoint:(OEIntPoint)aPoint {}
+- (void)keyDown:(unsigned short)keyCode characters:(NSString *)characters charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers flags:(NSEventModifierFlags)flags {}
+- (void)keyUp:(unsigned short)keyCode characters:(NSString *)characters charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers flags:(NSEventModifierFlags)flags {}
 
 @end

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroInputReceiver.h
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroInputReceiver.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-@protocol OELibretroInputReceiver <NSObject>
-- (void)receiveLibretroButton:(uint8_t)buttonID forPort:(NSUInteger)port pressed:(BOOL)pressed;
-- (void)receiveLibretroAnalogIndex:(uint8_t)index axis:(uint8_t)axis value:(int16_t)value forPort:(NSUInteger)port;
-@end
+// OEBridgeInputTranslation and OELibretroInputReceiver are both declared in OEGameCore.h.
+// Import that header to get both protocol definitions.
+#import <OpenEmuBase/OEGameCore.h>

--- a/OpenEmu-SDK/OpenEmuBase/OpenEmuBase.h
+++ b/OpenEmu-SDK/OpenEmuBase/OpenEmuBase.h
@@ -45,3 +45,4 @@
 #import <OpenEmuBase/OEAudioBuffer.h>
 #import <OpenEmuBase/NSUserDefaults+OpenEmuSDK.h>
 #import <OpenEmuBase/OEGameCoreDisplayModes.h>
+#import <OpenEmuBase/OELibretroCoreTranslator.h>

--- a/OpenEmu-SDK/OpenEmuBase/libretro.h
+++ b/OpenEmu-SDK/OpenEmuBase/libretro.h
@@ -1,3 +1,29 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef OE_LIBRETRO_H
+#define OE_LIBRETRO_H
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
@@ -8,40 +34,225 @@
 extern "C" {
 #endif
 
-// Minimal libretro.h for bridge compilation
-#define RETRO_DEVICE_JOYPAD 1
-#define RETRO_DEVICE_ANALOG 2
-#define RETRO_DEVICE_POINTER 6
-#define RETRO_DEVICE_ID_JOYPAD_B        0
-#define RETRO_DEVICE_ID_JOYPAD_Y        1
-#define RETRO_DEVICE_ID_JOYPAD_SELECT   2
-#define RETRO_DEVICE_ID_JOYPAD_START    3
-#define RETRO_DEVICE_ID_JOYPAD_UP       4
-#define RETRO_DEVICE_ID_JOYPAD_DOWN     5
-#define RETRO_DEVICE_ID_JOYPAD_LEFT     6
-#define RETRO_DEVICE_ID_JOYPAD_RIGHT    7
-#define RETRO_DEVICE_ID_JOYPAD_A        8
-#define RETRO_DEVICE_ID_JOYPAD_X        9
-#define RETRO_DEVICE_ID_JOYPAD_L        10
-#define RETRO_DEVICE_ID_JOYPAD_R        11
-#define RETRO_DEVICE_ID_JOYPAD_L2       12
-#define RETRO_DEVICE_ID_JOYPAD_R2       13
-#define RETRO_DEVICE_ID_JOYPAD_L3       14
-#define RETRO_DEVICE_ID_JOYPAD_R3       15
-#define RETRO_DEVICE_ID_POINTER_X 0
-#define RETRO_DEVICE_ID_POINTER_Y 1
-#define RETRO_DEVICE_ID_POINTER_PRESSED 2
-typedef bool (*retro_environment_t)(unsigned cmd, void *data);
-typedef void (*retro_video_refresh_t)(const void *data, unsigned width, unsigned height, size_t pitch);
-typedef void (*retro_audio_sample_t)(int16_t left, int16_t right);
-typedef size_t (*retro_audio_sample_batch_t)(const int16_t *data, size_t frames);
-typedef void (*retro_input_poll_t)(void);
+// Minimal subset of upstream libretro.h sufficient to bridge the cores we
+// support. Field types and ordering must match
+// https://github.com/libretro/libretro-common/blob/master/include/libretro.h
+// exactly, because libretro cores write into these structs by offset.
+//
+// Historical note (the "shift" bug): we previously declared the boolean
+// flags in retro_hw_render_callback as `uint32_t`. The upstream ABI uses
+// C99 `bool` (1 byte), so cores wrote three bools + padding into 4 bytes
+// while the bridge expected three 4-byte ints. Every field after that
+// (including version_major) was read from the wrong offset and appeared
+// as zero, producing black screens during HW context init. Keep these
+// types in sync with upstream — this is a struct-layout invariant, not
+// an arm64-specific quirk.
+
+// ── Environment commands ─────────────────────────────────────────────
+#define RETRO_ENVIRONMENT_GET_CAN_DUPE                                 3
+#define RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY                         9
+#define RETRO_ENVIRONMENT_SET_PIXEL_FORMAT                             10
+#define RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS                        11
+#define RETRO_ENVIRONMENT_SET_HW_RENDER                                14
+#define RETRO_ENVIRONMENT_GET_VARIABLE                                 15
+#define RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE                          17
+#define RETRO_ENVIRONMENT_GET_LOG_INTERFACE                            27
+#define RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY                        30
+#define RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY                           31
+#define RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO                           32
+#define RETRO_ENVIRONMENT_SET_CONTROLLER_INFO                          35
+#define RETRO_ENVIRONMENT_SET_GEOMETRY                                 37
+#define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE                      41
+#define RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE  (43 | 0x10000)
+#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS                     44
+#define RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION                     52
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS                             53
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2                          67
+
+// ── Serialization quirk bitmask (RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS) ─
+#define RETRO_SERIALIZATION_QUIRK_INCOMPLETE                  (1 << 0)
+#define RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE             (1 << 1)
+#define RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE          (1 << 2)
+#define RETRO_SERIALIZATION_QUIRK_FRONT_VARIABLE_SIZE         (1 << 3)
+#define RETRO_SERIALIZATION_QUIRK_SINGLE_SESSION              (1 << 4)
+#define RETRO_SERIALIZATION_QUIRK_ENDIAN_DEPENDENT            (1 << 5)
+#define RETRO_SERIALIZATION_QUIRK_PLATFORM_DEPENDENT          (1 << 6)
+
+// ── Sentinel for HW-rendered frames ──────────────────────────────────
+#define RETRO_HW_FRAME_BUFFER_VALID ((void*)-1)
+
+// ── Input devices / IDs ──────────────────────────────────────────────
+#define RETRO_DEVICE_JOYPAD              1
+#define RETRO_DEVICE_ANALOG              2
+#define RETRO_DEVICE_POINTER             6
+
+#define RETRO_DEVICE_ID_JOYPAD_B         0
+#define RETRO_DEVICE_ID_JOYPAD_Y         1
+#define RETRO_DEVICE_ID_JOYPAD_SELECT    2
+#define RETRO_DEVICE_ID_JOYPAD_START     3
+#define RETRO_DEVICE_ID_JOYPAD_UP        4
+#define RETRO_DEVICE_ID_JOYPAD_DOWN      5
+#define RETRO_DEVICE_ID_JOYPAD_LEFT      6
+#define RETRO_DEVICE_ID_JOYPAD_RIGHT     7
+#define RETRO_DEVICE_ID_JOYPAD_A         8
+#define RETRO_DEVICE_ID_JOYPAD_X         9
+#define RETRO_DEVICE_ID_JOYPAD_L         10
+#define RETRO_DEVICE_ID_JOYPAD_R         11
+#define RETRO_DEVICE_ID_JOYPAD_L2        12
+#define RETRO_DEVICE_ID_JOYPAD_R2        13
+#define RETRO_DEVICE_ID_JOYPAD_L3        14
+#define RETRO_DEVICE_ID_JOYPAD_R3        15
+
+#define RETRO_DEVICE_INDEX_ANALOG_LEFT   0
+#define RETRO_DEVICE_INDEX_ANALOG_RIGHT  1
+#define RETRO_DEVICE_ID_ANALOG_X         0
+#define RETRO_DEVICE_ID_ANALOG_Y         1
+
+#define RETRO_DEVICE_ID_POINTER_X        0
+#define RETRO_DEVICE_ID_POINTER_Y        1
+#define RETRO_DEVICE_ID_POINTER_PRESSED  2
+
+// ── Callback typedefs ────────────────────────────────────────────────
+typedef bool    (*retro_environment_t)(unsigned cmd, void *data);
+typedef void    (*retro_video_refresh_t)(const void *data, unsigned width, unsigned height, size_t pitch);
+typedef void    (*retro_audio_sample_t)(int16_t left, int16_t right);
+typedef size_t  (*retro_audio_sample_batch_t)(const int16_t *data, size_t frames);
+typedef void    (*retro_input_poll_t)(void);
 typedef int16_t (*retro_input_state_t)(unsigned port, unsigned device, unsigned index, unsigned id);
-struct retro_system_info { const char *library_name; const char *library_version; const char *valid_extensions; bool need_fullpath; bool block_extract; };
-struct retro_game_geometry { unsigned base_width; unsigned base_height; unsigned max_width; unsigned max_height; float aspect_ratio; };
-struct retro_system_timing { double fps; double sample_rate; };
-struct retro_system_av_info { struct retro_game_geometry geometry; struct retro_system_timing timing; };
-struct retro_game_info { const char *path; const void *data; size_t size; const char *meta; };
+typedef void    (*retro_proc_address_t)(void);
+
+// ── Structs ──────────────────────────────────────────────────────────
+struct retro_variable {
+    const char *key;
+    const char *value;
+};
+
+enum retro_pixel_format {
+    RETRO_PIXEL_FORMAT_0RGB1555 = 0,
+    RETRO_PIXEL_FORMAT_XRGB8888 = 1,
+    RETRO_PIXEL_FORMAT_RGB565   = 2,
+    RETRO_PIXEL_FORMAT_UNKNOWN  = 0x7fffffff
+};
+
+enum retro_log_level {
+    RETRO_LOG_DEBUG = 0,
+    RETRO_LOG_INFO  = 1,
+    RETRO_LOG_WARN  = 2,
+    RETRO_LOG_ERROR = 3,
+    RETRO_LOG_DUMMY = 0x7fffffff
+};
+
+typedef void (*retro_log_printf_t)(enum retro_log_level level, const char *fmt, ...);
+struct retro_log_callback { retro_log_printf_t log; };
+
+enum retro_hw_context_type {
+    RETRO_HW_CONTEXT_NONE         = 0,
+    RETRO_HW_CONTEXT_OPENGL       = 1,
+    RETRO_HW_CONTEXT_OPENGLES2    = 2,
+    RETRO_HW_CONTEXT_OPENGL_CORE  = 3,
+    RETRO_HW_CONTEXT_OPENGLES3    = 4,
+    RETRO_HW_CONTEXT_OPENGLES_ANY = 5,
+    RETRO_HW_CONTEXT_VULKAN       = 6,
+    RETRO_HW_CONTEXT_DUMMY        = 2147483647
+};
+
+typedef void      (*retro_hw_context_reset_t)(void);
+typedef uintptr_t (*retro_hw_get_current_framebuffer_t)(void);
+typedef retro_proc_address_t (*retro_hw_get_proc_address_t)(const char *sym);
+
+struct retro_hw_render_callback {
+    enum retro_hw_context_type         context_type;
+    retro_hw_context_reset_t           context_reset;
+    retro_hw_get_current_framebuffer_t get_current_framebuffer;
+    retro_hw_get_proc_address_t        get_proc_address;
+
+    // Must remain `bool` (1 byte) to match upstream layout — see header
+    // comment above for the cautionary tale of declaring these as uint32_t.
+    bool                               depth;
+    bool                               stencil;
+    bool                               bottom_left_origin;
+    unsigned                           version_major;
+    unsigned                           version_minor;
+    bool                               cache_context;
+    retro_hw_context_reset_t           context_destroy;
+    bool                               debug_context;
+};
+
+struct retro_system_info {
+    const char *library_name;
+    const char *library_version;
+    const char *valid_extensions;
+    bool        need_fullpath;
+    bool        block_extract;
+};
+
+struct retro_game_geometry {
+    unsigned base_width;
+    unsigned base_height;
+    unsigned max_width;
+    unsigned max_height;
+    float    aspect_ratio;
+};
+
+struct retro_system_timing {
+    double fps;
+    double sample_rate;
+};
+
+struct retro_system_av_info {
+    struct retro_game_geometry geometry;
+    struct retro_system_timing timing;
+};
+
+struct retro_game_info {
+    const char *path;
+    const void *data;
+    size_t      size;
+    const char *meta;
+};
+
 #ifdef __cplusplus
 }
 #endif
+
+// ── ABI Verification ────────────────────────────────────────────────
+// These assertions pin the struct layout to the upstream Libretro ABI
+// under any LP64 target (Apple Silicon, macOS x86_64, Linux x86_64, ...).
+// A failure here means a field type or order changed and the bridge will
+// read cores at the wrong offsets — see the header comment at the top of
+// this file for the cautionary tale.
+#include <stddef.h>
+
+#ifdef __cplusplus
+#define RETRO_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define RETRO_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+#define RETRO_STATIC_ASSERT(cond, msg)
+#endif
+
+RETRO_STATIC_ASSERT(sizeof(struct retro_hw_render_callback) == 64,
+    "retro_hw_render_callback size mismatch — check field types against upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_system_info)        == 32,
+    "retro_system_info layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_game_geometry)      == 20,
+    "retro_game_geometry layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_system_timing)      == 16,
+    "retro_system_timing layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_system_av_info)     == 40,
+    "retro_system_av_info layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_game_info)          == 32,
+    "retro_game_info layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_variable)           == 16,
+    "retro_variable layout drift from upstream libretro ABI");
+RETRO_STATIC_ASSERT(sizeof(struct retro_log_callback)       == 8,
+    "retro_log_callback layout drift from upstream libretro ABI");
+
+// Offset assertion on the exact field that motivated this hardening.
+// If a future change reverts the bool flags to uint32_t (or reorders any
+// of depth/stencil/bottom_left_origin), version_major moves and the
+// bridge silently reads zero — the original "shift crash" failure mode.
+RETRO_STATIC_ASSERT(offsetof(struct retro_hw_render_callback, version_major) == 36,
+    "version_major must remain at offset 36 — see the bool/uint32_t shift-bug note in this header");
+
+#endif /* OE_LIBRETRO_H */

--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -125,15 +125,11 @@ class GameDocumentController: NSDocumentController {
     }
     
     fileprivate func setUpGameDocument(_ document: OEGameDocument, display displayDocument: Bool, fullScreen: Bool, completionHandler: ((OEGameDocument?, NSError?) -> Void)?) {
-        #if DEBUG
-        NSLog("[DEBUG] GameDocumentController: setUpGameDocument for url: \(document.fileURL?.path ?? "nil")")
-        #endif
+
         addDocument(document)
 
         document.setUpGame { success, error in
-            #if DEBUG
-            NSLog("[DEBUG] GameDocumentController: setUpGame result success: \(success), error: \(error?.localizedDescription ?? "nil")")
-            #endif
+
 
             
             if success {
@@ -151,13 +147,9 @@ class GameDocumentController: NSDocumentController {
     }
     
     override func openDocument(withContentsOf url: URL, display displayDocument: Bool, completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
-        #if DEBUG
-        NSLog("[DEBUG] GameDocumentController: openDocument with url: \(url.path)")
-        #endif
+
         super.openDocument(withContentsOf: url, display: false) { document, documentWasAlreadyOpen, error in
-            #if DEBUG
-            NSLog("[DEBUG] GameDocumentController: super.openDocument finished with error: \(error?.localizedDescription ?? "nil")")
-            #endif
+
             if let document = document as? OEGameDocument {
 
                 let fullScreen = UserDefaults.standard.bool(forKey: OEFullScreenGameWindowKey)

--- a/OpenEmu/OELibretroMetadata.swift
+++ b/OpenEmu/OELibretroMetadata.swift
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// ...
+//
+
+import Foundation
+
+/// Metadata for a required system file (BIOS).
+@objc protocol OELibretroBIOSRequirement {
+    var name: String { get }
+    var fileDescription: String { get }
+    var expectedMD5: String { get }
+    var expectedSize: Int { get }
+}
+
+final class BIOSRequirement: NSObject, OELibretroBIOSRequirement {
+    let name: String
+    let fileDescription: String
+    let expectedMD5: String
+    let expectedSize: Int
+
+    init(name: String, description: String, md5: String, size: Int) {
+        self.name = name
+        self.fileDescription = description
+        self.expectedMD5 = md5
+        self.expectedSize = size
+    }
+}
+
+/// Unified registry for Libretro core runtime metadata (BIOS, System IDs).
+/// This replaces the dynamic buildbot registry for runtime checks.
+@objc(OELibretroMetadata)
+final class OELibretroMetadata: NSObject {
+
+    @objc static let shared = OELibretroMetadata()
+    
+    /// The current version of the Libretro bridge.
+    /// Cores can specify OERequiredBridgeVersion in their Info.plist to ensure compatibility.
+    @objc let currentBridgeVersion: Double = 1.0
+    
+    @objc let versionDescription: String = "1.0-silicon-hardened"
+
+    /// Returns the BIOS requirements for a given system identifier.
+    /// - Parameter systemID: The OpenEmu system identifier (e.g. "openemu.system.psx").
+    /// - Returns: An array of BIOS requirements, or nil if none are defined.
+    @objc func biosRequirements(forSystem systemID: String) -> [OELibretroBIOSRequirement]? {
+        let id = systemID.lowercased()
+
+        if id.contains("psx") {
+            return [
+                BIOSRequirement(name: "scph5500.bin", description: "PlayStation BIOS (JP)", md5: "8dd7d5296a650fac7319bce665a6a53c", size: 524288),
+                BIOSRequirement(name: "scph5501.bin", description: "PlayStation BIOS (US)", md5: "490f666e1a21530d03ad55ad333aa372", size: 524288),
+                BIOSRequirement(name: "scph5502.bin", description: "PlayStation BIOS (EU)", md5: "32736f17079d0b2b7024407c39bd3050", size: 524288)
+            ]
+        }
+
+        if id.contains("dc") {
+            return [
+                BIOSRequirement(name: "dc_boot.bin", description: "Dreamcast BIOS", md5: "", size: 0),
+                BIOSRequirement(name: "dc_flash.bin", description: "Dreamcast Flash", md5: "", size: 0)
+            ]
+        }
+
+        if id.contains("saturn") {
+            return [
+                BIOSRequirement(name: "sat_bios_jp.bin", description: "Saturn BIOS (JP)", md5: "2aba4251329305f8b29bc62d3a3d537f", size: 524288),
+                BIOSRequirement(name: "sat_bios_us.bin", description: "Saturn BIOS (US)", md5: "af58e0fdc11efec58df169ca13c36c64", size: 524288),
+                BIOSRequirement(name: "sat_bios_eu.bin", description: "Saturn BIOS (EU)", md5: "9469502759e07503fa658d57053e19fb", size: 524288)
+            ]
+        }
+
+        if id.contains("nds") {
+            return [
+                BIOSRequirement(name: "bios7.bin", description: "DS BIOS 7", md5: "", size: 0),
+                BIOSRequirement(name: "bios9.bin", description: "DS BIOS 9", md5: "", size: 0),
+                BIOSRequirement(name: "firmware.bin", description: "DS Firmware", md5: "", size: 0)
+            ]
+        }
+        
+        if id.contains("msx") {
+            return [
+                BIOSRequirement(name: "MSX.ROM", description: "MSX BIOS", md5: "70d06191c95e1e1948842183f38128ec", size: 32768),
+                BIOSRequirement(name: "MSX2.ROM", description: "MSX2 BIOS", md5: "1356f627727a3c330f606a5992fe464d", size: 32768)
+            ]
+        }
+
+        return nil
+    }
+}

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 		8F93FDDA27374F2000B59F3E /* GameInfoHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDD927374F2000B59F3E /* GameInfoHelperTests.swift */; };
 		8F93FDE02737506900B59F3E /* ROMImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F93FDDF2737506900B59F3E /* ROMImporterTests.swift */; };
 		8F9410C0273A0167004C47CC /* CoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */; };
+		14FEB8870D5948A1BCD26EEF /* OELibretroMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C735BCE1E9487EA5A79659 /* OELibretroMetadata.swift */; };
 		8F94B44D25566FE00058AA94 /* NSShadow+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94B44C25566FE00058AA94 /* NSShadow+OEAdditions.swift */; };
 		8F94DEC1250EC701003A1F33 /* ThumbnailProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94DEC0250EC701003A1F33 /* ThumbnailProvider.swift */; };
 		8F94DED4250ED838003A1F33 /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F94DED3250ED838003A1F33 /* PreviewViewController.swift */; };
@@ -1554,6 +1555,9 @@
 		83753F1614F537C400D708A7 /* PrefDebugController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefDebugController.swift; sourceTree = "<group>"; };
 		83753F1914F5383F00D708A7 /* PrefDebugController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrefDebugController.xib; sourceTree = "<group>"; };
 		8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreUpdater.swift; sourceTree = "<group>"; };
+		8F22765129D30551001FB9F9 /* curate-core.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = "curate-core.sh"; path = "Scripts/curate-core.sh"; sourceTree = "<group>"; };
+		8F22765129D30551001FB9FA /* Core-Curation.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "Core-Curation.md"; path = "Documentation/Core-Curation.md"; sourceTree = "<group>"; };
+		62C735BCE1E9487EA5A79659 /* OELibretroMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OELibretroMetadata.swift; sourceTree = "<group>"; };
 		837820B71907FADB0043593F /* IKRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKRenderer.h; sourceTree = "<group>"; };
 		837820B81907FB2D0043593F /* IKImageWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKImageWrapper.h; sourceTree = "<group>"; };
 		837820BA1907FB6E0043593F /* IKImageBrowserView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IKImageBrowserView.h; sourceTree = "<group>"; };
@@ -3230,6 +3234,8 @@
 			children = (
 				83CACEC7196D6D1300999E70 /* Download.swift */,
 				8375E14E1477FC0D0018DA1F /* CoreUpdater.swift */,
+				62C735BCE1E9487EA5A79659 /* OELibretroMetadata.swift */,
+				8F22765129D30551001FB9FA /* Core-Curation.md */,
 				6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */,
 				839310BB147802380020058E /* CoreDownload.swift */,
 			);
@@ -6571,6 +6577,7 @@
 				94A4E98D179F9A4D00AD8C7D /* OEDBSaveStatesMedia.swift in Sources */,
 				56ECCDC1488945C2A09403D7 /* OECoreMigration.swift in Sources */,
 				8F9410C0273A0167004C47CC /* CoreUpdater.swift in Sources */,
+				14FEB8870D5948A1BCD26EEF /* OELibretroMetadata.swift in Sources */,
 				94A4E992179F9D0400AD8C7D /* OEDBScreenshotsMedia.swift in Sources */,
 				94A4E996179FAB9F00AD8C7D /* OEMediaViewController.m in Sources */,
 				8F4AEAC1273594E6005C6246 /* OpenVGDB.swift in Sources */,

--- a/OpenEmu/SystemPlugins/Dreamcast/OEDCSystemResponder.m
+++ b/OpenEmu/SystemPlugins/Dreamcast/OEDCSystemResponder.m
@@ -29,8 +29,8 @@
 #import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 #define RETRO_DEVICE_INDEX_ANALOG_BUTTON 2
-#define RETRO_DEVICE_ID_JOYPAD_L2 10
-#define RETRO_DEVICE_ID_JOYPAD_R2 11
+#define RETRO_DEVICE_ID_JOYPAD_L2 12
+#define RETRO_DEVICE_ID_JOYPAD_R2 13
 
 @implementation OEDCSystemResponder
 static const uint8_t kDCLibretroMap[] = { 4, 5, 6, 7, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 8, 9, 3, 2, 0, 1 };

--- a/OpenEmu/SystemPlugins/Dreamcast/OEDCSystemResponder.m
+++ b/OpenEmu/SystemPlugins/Dreamcast/OEDCSystemResponder.m
@@ -26,8 +26,14 @@
 
 #import "OEDCSystemResponder.h"
 #import "OEDCSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
+
+#define RETRO_DEVICE_INDEX_ANALOG_BUTTON 2
+#define RETRO_DEVICE_ID_JOYPAD_L2 10
+#define RETRO_DEVICE_ID_JOYPAD_R2 11
 
 @implementation OEDCSystemResponder
+static const uint8_t kDCLibretroMap[] = { 4, 5, 6, 7, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 8, 9, 3, 2, 0, 1 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,17 +43,45 @@
 
 - (void)changeAnalogEmulatorKey:(OESystemKey *)aKey value:(CGFloat)value
 {
-    [self.client didMoveDCJoystickDirection:(OEDCButton)aKey.key withValue:value forPlayer:aKey.player];
+    NSUInteger k = aKey.key;
+    id client = (id)self.client;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        int16_t val = (int16_t)round(value * 32767.0);
+        switch (k) {
+            case OEDCAnalogUp:    [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:-val forPort:aKey.player - 1]; break;
+            case OEDCAnalogDown:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:val  forPort:aKey.player - 1]; break;
+            case OEDCAnalogLeft:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:-val forPort:aKey.player - 1]; break;
+            case OEDCAnalogRight: [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:val  forPort:aKey.player - 1]; break;
+            case OEDCAnalogL:     [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_BUTTON axis:RETRO_DEVICE_ID_JOYPAD_L2 value:val forPort:aKey.player - 1]; break;
+            case OEDCAnalogR:     [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:RETRO_DEVICE_INDEX_ANALOG_BUTTON axis:RETRO_DEVICE_ID_JOYPAD_R2 value:val forPort:aKey.player - 1]; break;
+        }
+        return;
+    }
+    [client didMoveDCJoystickDirection:(OEDCButton)k withValue:value forPlayer:aKey.player];
 }
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushDCButton:(OEDCButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kDCLibretroMap)) ? kDCLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushDCButton:(OEDCButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseDCButton:(OEDCButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kDCLibretroMap)) ? kDCLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseDCButton:(OEDCButton)k forPlayer:aKey.player];
 }
 
 @end

--- a/OpenEmu/SystemPlugins/GameBoy Advance/OEGBASystemResponder.m
+++ b/OpenEmu/SystemPlugins/GameBoy Advance/OEGBASystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OEGBASystemResponder.h"
 #import "OEGBASystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OEGBASystemResponder
+static const uint8_t kGBALibretroMap[] = { 4, 5, 6, 7, 8, 0, 10, 11, 3, 2 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,12 +39,26 @@
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushGBAButton:(OEGBAButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kGBALibretroMap)) ? kGBALibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushGBAButton:(OEGBAButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseGBAButton:(OEGBAButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kGBALibretroMap)) ? kGBALibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseGBAButton:(OEGBAButton)k forPlayer:aKey.player];
 }
 
 @end

--- a/OpenEmu/SystemPlugins/Genesis/OEGenesisSystemResponder.m
+++ b/OpenEmu/SystemPlugins/Genesis/OEGenesisSystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OEGenesisSystemResponder.h"
 #import "OEGenesisSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OEGenesisSystemResponder
+static const uint8_t kGenesisLibretroMap[] = { 4, 5, 6, 7, 1, 0, 8, 10, 9, 11, 3, 2 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,12 +39,26 @@
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushGenesisButton:(OEGenesisButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kGenesisLibretroMap)) ? kGenesisLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushGenesisButton:(OEGenesisButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseGenesisButton:(OEGenesisButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kGenesisLibretroMap)) ? kGenesisLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseGenesisButton:(OEGenesisButton)k forPlayer:aKey.player];
 }
 
 - (void)mouseMovedAtPoint:(OEIntPoint)aPoint

--- a/OpenEmu/SystemPlugins/N64/OEN64SystemResponder.m
+++ b/OpenEmu/SystemPlugins/N64/OEN64SystemResponder.m
@@ -26,8 +26,16 @@
 
 #import "OEN64SystemResponder.h"
 #import "OEN64SystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OEN64SystemResponder
+// OEN64Button enum → RETRO_DEVICE_ID_JOYPAD mapping:
+//   0 DPadUp→UP(4), 1 DPadDown→DOWN(5), 2 DPadLeft→LEFT(6), 3 DPadRight→RIGHT(7),
+//   4 CUp→X(9),     5 CDown→A(8),       6 CLeft→Y(1),       7 CRight→B(0) [C-pad as face],
+//   8 A→A(8),        9 B→B(0),           10 L→L(10),         11 R→R(11),
+//   12 Z→L2(12),     13 Start→START(3)
+// NOTE: must stay in sync with translator-side tables if any exist.
+static const uint8_t kN64LibretroMap[] = { 4, 5, 6, 7, 9, 8, 1, 0, 8, 0, 10, 11, 12, 3 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,17 +45,43 @@
 
 - (void)changeAnalogEmulatorKey:(OESystemKey *)aKey value:(CGFloat)value
 {
-    [self.client didMoveN64JoystickDirection:(OEN64Button)aKey.key withValue:value forPlayer:aKey.player];
+    NSUInteger k = aKey.key;
+    id client = (id)self.client;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        int16_t val = (int16_t)round(value * 32767.0);
+        switch (k) {
+            case OEN64AnalogUp:    [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:-val forPort:aKey.player - 1]; break;
+            case OEN64AnalogDown:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:val  forPort:aKey.player - 1]; break;
+            case OEN64AnalogLeft:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:-val forPort:aKey.player - 1]; break;
+            case OEN64AnalogRight: [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:val  forPort:aKey.player - 1]; break;
+        }
+        return;
+    }
+    [client didMoveN64JoystickDirection:(OEN64Button)k withValue:value forPlayer:aKey.player];
 }
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushN64Button:(OEN64Button)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kN64LibretroMap)) ? kN64LibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushN64Button:(OEN64Button)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseN64Button:(OEN64Button)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kN64LibretroMap)) ? kN64LibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseN64Button:(OEN64Button)k forPlayer:aKey.player];
 }
 
 @end

--- a/OpenEmu/SystemPlugins/NDS/OENDSSystemResponder.m
+++ b/OpenEmu/SystemPlugins/NDS/OENDSSystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OENDSSystemResponder.h"
 #import "OENDSSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OENDSSystemResponder
+static const uint8_t kNDSLibretroMap[] = { 4, 5, 6, 7, 8, 0, 9, 1, 10, 11, 3, 2, 0xFF, 0xFF, 0xFF };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,12 +39,26 @@
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushNDSButton:(OENDSButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kNDSLibretroMap)) ? kNDSLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushNDSButton:(OENDSButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseNDSButton:(OENDSButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kNDSLibretroMap)) ? kNDSLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseNDSButton:(OENDSButton)k forPlayer:aKey.player];
 }
 
 - (void)mouseDownAtPoint:(OEIntPoint)aPoint

--- a/OpenEmu/SystemPlugins/PlayStation/OEPSXSystemResponder.m
+++ b/OpenEmu/SystemPlugins/PlayStation/OEPSXSystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OEPSXSystemResponder.h"
 #import "OEPSXSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OEPSXSystemResponder
+static const uint8_t kPSXLibretroMap[] = { 4, 5, 6, 7, 10, 8, 11, 9, 3, 2, 0, 1, 12, 13, 14, 15 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,17 +39,47 @@
 
 - (void)changeAnalogEmulatorKey:(OESystemKey *)aKey value:(CGFloat)value
 {
-    [self.client didMovePSXJoystickDirection:(OEPSXButton)aKey.key withValue:value forPlayer:aKey.player];
+    NSUInteger k = aKey.key;
+    id client = (id)self.client;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        int16_t val = (int16_t)round(value * 32767.0);
+        switch (k) {
+            case OEPSXLeftAnalogUp:    [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:-val forPort:aKey.player - 1]; break;
+            case OEPSXLeftAnalogDown:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:1 value:val  forPort:aKey.player - 1]; break;
+            case OEPSXLeftAnalogLeft:  [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:-val forPort:aKey.player - 1]; break;
+            case OEPSXLeftAnalogRight: [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:0 axis:0 value:val  forPort:aKey.player - 1]; break;
+            case OEPSXRightAnalogUp:   [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:1 axis:1 value:-val forPort:aKey.player - 1]; break;
+            case OEPSXRightAnalogDown: [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:1 axis:1 value:val  forPort:aKey.player - 1]; break;
+            case OEPSXRightAnalogLeft: [(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:1 axis:0 value:-val forPort:aKey.player - 1]; break;
+            case OEPSXRightAnalogRight:[(id<OEBridgeInputTranslation>)client receiveLibretroAnalogIndex:1 axis:0 value:val  forPort:aKey.player - 1]; break;
+        }
+        return;
+    }
+    [client didMovePSXJoystickDirection:(OEPSXButton)k withValue:value forPlayer:aKey.player];
 }
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushPSXButton:(OEPSXButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kPSXLibretroMap)) ? kPSXLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushPSXButton:(OEPSXButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleasePSXButton:(OEPSXButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kPSXLibretroMap)) ? kPSXLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleasePSXButton:(OEPSXButton)k forPlayer:aKey.player];
 }
 
 - (void)mouseMovedAtPoint:(OEIntPoint)aPoint

--- a/OpenEmu/SystemPlugins/Saturn/OESaturnSystemResponder.m
+++ b/OpenEmu/SystemPlugins/Saturn/OESaturnSystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OESaturnSystemResponder.h"
 #import "OESaturnSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OESaturnSystemResponder
+static const uint8_t kSaturnLibretroMap[] = { 4, 5, 6, 7, 1, 0, 8, 10, 9, 11, 12, 13, 3, 0xFF };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -42,12 +44,26 @@
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushSaturnButton:(OESaturnButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kSaturnLibretroMap)) ? kSaturnLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushSaturnButton:(OESaturnButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseSaturnButton:(OESaturnButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kSaturnLibretroMap)) ? kSaturnLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseSaturnButton:(OESaturnButton)k forPlayer:aKey.player];
 }
 
 - (void)mouseMovedAtPoint:(OEIntPoint)aPoint

--- a/OpenEmu/SystemPlugins/SuperNES/OESNESSystemResponder.m
+++ b/OpenEmu/SystemPlugins/SuperNES/OESNESSystemResponder.m
@@ -26,8 +26,10 @@
 
 #import "OESNESSystemResponder.h"
 #import "OESNESSystemResponderClient.h"
+#import <OpenEmuBase/OELibretroCoreTranslator.h>
 
 @implementation OESNESSystemResponder
+static const uint8_t kSNESLibretroMap[] = { 4, 5, 6, 7, 8, 0, 9, 1, 10, 11, 3, 2 };
 @dynamic client;
 
 + (Protocol *)gameSystemResponderClientProtocol;
@@ -37,12 +39,26 @@
 
 - (void)pressEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didPushSNESButton:(OESNESButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kSNESLibretroMap)) ? kSNESLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:YES];
+        return;
+    }
+    [client didPushSNESButton:(OESNESButton)k forPlayer:aKey.player];
 }
 
 - (void)releaseEmulatorKey:(OESystemKey *)aKey
 {
-    [self.client didReleaseSNESButton:(OESNESButton)aKey.key forPlayer:aKey.player];
+    id client = (id)self.client;
+    NSUInteger k = aKey.key;
+    if ([client conformsToProtocol:@protocol(OEBridgeInputTranslation)]) {
+        uint8_t btn = (k < sizeof(kSNESLibretroMap)) ? kSNESLibretroMap[k] : 0xFF;
+        [(id<OEBridgeInputTranslation>)client receiveLibretroButton:btn forPort:aKey.player - 1 pressed:NO];
+        return;
+    }
+    [client didReleaseSNESButton:(OESNESButton)k forPlayer:aKey.player];
 }
 
 - (void)mouseMovedAtPoint:(OEIntPoint)aPoint


### PR DESCRIPTION
What does this PR do?

This PR provides PR Split 3: The Actual Universal Bridge and Stability Foundation. It is a fundamental hardening of the Libretro bridge foundation for macOS on Apple Silicon and split from my previous PR. Following suggested practices.

It solves the critical shift-bug (memory misalignment in retro_hw_render_callback) that led to black screens in hardware-rendered cores. It also introduces hand-optimized NEON SIMD kernels for pixel translation,  improving pixel conversion performance for softwarerendered cores. I will retire PR Split 2 - Fix/ critical arm64 ABI alignment for hardware rendering negotiation Issue #50, #67, #41 its all incorporated in this and my game fixes pull.

strdup() lifecycle for C-string paths (dangling pointer fix)
Async save state API (completionHandler: pattern)
Bundle fallback for core discovery
Single-instance guard in release builds
Flycast/Reicast environment variable support
DC analog stick + trigger mapping
GB, GBA, N64, Genesis input lookup tables
Serialization quirks support (cmd 44)

What did you test?
Saturn, SNES, NES, GBA, PSP, PSX, Dreamcast: All boot, render, and play audio through the bridge foundation on Apple Silicon.
N64 & Genesis: Input mapping has been wired to the bridge and is ready for controller verification.
PPSSPP (PSP): Verified forced software rendering and XRGB8888 stability guards.
 Genesis Plus GX: Verified NEON-accelerated video copy paths on M series Macs.
Systems tested: macOS 15.x on Apple Silicon (M4).

Which cores or systems are affected?
All Libretro based emulation cores. This is a framework change to OpenEmuBase that stabilizes the foundation for all cores to be inversely translated from one bridge they can be nested into.

Did you use AI tools?
Yes. Antigravity was used to perform hardening, and architectural review. Claude for final cleanup.

Linked issues

# 1. Check out this PR
# (Replace <PR_NUMBER> with this PR's actual ID once opened)
gh pr checkout <PR_NUMBER> --repo nickybmon/OpenEmu-Silicon

# 2. Build OpenEmu
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug/OpenEmu.app

Branched from an up-to-date main
 Build passes
 Tested on Apple Silicon (M4 Mac)
 No build logs, binaries, or credentials committed
 Copyright headers preserved on all modified files
 New files include the BSD 2-Clause license header
