### PR TITLE
chore: bump Flycast to 2.4 and publish cores-v1.1.1 hotfix appcast

### DIFF
--- a/.claude/commands/release-core.md
+++ b/.claude/commands/release-core.md
@@ -1,0 +1,217 @@
+Release a core plugin update or hotfix. Usage: `/release-core <CoreName> <NewVersion>`
+
+Example: `/release-core Flycast 2.5`
+
+Use this command when:
+- A bug fix has been merged to main that affects a specific core (plist data, game core code, BIOS registry)
+- You want to ship that fix to users without a full app release
+
+This command covers **in-repo built cores** (Flycast, Dolphin, 4DO, etc.) — cores whose source code lives in this repository and are built from Xcode. For buildbot-sourced core updates, see `docs/core-update-process.md` instead.
+
+---
+
+## !! HARD RULE — NO EXCEPTIONS !!
+
+**NEVER publish a GitHub Release.**
+Never run `gh release edit ... --draft=false`, never change a prerelease to a full release,
+never push tags that trigger release workflows. Publishing is always the user's action.
+
+---
+
+## Step 1 — Confirm prerequisites
+
+```bash
+git checkout main
+git fetch origin && git merge origin/main
+```
+
+Confirm:
+- The fix being released is already merged to `main`
+- The working tree is clean
+- `gh auth status` passes
+- Developer ID cert is in keychain: `security find-identity -v | grep "Developer ID Application"`
+
+If any of these fail, stop and report what needs to be fixed.
+
+## Step 2 — Create a release branch
+
+```bash
+git checkout -b chore/<corename-lowercase>-<version>-release
+# e.g. chore/flycast-2.5-release
+```
+
+## Step 3 — Bump the core version
+
+Edit `<CoreName>/OpenEmu/Info.plist` (or the equivalent path for that core):
+- Increment `CFBundleVersion` to the new version string
+
+Verify with:
+```bash
+plutil -lint <CoreName>/OpenEmu/Info.plist
+```
+
+## Step 4 — Build the main workspace in Release (produces frameworks the core needs)
+
+```bash
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme OpenEmu \
+  -configuration Release \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -5
+```
+
+If this fails, stop and report the errors. Do not continue.
+
+## Step 5 — Build the core in Release
+
+Find the Release framework path:
+```bash
+DERIVED_RELEASE=$(find ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-* \
+  -maxdepth 3 -name "Release" -path "*/Build/Products/Release" 2>/dev/null | head -1)
+echo "$DERIVED_RELEASE"
+```
+
+Build the core:
+```bash
+xcodebuild \
+  -project <CoreName>/<CoreName>.xcodeproj \
+  -scheme <CoreName> \
+  -configuration Release \
+  -destination 'platform=macOS,arch=arm64' \
+  ONLY_ACTIVE_ARCH=YES \
+  FRAMEWORK_SEARCH_PATHS="$DERIVED_RELEASE" \
+  build 2>&1 | tail -10
+```
+
+If the build fails, stop and report the errors.
+
+## Step 6 — Locate the built plugin
+
+```bash
+PLUGIN=$(find ~/Library/Developer/Xcode/DerivedData/<CoreName>-* \
+  -name "<CoreName>.oecoreplugin" \
+  -path "*/Release/*" \
+  -not -path "*.dSYM*" \
+  2>/dev/null | head -1)
+echo "Plugin: $PLUGIN"
+```
+
+Verify the built version matches the target:
+```bash
+/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "$PLUGIN/Contents/Info.plist"
+```
+
+## Step 7 — Sign and zip the plugin
+
+```bash
+codesign --force --sign "Developer ID Application" \
+  --options runtime --timestamp \
+  "$PLUGIN" && echo "Signed OK"
+
+ZIP="/tmp/<CoreName>.oecoreplugin.zip"
+ditto -c -k --keepParent "$PLUGIN" "$ZIP"
+wc -c < "$ZIP" | tr -d ' '   # note the byte count — needed for the appcast
+```
+
+## Step 8 — Determine the release tag
+
+Check existing cores releases:
+```bash
+gh release list --repo nickybmon/OpenEmu-Silicon | grep "^Emulation Cores"
+```
+
+- If this is the only core being updated, create a new `cores-vX.Y.Z` tag (increment the patch).
+- If multiple cores are being updated together, they can share one release.
+
+Convention: `cores-v1.0.0` → `cores-v1.0.1` for a single-core hotfix. `cores-v1.1.0` → `cores-v1.2.0` for a batch update with notable changes.
+
+## Step 9 — Create the GitHub Release (prerelease)
+
+Core releases are always created as `--prerelease`. This keeps them off the main releases page but leaves them reachable by appcast URLs.
+
+```bash
+NEXT_TAG="cores-vX.Y.Z"   # determined above
+
+gh release create "$NEXT_TAG" "$ZIP" \
+  --repo nickybmon/OpenEmu-Silicon \
+  --title "Emulation Cores vX.Y.Z" \
+  --prerelease \
+  --notes "<CoreName> <NewVersion> — <one-line description of what changed>.
+
+Distributed via the in-app core updater — not a user-facing download. If you are looking to install OpenEmu-Silicon, see the [latest release](https://github.com/nickybmon/OpenEmu-Silicon/releases/latest)."
+```
+
+Note the asset URL — it will be:
+```
+https://github.com/nickybmon/OpenEmu-Silicon/releases/download/<NEXT_TAG>/<CoreName>.oecoreplugin.zip
+```
+
+## Step 10 — Update the appcast
+
+Edit `Appcasts/<corename-lowercase>.xml`:
+- Add a new `<item>` at the top of the `<channel>` for the new version
+- Keep the previous item as a fallback (do not remove it)
+
+The new item format:
+```xml
+<item>
+  <title><CoreName> <NewVersion></title>
+  <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/<NEXT_TAG>/<CoreName>.oecoreplugin.zip"
+    sparkle:version="<NewVersion>"
+    sparkle:shortVersionString="<NewVersion>"
+    length="<BYTE_COUNT_FROM_STEP_7>"
+    type="application/octet-stream" />
+</item>
+```
+
+Verify the XML is valid:
+```bash
+xmllint --noout Appcasts/<corename>.xml && echo "Valid XML"
+```
+
+## Step 11 — Commit, push, and open a PR
+
+```bash
+git add <CoreName>/OpenEmu/Info.plist Appcasts/<corename-lowercase>.xml
+git commit -m "chore: bump <CoreName> to <NewVersion>, update appcast for <NEXT_TAG>
+
+<One sentence describing the fix being shipped.>
+
+Related to #<issue-number>
+Assisted by Claude (Sonnet 4.6)"
+
+git push -u origin chore/<corename-lowercase>-<version>-release
+```
+
+Open a PR targeting `main`. The PR description must include:
+- What fix is being shipped and why
+- The new version and release tag
+- How to verify the update is offered in-app (check Preferences → Cores)
+- A QA checklist covering: update offered, update installs, the specific fix works, previous behavior no longer occurs
+
+## Step 12 — Post a user-facing issue comment (if fixing a user-reported bug)
+
+If the fix resolves a GitHub issue reported by someone other than `nickybmon`, post a comment on that issue **after the PR is merged**. Draft the comment and show it to the owner before posting — issue comments appear in the owner's voice.
+
+The comment should:
+- Be written in plain English, no jargon
+- Briefly explain what the bug was and why it happened
+- Confirm it's fixed and how to get the fix (open OpenEmu → the update will be offered automatically)
+- Thank the reporter
+
+Do not post this comment until the PR is merged and the appcast is live on `main`.
+
+## Step 13 — After PR is merged: verify the update pipeline is live
+
+Once the PR merges:
+```bash
+# Confirm the appcast on main has the new version
+curl -s https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<corename-lowercase>.xml | grep "sparkle:version"
+```
+
+The new version should appear at the top. If it does, the update will be offered to users on their next OpenEmu launch.
+
+Report the final state: PR merged, appcast live, release tag, issue comment posted (or not applicable).

--- a/Appcasts/flycast.xml
+++ b/Appcasts/flycast.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>Flycast</title>
     <item>
+      <title>Flycast 2.4</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.1.1/Flycast.oecoreplugin.zip"
+        sparkle:version="2.4"
+        sparkle:shortVersionString="2.4"
+        length="3093872"
+        type="application/octet-stream" />
+    </item>
+    <item>
       <title>Flycast 2.3</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Flycast/OpenEmu/Info.plist
+++ b/Flycast/OpenEmu/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/docs/core-update-process.md
+++ b/docs/core-update-process.md
@@ -1,8 +1,17 @@
 # Core Update Process — OpenEmu-Silicon
 
-_Last updated: 2026-04-14_
+_Last updated: 2026-04-17_
 
 This document explains how core updates work in this project: where binaries come from, how to evaluate whether a given build is safe to ship, and how to publish an update.
+
+There are two kinds of core updates, and they use different processes:
+
+| Type | Cores | Process |
+|------|-------|---------|
+| **In-repo built** | Flycast, Dolphin, 4DO, DeSmuME, and other cores whose source lives in this repo | Use the `/release-core` command (see `.claude/commands/release-core.md`) |
+| **Buildbot-sourced** | mGBA, Nestopia, Genesis Plus GX, Mednafen, SNES9x, and other cores pulled as pre-built binaries | Follow the process in this document |
+
+The rest of this document covers **buildbot-sourced cores only**.
 
 ---
 
@@ -174,3 +183,60 @@ Do **not** update cores on a fixed schedule just to stay "current." Every update
 - **Do not update a core without testing.** Even a minor-looking upstream change can break a specific game or system.
 - **Do not batch multiple core updates into one PR.** If something breaks, you need to be able to isolate which core caused it.
 - **Do not delete or replace a working core without a verified replacement ready.** A broken core is worse than an old one.
+
+---
+
+## Release Infrastructure Reference
+
+This section applies to all core updates regardless of type.
+
+### How the update pipeline works
+
+```
+oecores.xml (in repo, on main)
+  └── lists each core with an appcastURL
+        └── Appcasts/<corename>.xml (in repo, on main)
+              └── enclosure url → GitHub Release asset (.oecoreplugin.zip)
+```
+
+The app fetches `oecores.xml` to discover cores, then fetches each core's appcast to check for updates. The appcast's `sparkle:version` is compared against the installed core's `CFBundleVersion`. If the appcast version is higher, an update is offered.
+
+**Key point:** The appcast goes live the moment the PR merges to `main`. The GitHub Release asset must already exist before the PR merges — you upload the binary first, then update the appcast to point at it.
+
+### Appcast format
+
+Each `Appcasts/<corename>.xml` is a minimal RSS feed. Keep all previous items — do not delete old ones. New items go at the top. Sparkle reads top-to-bottom and uses the first item whose `sparkle:version` is higher than what's installed.
+
+```xml
+<item>
+  <title>CoreName X.Y</title>
+  <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+  <enclosure
+    url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-vX.Y.Z/CoreName.oecoreplugin.zip"
+    sparkle:version="X.Y"
+    sparkle:shortVersionString="X.Y"
+    length="<byte count of zip>"
+    type="application/octet-stream" />
+</item>
+```
+
+The `length` field must be exact — get it with `wc -c < CoreName.oecoreplugin.zip | tr -d ' '`.
+
+### GitHub Release conventions
+
+- Core releases use the tag format `cores-vX.Y.Z`
+- They are always created as `--prerelease` — this hides them from the main releases page while keeping the asset URLs accessible to the appcast
+- One release can contain multiple core zips if updating several cores at once
+- Patch bumps (`cores-v1.0.0` → `cores-v1.0.1`) for single-core hotfixes; minor bumps (`cores-v1.1.0` → `cores-v1.2.0`) for batch updates with new cores or significant changes
+
+### Version numbers
+
+Core `CFBundleVersion` values are simple decimals (e.g. `2.3`, `2.4`). They do not need to match the upstream core's version — they just need to increase monotonically so Sparkle knows there's something newer. When in doubt, increment the minor number.
+
+### Rollback
+
+If a core update causes a regression, rollback is straightforward:
+1. Add a new appcast item pointing back at the previous release asset with a higher `sparkle:version`
+2. Users will receive it on their next update check and the older binary will be re-installed
+
+You do not need to delete the bad release or change any previously shipped version numbers.


### PR DESCRIPTION
## What this does

Ships the dc_flash.bin BIOS fix from #189 as an over-the-air core update.

- Bumps `CFBundleVersion` in `Flycast/OpenEmu/Info.plist` from `2.3` → `2.4`
- Updates `Appcasts/flycast.xml` with a new item pointing to the `cores-v1.1.1` GitHub release
- The `cores-v1.1.1` release is already live and marked as prerelease (not visible on the main releases page)

Once this PR merges, the appcast on `main` goes live immediately and existing users with Flycast installed will see the update offered on their next OpenEmu launch.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Verify the appcast looks right
cat Appcasts/flycast.xml

# 3. Verify the bundle version in the plist
/usr/libexec/PlistBuddy -c "Print CFBundleVersion" Flycast/OpenEmu/Info.plist
# Should print: 2.4
```

To verify the update is actually offered in-app: install the v1.0.5 release, open Preferences → Cores, and check that Flycast shows an available update.

## QA Spec

- [ ] `Appcasts/flycast.xml` has a `2.4` item pointing at `cores-v1.1.1`
- [ ] `Flycast/OpenEmu/Info.plist` has `CFBundleVersion` = `2.4`
- [ ] Existing users with Flycast 2.3 are offered the update in-app
- [ ] After updating, dc_flash.bin (All-regions) can be imported via Settings → System Files
- [ ] Flycast 2.3 download URL (cores-v1.0.0) is still present in the appcast as a fallback item

Made with [Cursor](https://cursor.com)