### PR TITLE
fix: restore NES color palette for FCEU core (grey screen regression)

### DIFF
--- a/FCEU/src/palette.cpp
+++ b/FCEU/src/palette.cpp
@@ -569,6 +569,12 @@ void WritePalette(void)
 	for(x=unvaried;x<256;x++)
 		FCEUD_SetPalette(x,205,205,205);
 
+	//sets palette entries 0–63 with the 64 selected main colors so the PPU's
+	//0–63 pixel values map to real colors (non-MSVC platforms need this explicit write;
+	//MSVC's malloc happened to fill these with correct values before 2.6.6 made it deterministic)
+	for(x=0;x<64;x++)
+		FCEUD_SetPalette(x,palo[x].r,palo[x].g,palo[x].b);
+
 	//sets palette entries >= 128 with the 64 selected main colors
 	for(x=0;x<64;x++)
 		FCEUD_SetPalette(128+x,palo[x].r,palo[x].g,palo[x].b);


### PR DESCRIPTION
## Summary

- Fixes a grey screen on all NES ROMs when using the FCEU core
- Root cause: FCEU 2.6.6 introduced a deterministic grey fill (`205,205,205`) for palette entries 0–127, but the PPU writes pixel values in the 0–63 range — so every pixel looked up a grey entry
- Fix: mirror the existing color write (entries 128–191) to entries 0–63 so the PPU's pixel values map to real colors

## What changed

`FCEU/src/palette.cpp` — `WritePalette()`: added a write loop for palette entries 0–63 immediately before the existing 128–191 loop. No other files touched.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

4. Open any NES ROM and select the FCEU core — game should render with correct colors instead of a grey screen.
5. Verify Nestopia still works (unrelated, no change expected).

## QA Spec

- [ ] NES ROM renders with correct colors using FCEU core
- [ ] Game audio still plays normally
- [ ] Nestopia unaffected — still renders correctly
- [ ] No regression on other systems (SNES, GBA, etc.)

Fixes #214

Made with [Cursor](https://cursor.com)