### PR TITLE
fix(flycast): throttle SH4 thread via audio back-pressure to fix fast speed

### DIFF
--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -77,7 +77,7 @@ public:
             // to OE's audio consumption rate, fixing games running too fast (#202).
             // 200 × 100µs = 20ms max (one PAL frame), preventing infinite spin if
             // the emulator stops while the SH4 thread is mid-flight.
-            for (int i = 0; i < 200 && [buf freeBytes] < byteCount; i++)
+            for (int i = 0; i < 200 && _current && [buf freeBytes] < byteCount; i++)
                 usleep(100);
         }
         [buf write:(const uint8_t *)data maxLength:byteCount];

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -65,10 +65,22 @@ public:
 
     u32 push(const void *data, u32 frames, bool wait) override
     {
-        if (_current) {
-            [[_current audioBufferAtIndex:0] write:(const uint8_t *)data
-             maxLength:frames * 4]; // stereo s16 = 4 bytes per frame
+        if (!_current) return frames;
+
+        OERingBuffer *buf = [_current audioBufferAtIndex:0];
+        NSUInteger byteCount = frames * 4; // stereo s16 = 4 bytes per frame
+
+        if (wait) {
+            // Block until there's room in the ring buffer. This is the primary
+            // real-time throttle: config::LimitFPS is constexpr true, so push()
+            // is always called with wait=true. Spinning here paces the SH4 thread
+            // to OE's audio consumption rate, fixing games running too fast (#202).
+            // 200 × 100µs = 20ms max (one PAL frame), preventing infinite spin if
+            // the emulator stops while the SH4 thread is mid-flight.
+            for (int i = 0; i < 200 && [buf freeBytes] < byteCount; i++)
+                usleep(100);
         }
+        [buf write:(const uint8_t *)data maxLength:byteCount];
         return frames;
     }
 

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,7 +1077,7 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	return rend_single_frame(true, 14); // 14ms: return quickly if no frame ready so OE game loop stays responsive
+	return rend_single_frame(true); // use default timeout (20ms NTSC / 23ms PAL)
 }
 
 void Emulator::vblank()


### PR DESCRIPTION
The SH4 emulation thread was running unconstrained. Flycast's only
real-time throttle is the audio push path: audiostream.cpp calls
push(..., config::LimitFPS) where LimitFPS is constexpr true, so
wait=true on every call. But OpenEmuAudioBackend::push() ignored the
wait parameter entirely — it wrote to the ring buffer and returned
immediately, giving the SH4 no back-pressure.

Fix 1 (FlycastGameCore.mm): when wait=true, spin-wait on OERingBuffer
freeBytes until there is room for the batch before writing. OE drains
audio at 44100 Hz, so this naturally throttles the SH4 to real-time
speed. Max spin is 200 × 100µs = 20ms (one PAL frame) to avoid an
infinite loop if emulation stops mid-flight.

Fix 2 (emulator.cpp): revert the OE-specific 14ms timeout on
rend_single_frame(). The default (20ms NTSC / 23ms PAL, chosen by
SPG_CONTROL.isPAL()) is correct. The short 14ms value caused
rend_single_frame() to return early before a full frame was due,
compounding the run-ahead.

Together these fixes resolve the too-fast game speed and severely
distorted audio reported on all Dreamcast titles with 3D graphics.

Fixes #202