### PR TITLE
fix: center PlayStation display rect when horizontal offset shifts mid-game

### DIFF
--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -3395,6 +3395,24 @@ static __weak MednafenGameCore *_current;
     }
     _videoHeight  = spec.DisplayRect.h;
 
+    // PSX reports a non-zero DisplayRect.x when the GPU's horizontal start register
+    // shifts mid-game (e.g. after the BIOS splash). The host compositor renders the
+    // active rect left-aligned in the window, leaving a blank strip on the right equal
+    // to the offset. Zero out the X offset and expand the width to fill the framebuffer
+    // so the image stays centered. Log on first occurrence per session to aid diagnosis.
+    if ([_mednafenCoreModule isEqualToString:@"psx"] && _videoOffsetX != 0) {
+        static int psxOffsetLogCount = 0;
+        if (psxOffsetLogCount < 5) {
+            NSLog(@"[Mednafen] PSX DisplayRect x=%d y=%d w=%d h=%d fb_w=%d (centering)",
+                  spec.DisplayRect.x, spec.DisplayRect.y, _videoWidth, _videoHeight, game->fb_width);
+            psxOffsetLogCount++;
+        }
+        // Expand width to cover the offset so the active area fills the full framebuffer
+        // width, then zero the offset so the compositor centers it correctly.
+        _videoWidth  = MIN(_videoWidth + _videoOffsetX, (int)game->fb_width);
+        _videoOffsetX = 0;
+    }
+
     [[self ringBufferAtIndex:0] write:spec.SoundBuf maxLength:spec.SoundBufSize * self.channelCount * 2];
 }
 


### PR DESCRIPTION
## Summary

- Fixes the asymmetric black bar on the right side of the PlayStation game window (#201)
- Root cause: the PSX GPU's horizontal start register changes after the BIOS splash, causing Mednafen to report a non-zero `DisplayRect.x` mid-game. The host compositor renders the active area left-aligned, leaving a blank strip on the right equal to the offset.
- Fix: when running the `psx` module and `DisplayRect.x != 0`, absorb the offset into the reported width (clamped to `fb_width`) and zero the offset so the image renders centered.

## What changed

`Mednafen/MednafenGameCore.mm` — in `executeFrame`, after the existing `_videoOffsetX` / `_videoWidth` assignment: added a PSX-specific block that zeroes the X offset and expands the width to compensate. Also logs the raw `DisplayRect` values on the first five occurrences per session via `NSLog` so the behavior is observable in Console.app.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

4. Launch a PlayStation game (Castlevania: Symphony of the Night confirmed the issue previously).
5. Let it run past the BIOS splash — the black bar should no longer appear.
6. Verify image is centered with equal pillarboxing on both sides.
7. Open Console.app filtered by `[Mednafen] PSX DisplayRect` to see the logged offset values.

## QA Spec

- [ ] PSX game renders centered — no black bar on the right side after BIOS splash
- [ ] Image does not shift or jump when the offset correction fires
- [ ] Other Mednafen-backed systems (Saturn, WonderSwan, Lynx) are unaffected — only the `psx` module path runs the new block
- [ ] Console.app shows `[Mednafen] PSX DisplayRect` log entries when the offset fires (confirms the code path is hit)

Fixes #201

Made with [Cursor](https://cursor.com)