### PR TITLE
fix: add All-regions dc_flash.bin variant to Flycast BIOS registry

### DIFF
--- a/Flycast/OpenEmu/Info.plist
+++ b/Flycast/OpenEmu/Info.plist
@@ -54,6 +54,16 @@
 					<key>Size</key>
 					<integer>131072</integer>
 				</dict>
+				<dict>
+					<key>Description</key>
+					<string>Dreamcast Flash ROM (All regions)</string>
+					<key>MD5</key>
+					<string>93a9766f14159b403178ac77417c6b68</string>
+					<key>Name</key>
+					<string>dc_flash.bin</string>
+					<key>Size</key>
+					<integer>131072</integer>
+				</dict>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
## What and why

Fixes #188.

`dc_flash.bin` is a required Dreamcast BIOS file but users with the "All regions" dump were unable to add it through the System Files settings screen or by dragging it into the game window. Instead, OpenEmu presented an error offering to import it as an Atari 2600, Atari 5200, Intellivision, Vectrex, or Videopac+ ROM. Users who manually placed the file in the BIOS folder found it silently deleted on the next Dreamcast game launch.

## Root cause

OpenEmu's BIOS importer works by matching the MD5 hash of the dropped file against the `OERequiredFiles` list in each core's `Info.plist`. The Flycast plist only registered one `dc_flash.bin` hash (`0a93f7940c455905bea6e392dfde92a4`), which is the standard USA dump. The widely-circulated "All regions" flash dump has a different hash (`93a9766f14159b403178ac77417c6b68`). When the hash didn't match, the file fell through to the ROM importer, which correctly noticed `.bin` is a valid extension for several other systems — hence the multi-system picker.

The deletion on game load was a downstream consequence of the same thing: `isBIOSFileAvailable` hashes the manually placed file, finds the MD5 doesn't match the one registered entry, and deletes it as corrupt.

## What changed

Added a second `OERequiredFiles` entry in `Flycast/OpenEmu/Info.plist` for the All-regions variant of `dc_flash.bin`. Both hashes are from the [Emulation General Wiki file-hashes database](https://emulation.gametechwiki.com/index.php/File_hashes). No Swift or Objective-C changes — the fix is purely in the plist.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

To verify the fix, you need a `dc_flash.bin` with MD5 `93a9766f14159b403178ac77417c6b68` (the All-regions variant). You can confirm your hash with `md5 dc_flash.bin`.

- **Expected (fixed):** Dragging `dc_flash.bin` into the System Files screen imports it silently and the row for "Dreamcast Flash ROM" shows a green checkmark.
- **Previously broken:** OpenEmu asked whether to import the file as an Atari 2600 / Intellivision / etc. ROM, and if you chose "Don't Import", the file was ignored entirely.
- **Also verify:** The standard USA `dc_flash.bin` (MD5 `0a93f7940c455905bea6e392dfde92a4`) still imports correctly — both entries should coexist without conflict.

## QA Spec

- [ ] All-regions `dc_flash.bin` (MD5 `93a9766f14159b403178ac77417c6b68`) is accepted when dragged to the System Files screen
- [ ] All-regions `dc_flash.bin` is accepted when dragged into an open Dreamcast game window
- [ ] Standard USA `dc_flash.bin` (MD5 `0a93f7940c455905bea6e392dfde92a4`) still imports correctly
- [ ] `dc_boot.bin` import behavior is unchanged
- [ ] No multi-system ROM picker appears when dropping either `dc_flash.bin` variant
- [ ] A `dc_flash.bin` placed manually in the BIOS folder is no longer deleted when loading a Dreamcast game

Made with [Cursor](https://cursor.com)