### PR TITLE
fix: warn before loading save state created on a different core version

### DIFF
--- a/OpenEmu/OEAlert+Additions.swift
+++ b/OpenEmu/OEAlert+Additions.swift
@@ -231,6 +231,19 @@ extension OEAlert {
         return alert
     }
     
+    final class func coreVersionMismatch(coreName: String, savedVersion: String, installedVersion: String) -> OEAlert {
+
+        let alert = OEAlert()
+        alert.messageText = NSLocalizedString("Save State Version Mismatch", comment: "")
+        alert.informativeText = .localizedStringWithFormat(
+            NSLocalizedString("This save state was created with %@ version %@, but version %@ is installed. Loading it may cause a crash.", comment: ""),
+            coreName, savedVersion, installedVersion)
+        alert.defaultButtonTitle = NSLocalizedString("Load Anyway", comment: "")
+        alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
+
+        return alert
+    }
+
     final class func missingBIOSFiles(_ missingFilesList: String) -> OEAlert {
         
         let alert = OEAlert()

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1787,7 +1787,24 @@ final class OEGameDocument: NSDocument {
         }
         
         if coreIdentifier == state.coreIdentifier {
-            loadState()
+            // Same core — guard against version mismatch before loading.
+            // Save states are raw memory dumps; loading one created on a different
+            // core version can corrupt internal state and crash the helper process.
+            if let savedVersion = state.coreVersion,
+               !savedVersion.isEmpty,
+               savedVersion != corePlugin.version {
+                let alert = OEAlert.coreVersionMismatch(
+                    coreName: corePlugin.displayName,
+                    savedVersion: savedVersion,
+                    installedVersion: corePlugin.version)
+                if alert.runModal() == .alertFirstButtonReturn {
+                    loadState()
+                } else {
+                    startEmulation()
+                }
+            } else {
+                loadState()
+            }
             return
         }
         


### PR DESCRIPTION
## Summary

- Adds a version check in `loadState(state:)` before loading a save state on the same core it was created with
- If the installed core version differs from the version recorded in the save state, shows a dialog: **"Save State Version Mismatch"** with "Load Anyway" / "Cancel" instead of crashing silently
- Save states with no recorded version (nil/empty — predating version tracking) are loaded without a warning to avoid breaking old saves

## Why it crashed

Save states are raw memory dumps. When a core's internal data structures change between versions (e.g. Flycast 2.3 → 2.4), the old dump no longer maps to the new layout. The helper process gets an invalid memory access and dies immediately with no user-visible error.

The existing code only checked whether the `coreIdentifier` matched — it had no version awareness at all.

## What changed

**`OEAlert+Additions.swift`** — new `coreVersionMismatch(coreName:savedVersion:installedVersion:)` factory that builds the warning dialog.

**`OEGameDocument.swift`** — in `loadState(state:)`, after the identifier match, compare `state.coreVersion` against `corePlugin.version`. On mismatch: show alert → load or cancel. No suppression button — this is a safety warning.

## Test plan

- [ ] Create a save state, manually edit the `coreVersion` in the state's `Info.plist` to a different value, reload the game and trigger the state load — warning dialog should appear
- [ ] Click "Load Anyway" — state loads (may or may not work depending on actual structure compatibility)
- [ ] Click "Cancel" — game resumes from scratch, no crash
- [ ] Save state with matching version — loads immediately with no dialog
- [ ] Save state with nil/empty coreVersion (old format) — loads immediately with no dialog

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)