### PR TITLE
fix: treat multiple BIOS plist entries for same filename as alternate hashes

### DIFF
--- a/OpenEmu/BIOSFile.swift
+++ b/OpenEmu/BIOSFile.swift
@@ -46,29 +46,18 @@ enum BIOSFile {
     /// - Parameter fileInfo: Dictionary containing "Name" and "MD5" keys.
     /// - Returns: Returns `true` if file exists with correct MD5.
     static func isBIOSFileAvailable(withFileInfo fileInfo: [String: Any]) -> Bool {
-        
+
         let biosSystemFilename = fileInfo["Name"] as! String
         let biosSystemMD5 = fileInfo["MD5"] as! String
-        
+
         let destinationURL = biosFolderURL.appendingPathComponent(biosSystemFilename, isDirectory: false)
-        
+
         let isReachable = (try? destinationURL.checkResourceIsReachable()) ?? false
-        
+        guard isReachable else { return false }
+
         do {
             let md5 = try FileManager.default.hashFile(at: destinationURL)
-            
-            if isReachable {
-                
-                if md5.caseInsensitiveCompare(biosSystemMD5) == .orderedSame {
-                    return true
-                } else {
-                    DLog("Incorrect MD5, deleting \(destinationURL)")
-                    try? FileManager.default.removeItem(at: destinationURL)
-                }
-            }
-            
-            return false
-            
+            return md5.caseInsensitiveCompare(biosSystemMD5) == .orderedSame
         } catch {
             return false
         }
@@ -104,36 +93,58 @@ enum BIOSFile {
     ///     * "Optional"
     /// - Returns: Returns `true` if all required files exist. Otherwise, returns `false` and displays a user alert.
     static func requiredFilesAvailable(forSystemIdentifier systemIdentifier: [[String: Any]]) -> Bool {
-        
+
+        // Group entries by filename. Multiple entries with the same name represent alternate valid
+        // hashes — the user only needs one matching variant, not one per entry.
+        var fileGroups: [String: [[String: Any]]] = [:]
+        for entry in systemIdentifier {
+            let name = entry["Name"] as! String
+            fileGroups[name, default: []].append(entry)
+        }
+
         var missingFileStatus = false
-        
-        let validRequiredFiles = systemIdentifier.sorted { ($0["Name"] as! String).compare($1["Name"] as! String, options: .caseInsensitive) == .orderedAscending }
-        
         var missingFilesList = ""
-        
-        for validRequiredFile in validRequiredFiles {
-            
-            let biosFilename = validRequiredFile["Name"] as! String
-            let biosDescription = validRequiredFile["Description"] as! String
-            let biosOptional = (validRequiredFile["Optional"] as? Bool) ?? false
-            
-            // Check if the required files exist and are optional.
-            if !isBIOSFileAvailable(withFileInfo: validRequiredFile) && !biosOptional {
-                missingFileStatus = true
-                missingFilesList += "\(biosDescription)\n\t\"\(biosFilename)\"\n\n"
+
+        let sortedFilenames = fileGroups.keys.sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
+
+        for filename in sortedFilenames {
+            let entries = fileGroups[filename]!
+            let biosDescription = entries.first!["Description"] as! String
+            let biosOptional = entries.contains { ($0["Optional"] as? Bool) == true }
+
+            let destinationURL = biosFolderURL.appendingPathComponent(filename, isDirectory: false)
+            let isReachable = (try? destinationURL.checkResourceIsReachable()) ?? false
+
+            guard isReachable, let md5 = try? FileManager.default.hashFile(at: destinationURL) else {
+                if !biosOptional {
+                    missingFileStatus = true
+                    missingFilesList += "\(biosDescription)\n\t\"\(filename)\"\n\n"
+                }
+                continue
+            }
+
+            let matchesAny = entries.contains { entry in
+                let hash = entry["MD5"] as! String
+                return md5.caseInsensitiveCompare(hash) == .orderedSame
+            }
+
+            if !matchesAny {
+                DLog("Incorrect MD5 for \(filename), deleting \(destinationURL)")
+                try? FileManager.default.removeItem(at: destinationURL)
+                if !biosOptional {
+                    missingFileStatus = true
+                    missingFilesList += "\(biosDescription)\n\t\"\(filename)\"\n\n"
+                }
             }
         }
-        
+
         guard !missingFileStatus else {
-            
-            // Alert the user of missing BIOS/system files that are required for the core.
             if OEAlert.missingBIOSFiles(missingFilesList).runModal() == .alertSecondButtonReturn {
                 NSWorkspace.shared.open(.userGuideBIOSFiles)
             }
-            
             return false
         }
-        
+
         return true
     }
     


### PR DESCRIPTION
## What and why

Follow-up fix for #188. The dc_flash.bin import now works (PR #189), but users still hit "required files are missing" on game launch, and any dc_flash.bin placed manually in the BIOS folder is silently deleted when they try to run a game.

## Root cause

PR #189 added a second `OERequiredFiles` entry in `Flycast/OpenEmu/Info.plist` for the All-regions `dc_flash.bin` variant. That gave the plist two entries with the same filename but different MD5s:

- `dc_flash.bin` — USA hash (`0a93f7940c455905bea6e392dfde92a4`)
- `dc_flash.bin` — All-regions hash (`93a9766f14159b403178ac77417c6b68`)

The old `requiredFilesAvailable` iterated over every entry independently and called `isBIOSFileAvailable` for each. `isBIOSFileAvailable` would hash the file, and if the hash didn't match **that specific entry**, it would **delete the file**. So for a user with the All-regions variant:

1. Entry 1 (USA): hash mismatch → file deleted
2. Entry 2 (All-regions): file is gone → missing

And for a user with the USA variant:
1. Entry 1 (USA): hash match → OK
2. Entry 2 (All-regions): hash mismatch → **file deleted** → missing

Both users end up with their file deleted and the game refusing to launch — even after successfully importing through the System Files UI. The same deletion also happened while the Prefs System Files screen was rendering its rows.

## What changed

**`BIOSFile.swift` — two changes:**

1. **`isBIOSFileAvailable` no longer deletes files.** It only checks. This was always the wrong place for deletion — the function is also called by the Prefs screen to show the availability indicator, and deleting as a side effect of a UI render is clearly wrong.

2. **`requiredFilesAvailable` groups entries by filename.** Multiple entries with the same `Name` are now treated as alternate valid hashes — the user needs a file that matches **any one** of them, not all of them. Deletion only happens when the file exists but matches none of the registered hashes (i.e. it is genuinely wrong). This is the correct semantics for "we accept multiple known-good dumps of the same file."

The fix is general — any core that registers multiple hash variants for the same BIOS filename will benefit from this.

## How to test locally

```bash
gh pr checkout 192 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

To verify, you need a `dc_flash.bin` with MD5 `93a9766f14159b403178ac77417c6b68` (All-regions) or `0a93f7940c455905bea6e392dfde92a4` (USA). Confirm with `md5 dc_flash.bin`.

## QA Spec

- [ ] All-regions `dc_flash.bin` (MD5 `93a9766f14159b403178ac77417c6b68`) can be imported and stays imported across app restarts
- [ ] USA `dc_flash.bin` (MD5 `0a93f7940c455905bea6e392dfde92a4`) still works correctly
- [ ] A Dreamcast game launches without "required files are missing" when either variant is present
- [ ] Opening Preferences → System Files does not delete a valid dc_flash.bin
- [ ] A dc_flash.bin placed manually in the BIOS folder is no longer deleted on game launch (when it has a known-good hash)
- [ ] A genuinely corrupt/wrong file (hash matches neither entry) is still deleted and the error is shown
- [ ] No regression on dc_boot.bin or any other system's BIOS files

Fixes #188

https://claude.ai/code/session_01Pn6qt8LtBykEUYprYibje1