### PR TITLE
fix: update Homebrew cask to v1.0.5 and auto-update cask in release script

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -233,7 +233,8 @@ The script does everything in one shot:
 4. Runs `sign_update` on that exact DMG to get the EdDSA signature
 5. Prepends a new entry to `appcast.xml` with the correct signature and length
 6. Creates a **draft** GitHub Release and uploads the DMG
-7. Commits and pushes the updated `appcast.xml`
+7. Updates `Casks/openemu-silicon.rb` with the new version and DMG SHA256
+8. Commits and pushes the updated `appcast.xml` and Homebrew cask together
 
 ### After the script finishes
 

--- a/.claude/commands/prep-release.md
+++ b/.claude/commands/prep-release.md
@@ -136,10 +136,11 @@ The script will:
 1. Archive the app (Release config, Developer ID signed, hardened runtime)
 2. Re-sign all binaries, notarize with Apple, staple the ticket
 3. Create a DMG from the stapled `.app`
-4. Run `sign_update` to get the EdDSA signature
-5. Prepend a new entry to `appcast.xml` with the correct signature and length
-6. Create a **draft** GitHub Release and upload the DMG
-7. Commit and push the updated `appcast.xml`
+4. Update `Casks/openemu-silicon.rb` with the new version and DMG SHA256
+5. Run `sign_update` to get the EdDSA signature
+6. Prepend a new entry to `appcast.xml` with the correct signature and length
+7. Create a **draft** GitHub Release and upload the DMG
+8. Commit and push the updated `appcast.xml` and Homebrew cask together
 
 ## Step 9 — Report and hand off
 

--- a/Casks/openemu-silicon.rb
+++ b/Casks/openemu-silicon.rb
@@ -1,6 +1,6 @@
 cask "openemu-silicon" do
-  version "1.0.4"
-  sha256 "3bfee455fe5839467e055c152537009857245e80732d1347a1ab233cd92d8e86"
+  version "1.0.5"
+  sha256 "e41345cdcbaf90985fc17c858d699be0e5b759fb6b5e35f98b393fea22871f01"
 
   url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
   name "OpenEmu Silicon"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -159,6 +159,18 @@ step "2/5  Re-signing, notarizing, and creating DMG"
 
 [ -f "$DMG" ] || die "DMG not found at $DMG after notarize.sh. Check notarize.sh output above."
 
+# ── 2.5. Update Homebrew cask ─────────────────────────────────────────────────
+step "2.5/5  Updating Homebrew cask (Casks/openemu-silicon.rb)"
+
+CASK_FILE="$REPO_ROOT/Casks/openemu-silicon.rb"
+DMG_SHA256=$(shasum -a 256 "$DMG" | awk '{print $1}')
+echo "DMG SHA256: $DMG_SHA256"
+
+# Update version and sha256 in the cask file
+sed -i '' "s/version \"[^\"]*\"/version \"$VERSION\"/" "$CASK_FILE"
+sed -i '' "s/sha256 \"[^\"]*\"/sha256 \"$DMG_SHA256\"/" "$CASK_FILE"
+echo "Updated $CASK_FILE → version $VERSION, sha256 $DMG_SHA256"
+
 # ── 3. Sign for Sparkle ───────────────────────────────────────────────────────
 step "3/5  Generating Sparkle EdDSA signature"
 
@@ -298,9 +310,9 @@ fi
 
 echo "DMG uploaded to draft release $TAG."
 
-# Commit and push appcast
-git -C "$REPO_ROOT" add "$APPCAST"
-git -C "$REPO_ROOT" commit -m "chore: add v$VERSION appcast entry"
+# Commit and push appcast + cask
+git -C "$REPO_ROOT" add "$APPCAST" "$CASK_FILE"
+git -C "$REPO_ROOT" commit -m "chore: release v$VERSION — update appcast and Homebrew cask"
 git -C "$REPO_ROOT" push origin main
 
 echo ""


### PR DESCRIPTION
## Summary

- Bumps `Casks/openemu-silicon.rb` from v1.0.4 → v1.0.5 with the correct SHA256 for the v1.0.5 DMG, fixing `brew install --cask openemu-silicon` today
- Adds step 2.5 to `Scripts/release.sh` that computes the DMG SHA256 via `shasum` and patches `version` + `sha256` in the cask file automatically after every build — cask can no longer be forgotten
- Includes the cask in the same final commit as `appcast.xml` so both are always in sync
- Updates `CLAUDE.md` and `.claude/commands/prep-release.md` to document the new cask step

Fixes #163

## Test plan

- [ ] Merge and verify `brew tap nickybmon/openemu-silicon https://github.com/nickybmon/OpenEmu-Silicon && brew install --cask openemu-silicon` installs v1.0.5 cleanly
- [ ] On next release, confirm `Scripts/release.sh` automatically updates the cask and includes it in the commit (no manual step needed)

https://claude.ai/code/session_01XawtD9L8XMQaxwJkEhBWkM