### PR TITLE
fix: surface ScreenScraper fetch errors instead of silently discarding them

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -64,7 +64,7 @@ final class GameInfoHelper {
                 // ROMs that share the same name across platforms (e.g. .n64 vs .sfc).
                 let romName = url?.lastPathComponent
                 var fallback: [String: Any] = [:]
-                if let ss = ScreenScraperClient.shared.fetchGameInfo(md5: md5, romName: romName, systemIdentifier: systemIdentifier) {
+                if case .success(let ss) = ScreenScraperClient.shared.fetchGameInfo(md5: md5, romName: romName, systemIdentifier: systemIdentifier), let ss = ss {
                     if let boxURL = ss.boxImageURL { fallback["boxImageURL"] = boxURL.absoluteString }
                     if let title = ss.gameTitle   { fallback["gameTitle"] = title }
                     if let desc  = ss.gameDescription { fallback["gameDescription"] = desc }
@@ -200,11 +200,11 @@ final class GameInfoHelper {
                 // FIX: pass full filename (including extension) so ScreenScraper
                 // can differentiate ROMs sharing names across systems.
                 let romName = url?.lastPathComponent
-                if let ss = ScreenScraperClient.shared.fetchGameInfo(
+                if case .success(let ss) = ScreenScraperClient.shared.fetchGameInfo(
                     md5: md5,
                     romName: romName,
                     systemIdentifier: systemIdentifier
-                ) {
+                ), let ss = ss {
                     if let boxURL = ss.boxImageURL {
                         resultDict["boxImageURL"] = boxURL.absoluteString
                     }

--- a/OpenEmu/PrefScreenScraperController.swift
+++ b/OpenEmu/PrefScreenScraperController.swift
@@ -54,6 +54,11 @@ final class PrefScreenScraperController: NSViewController {
         updateStatus()
     }
 
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        updateStatus()
+    }
+
     // MARK: - Build UI
 
     private func buildUI() {
@@ -184,9 +189,20 @@ final class PrefScreenScraperController: NSViewController {
 
     private func updateStatus() {
         let username = UserDefaults.standard.string(forKey: "ScreenScraperUsername") ?? ""
-        if !username.isEmpty && ScreenScraperCredentials.hasStoredPassword() {
-            statusLabel.stringValue = "✓  Signed in as \(username)"
-            statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+        let isSignedIn = !username.isEmpty && ScreenScraperCredentials.hasStoredPassword()
+
+        if isSignedIn {
+            // Show the last fetch error if one occurred, so users know why art lookup failed
+            Task { @MainActor in
+                if let fetchError = ScreenScraperClient.shared.lastFetchError,
+                   let description = fetchError.errorDescription {
+                    self.statusLabel.stringValue = description
+                    self.statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
+                } else {
+                    self.statusLabel.stringValue = "✓  Signed in as \(username)"
+                    self.statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+                }
+            }
         } else {
             statusLabel.stringValue = "Not signed in — ScreenScraper will be skipped. OpenVGDB and libretro-thumbnails are still active."
             statusLabel.textColor = .secondaryLabelColor

--- a/OpenEmu/ScreenScraperClient.swift
+++ b/OpenEmu/ScreenScraperClient.swift
@@ -32,9 +32,38 @@ struct ScreenScraperResult {
     var gameDescription: String?
 }
 
+enum ScreenScraperFetchError: Error, Equatable {
+    case networkUnavailable(String)
+    case badCredentials
+    case rateLimited
+    case notFound
+    case invalidResponse
+}
+
+extension ScreenScraperFetchError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .networkUnavailable(let detail):
+            return "Could not reach ScreenScraper — check your connection. (\(detail))"
+        case .badCredentials:
+            return "ScreenScraper rejected your credentials. Check your username and password in Preferences → Cover Art."
+        case .rateLimited:
+            return "ScreenScraper rate limit reached. Try again later."
+        case .notFound:
+            return nil  // Not an error worth surfacing — ROM simply isn't in the database
+        case .invalidResponse:
+            return "ScreenScraper returned an unexpected response."
+        }
+    }
+}
+
 final class ScreenScraperClient {
 
     static let shared = ScreenScraperClient()
+
+    /// The error from the most recent fetch, if any. Nil on success or .notFound.
+    /// Updated on every call to fetchGameInfo. Thread-safe via main-queue dispatch.
+    @MainActor private(set) var lastFetchError: ScreenScraperFetchError?
 
     // ScreenScraper numeric system IDs keyed by OpenEmu system identifier
     static let systemIDs: [String: Int] = [
@@ -82,13 +111,16 @@ final class ScreenScraperClient {
     }
 
     /// Synchronous fetch suitable for calling from a background DispatchQueue.sync block.
-    /// Returns nil silently on error (network unavailable, rate-limited, not found, etc.)
+    ///
+    /// Returns `.success(nil)` when the ROM was not found (not an error).
+    /// Returns `.failure` for network errors, bad credentials, rate limiting, etc.
+    /// Also writes to `lastFetchError` (main actor) for UI display.
     ///
     /// Pass `debugMode: true` to attach the developer debug password (100 uses/day limit).
-    func fetchGameInfo(md5: String?, romName: String?, systemIdentifier: String, debugMode: Bool = false) -> ScreenScraperResult? {
+    func fetchGameInfo(md5: String?, romName: String?, systemIdentifier: String, debugMode: Bool = false) -> Result<ScreenScraperResult?, ScreenScraperFetchError> {
 
         guard let systemID = ScreenScraperClient.systemIDs[systemIdentifier] else {
-            return nil
+            return .success(nil)
         }
 
         var components = URLComponents(string: "https://www.screenscraper.fr/api2/jeuInfos.php")!
@@ -104,7 +136,7 @@ final class ScreenScraperClient {
         // ScreenScraper requires romnom; rommd5 is additive for accuracy.
         // Sending both when available gives the best match rate.
         guard (md5 != nil && !(md5!.isEmpty)) || (romName != nil && !(romName!.isEmpty)) else {
-            return nil
+            return .success(nil)
         }
         if let md5 = md5, !md5.isEmpty {
             queryItems.append(URLQueryItem(name: "rommd5", value: md5.uppercased()))
@@ -131,9 +163,9 @@ final class ScreenScraperClient {
 
         components.queryItems = queryItems
 
-        guard let url = components.url else { return nil }
+        guard let url = components.url else { return .success(nil) }
 
-        var result: ScreenScraperResult?
+        var fetchResult: Result<ScreenScraperResult?, ScreenScraperFetchError> = .success(nil)
         let semaphore = DispatchSemaphore(value: 0)
 
         let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
@@ -142,28 +174,58 @@ final class ScreenScraperClient {
             guard let self = self else { return }
 
             if let error = error {
-                os_log(.debug, log: .default, "ScreenScraper network error: %{public}@", error.localizedDescription)
+                let detail = error.localizedDescription
+                os_log(.error, log: .default, "ScreenScraper network error: %{public}@", detail)
+                let ssError = ScreenScraperFetchError.networkUnavailable(detail)
+                fetchResult = .failure(ssError)
+                Task { @MainActor in self.lastFetchError = ssError }
                 return
             }
 
             if let http = response as? HTTPURLResponse {
-                // 430 = rate limited; 404 = not found — both are silent no-ops
-                guard (200..<300).contains(http.statusCode) else { return }
+                switch http.statusCode {
+                case 200..<300:
+                    break
+                case 401, 403:
+                    os_log(.error, log: .default, "ScreenScraper auth error: HTTP %d", http.statusCode)
+                    fetchResult = .failure(.badCredentials)
+                    Task { @MainActor in self.lastFetchError = .badCredentials }
+                    return
+                case 404:
+                    fetchResult = .success(nil)
+                    Task { @MainActor in self.lastFetchError = nil }
+                    return
+                case 430:
+                    os_log(.error, log: .default, "ScreenScraper rate limited (HTTP 430)")
+                    fetchResult = .failure(.rateLimited)
+                    Task { @MainActor in self.lastFetchError = .rateLimited }
+                    return
+                default:
+                    os_log(.error, log: .default, "ScreenScraper unexpected HTTP %d", http.statusCode)
+                    fetchResult = .failure(.invalidResponse)
+                    Task { @MainActor in self.lastFetchError = .invalidResponse }
+                    return
+                }
             }
 
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let response = json["response"] as? [String: Any],
                   let jeu = response["jeu"] as? [String: Any] else {
+                os_log(.error, log: .default, "ScreenScraper returned unparseable response")
+                fetchResult = .failure(.invalidResponse)
+                Task { @MainActor in self.lastFetchError = .invalidResponse }
                 return
             }
 
-            result = self.parseGameInfo(jeu: jeu)
+            let parsed = self.parseGameInfo(jeu: jeu)
+            fetchResult = .success(parsed)
+            Task { @MainActor in self.lastFetchError = nil }
         }
 
         task.resume()
         semaphore.wait()
-        return result
+        return fetchResult
     }
 
     // MARK: - JSON Parsing


### PR DESCRIPTION
## Summary

- Fixes cover art lookup silently failing with no user feedback (#205)
- When ScreenScraper is unreachable, rejects credentials, or rate-limits the app, users now see a clear error message in Preferences → Cover Art instead of no indication anything went wrong

## What changed

**`ScreenScraperClient.swift`**
- Added `ScreenScraperFetchError` enum: `.networkUnavailable`, `.badCredentials`, `.rateLimited`, `.notFound`, `.invalidResponse`
- Changed `fetchGameInfo` return type from `ScreenScraperResult?` to `Result<ScreenScraperResult?, ScreenScraperFetchError>`
- Each failure path now logs at `.error` level (visible in Console.app) and sets `lastFetchError` on the shared client
- `.notFound` (HTTP 404) is still a silent no-op — ROM not in the database isn't an error worth surfacing

**`GameInfoHelper.swift`**
- Updated both `fetchGameInfo` call sites to pattern-match on `.success`

**`PrefScreenScraperController.swift`**
- `updateStatus()` reads `ScreenScraperClient.shared.lastFetchError` and shows the human-readable description when signed in but a lookup has recently failed
- Added `viewWillAppear` override so the status refreshes each time the pane opens

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

4. Open Preferences → Cover Art. Sign in with valid ScreenScraper credentials.
5. Disconnect from the internet and add a game to the library — check that Preferences → Cover Art shows a network error message.
6. Reconnect, enter wrong credentials, add another game — check that the pane shows a bad credentials message.
7. With valid credentials and internet, add a known game — art should fetch normally, status shows "✓ Signed in as...".

## QA Spec

- [ ] Network error shows "Could not reach ScreenScraper..." message in Preferences → Cover Art
- [ ] Bad credentials (401) shows credential error message
- [ ] Rate limit (430) shows rate limit message
- [ ] Successful lookup clears the error and shows the signed-in status
- [ ] ROM not found (no art) does NOT show an error — silent success
- [ ] Errors are visible in Console.app filtered by "ScreenScraper"
- [ ] No regression on art fetching when credentials are valid and network is available

Fixes #205

Made with [Cursor](https://cursor.com)