### PR TITLE
fix(ci): clear SPM binary artifact cache before build

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Clear SPM binary artifact cache
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts/
+
       - name: Generate credentials stubs
         run: |
           cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift


### PR DESCRIPTION
## Summary

Build Check was failing on PRs with:
```
failed downloading sentry-cocoa 9.9.0 Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip
… already exists in file system
```

GitHub-hosted runners can share a machine pool and retain a stale or partial SPM binary artifact cache between jobs. When the cache entry exists but is corrupted or incomplete, SPM refuses to re-download and the build aborts. Adds a `rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts/` step before package resolution to ensure a clean state.

## Test plan
- [ ] Build Check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)