### PR TITLE
fix: bypass URLSession cache for core appcast requests

### DIFF
--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -95,7 +95,9 @@ final class CoreUpdater: NSObject {
     }
     
     private func checkForUpdateInformation(url: URL, plugin: OECorePlugin, handler: @escaping (CoreAppcastItem) -> Void) {
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
             if let error {
                 if #available(macOS 11.0, *) {
                     Logger.download.error("Failed to download \(url, privacy: .public): \(error, privacy: .public)")
@@ -159,7 +161,9 @@ final class CoreUpdater: NSObject {
         
         let coreListURL = URL(string: Bundle.main.infoDictionary!["OECoreListURL"] as! String)!
         
-        lastCoreListURLTask = URLSession.shared.dataTask(with: coreListURL) { data, response, error in
+        var coreListRequest = URLRequest(url: coreListURL)
+        coreListRequest.cachePolicy = .reloadIgnoringLocalCacheData
+        lastCoreListURLTask = URLSession.shared.dataTask(with: coreListRequest) { data, response, error in
             defer {
                 DispatchQueue.main.async {
                     if error == nil {
@@ -558,7 +562,9 @@ private final class CoreAppcast {
     
     func fetch(completionHandler handler: (() -> Void)? = nil) {
         let url = url
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
             defer { handler?() }
             
             guard let data else { return }


### PR DESCRIPTION
## What and why

Fixes a bug where the core update checker showed stale version numbers after a core update was published. Reported in #188 — after shipping Flycast 2.4, both the reporter and the maintainer saw \"Ver: 2.3 / Lat: 2.3\" in Preferences → Cores even though the live appcast correctly served 2.4.

## Root cause

All three appcast fetch sites in `CoreUpdater.swift` used `URLSession.shared.dataTask(with: url)` with no cache policy. macOS URLSession caches responses from `raw.githubusercontent.com` aggressively based on the server's cache headers. The cached response was served on subsequent launches until the system cache expired — meaning users never saw the updated version numbers.

## What changed

Added `request.cachePolicy = .reloadIgnoringLocalCacheData` to the three `URLRequest` objects in:
- `checkForUpdateInformation` — per-core appcast fetch (used when checking installed cores for updates)
- `checkForNewCores` — `oecores.xml` fetch (used to discover installable cores)
- `CoreAppcast.fetch` — appcast fetch for new/uninstalled cores

This is the correct policy for a version-check feed: we always want the current server state, not a locally cached copy from a previous session.

## How to test locally

```bash
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Open Preferences → Cores. Flycast should show \"Lat: 2.4\" immediately, even on first launch after a clean cache clear.

To verify caching is bypassed: check Console.app for any network requests to `raw.githubusercontent.com` — you should see a fresh fetch on every launch rather than a cache hit.

## QA Spec

- [ ] Flycast shows Lat: 2.4 in Preferences → Cores on first launch
- [ ] Relaunching still shows Lat: 2.4 (not reverting to a cached 2.3)
- [ ] Other cores still show correct latest versions
- [ ] No regression in core download or install behavior

Made with [Cursor](https://cursor.com)