### PR TITLE
chore(ci): fix workflow file issues causing false failures on every PR push

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -32,9 +32,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
 
-    env:
-      DERIVED_DATA_PATH: ${{ runner.temp }}/DerivedData-${{ inputs.core_name }}
-
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
       - name: Checkout repository
@@ -42,6 +39,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
+
+      # ── Set path variables ──────────────────────────────────────────────────
+      # runner.temp is only available inside steps, not at job-level env scope.
+      - name: Set path variables
+        run: |
+          echo "DERIVED_DATA_PATH=$RUNNER_TEMP/DerivedData-${{ inputs.core_name }}" >> $GITHUB_ENV
 
       # ── Validate inputs ─────────────────────────────────────────────────────
       - name: Validate inputs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,13 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   release:
     name: Build, sign, notarize, and publish
     runs-on: self-hosted
     timeout-minutes: 90
-
-    env:
-      DERIVED_DATA_PATH: ${{ runner.temp }}/DerivedData
-      DMG: ${{ github.workspace }}/Releases/OpenEmu-Silicon.dmg
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
@@ -37,6 +33,13 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
+
+      # ── Set path variables ──────────────────────────────────────────────────
+      # runner.temp is only available inside steps, not at job-level env scope.
+      - name: Set path variables
+        run: |
+          echo "DERIVED_DATA_PATH=$RUNNER_TEMP/DerivedData" >> $GITHUB_ENV
+          echo "DMG=${{ github.workspace }}/Releases/OpenEmu-Silicon.dmg" >> $GITHUB_ENV
 
       # ── Parse and validate version ──────────────────────────────────────────
       - name: Parse version from tag


### PR DESCRIPTION
## Summary

Fixes two bugs in the release workflows added in #193 that caused `release.yml` and `release-core.yml` to appear as failed runs on every PR push.

**Bug 1 — invalid tag glob pattern (`release.yml`)**
The tag filter `v[0-9]+.[0-9]+.[0-9]+` used regex `+` quantifiers. GitHub Actions tag patterns use fnmatch glob syntax where `+` is a literal character, not "one or more". The pattern never matched a real version tag, and GitHub's handling of unmatchable patterns caused the workflow to trigger on all branch pushes instead.
→ Fixed to `v[0-9]*.[0-9]*.[0-9]*`.

**Bug 2 — `runner` context in job-level `env:` (both files)**
`${{ runner.temp }}` was declared in `jobs.<job>.env:`. The `runner` context is only available inside steps, not at job scope. GitHub fails workflow file validation at parse time and reports "This run likely failed because of a workflow file issue" — which is why the workflow name showed as the file path instead of the declared `name:` field.
→ Moved to a `Set path variables` step that writes to `GITHUB_ENV`.

## Test plan
- [ ] Open a new PR after this merges — `release.yml` and `release-core.yml` should no longer appear in the Actions runs list
- [ ] Push a `v1.0.6` tag — `release.yml` should trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)