### PR TITLE
fix: correct OAuth redirect URI threading and register URL scheme for Google Drive

### DIFF
--- a/OpenEmu/OEGoogleDriveConfig.swift
+++ b/OpenEmu/OEGoogleDriveConfig.swift
@@ -29,6 +29,11 @@ enum OEGoogleDriveConfig {
     
     // MARK: - OAuth Credentials
     
+    // TODO: Inject real credentials before Cloud Sync can function.
+    // Strategy options: (a) CI secret → OEGoogleDriveSecrets.swift at build time,
+    //                   (b) runtime user-provided credentials in Preferences.
+    // See: OEGoogleDriveSecrets.template.swift for the secrets-file pattern.
+    // Tracked in: https://github.com/nickybmon/OpenEmu-Silicon/issues/129
     /// Your Google API OAuth 2.0 Client ID.
     static let clientID     = "YOUR_CLIENT_ID_HERE"
     

--- a/OpenEmu/OESaveSyncManager.swift
+++ b/OpenEmu/OESaveSyncManager.swift
@@ -529,7 +529,20 @@ final class OESaveSyncManager: NSObject {
         do {
             let listener = try NWListener(using: .tcp, on: .any)
             self.oauthListener = listener
-            
+
+            // Capture the assigned port when the listener becomes ready so we can pass
+            // the exact same redirect URI in both the auth request and the token exchange.
+            // listener.port is reliable here; by the time newConnectionHandler fires and
+            // the listener is cancelled, it may already be nil.
+            var capturedRedirectURI: String = OEGoogleDriveConfig.redirectURI
+
+            listener.stateUpdateHandler = { state in
+                if case .ready = state, let port = listener.port {
+                    capturedRedirectURI = "http://127.0.0.1:\(port.rawValue)"
+                    self.openAuthPage(with: capturedRedirectURI)
+                }
+            }
+
             listener.newConnectionHandler = { connection in
                 connection.start(queue: .main)
                 self.receiveOAuthRequest(on: connection) { code in
@@ -537,23 +550,13 @@ final class OESaveSyncManager: NSObject {
                     connection.send(content: response.data(using: .utf8), completion: .contentProcessed({ _ in
                         connection.cancel()
                         listener.cancel()
-                        
-                        if let port = listener.port {
-                            completion(code, "http://127.0.0.1:\(port.rawValue)")
-                        } else {
-                            completion(code, OEGoogleDriveConfig.redirectURI)
-                        }
+                        // Use the URI captured at listener-ready time, not listener.port
+                        // (which may be nil after cancel()).
+                        completion(code, capturedRedirectURI)
                     }))
                 }
             }
-            
-            listener.stateUpdateHandler = { state in
-                if case .ready = state, let port = listener.port {
-                    let redirectURI = "http://127.0.0.1:\(port.rawValue)"
-                    self.openAuthPage(with: redirectURI)
-                }
-            }
-            
+
             listener.start(queue: .main)
         } catch {
             os_log(.error, log: log, "Failed to start OAuth listener: %{public}@", error.localizedDescription)

--- a/OpenEmu/OpenEmu-Info.plist
+++ b/OpenEmu/OpenEmu-Info.plist
@@ -133,6 +133,14 @@
 				<string>com.openemu.OpenEmu</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.openemu.openemu.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.openemu.openemu</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>7</string>


### PR DESCRIPTION
## Summary

- Fixes two bugs in the Google Drive OAuth flow that would cause sign-in to fail even with valid credentials (#129)
- The placeholder `YOUR_CLIENT_ID_HERE` credentials are **not** changed in this PR — that requires a separate credential distribution decision. This PR removes the structural failures so the flow works once real credentials are provided.

## What changed

**`OESaveSyncManager.swift` — redirect URI threading**

The listener port was read from `listener.port` inside `newConnectionHandler`, _after_ `listener.cancel()` was called. At that point the port may be nil, causing the code to fall back to the static portless `"http://127.0.0.1"` URI. Google requires the `redirect_uri` in the token exchange to exactly match the one sent in the authorization request, so this produced a second 400/401 failure after the consent screen.

Fix: capture the port string in `stateUpdateHandler` (where `listener.port` is reliably non-nil, set by the OS when the listener becomes ready) and pass that captured string through the completion callback.

**`OpenEmu-Info.plist` — URL scheme registration**

`AppDelegate` handles `com.openemu.openemu://oauth2callback` for scheme-based OAuth, but only `com.openemu.OpenEmu` (mixed case) was registered. Added `com.openemu.openemu` (lowercase) as a second `CFBundleURLTypes` entry so macOS can route the callback URL to the app.

**`OEGoogleDriveConfig.swift` — credential blocker comment**

Added a `TODO` block explaining the credential injection decision and linking to this issue, so it's visible to anyone reading the file in the future.

## What's still needed (not in this PR)

- Deciding how to inject real OAuth credentials: CI secret → `OEGoogleDriveSecrets.swift` at build time, or runtime user-provided credentials in Preferences
- Wiring up `OEGoogleDriveSecrets.swift` so `OEGoogleDriveConfig.clientID` reads from it instead of the placeholder

## How to test locally

Navigate to your local clone, then paste this block.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 232 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug 2>/dev/null | head -1)
open "$DEBUG_DIR/OpenEmu.app"
```

Full OAuth flow can only be tested with real credentials injected via `OEGoogleDriveSecrets.swift`. To verify the redirect URI fix structurally: add a breakpoint or `NSLog` in `startOAuthListener` and confirm `capturedRedirectURI` is `http://127.0.0.1:<port>` (not `http://127.0.0.1`) when `completion` is called. To verify the URL scheme: run `xcrun simctl openurl booted "com.openemu.openemu://oauth2callback?code=test"` — the app should open and attempt to handle the callback.

## QA Spec

- [ ] `capturedRedirectURI` in the completion block matches the URI sent to Google in the auth request
- [ ] `com.openemu.openemu` URL scheme is registered — app opens when the scheme is invoked
- [ ] No regression in existing sync flow (sign-out, status updates, FSEvent monitoring)
- [ ] Build succeeds cleanly (no new errors or warnings)

Partially fixes #129

Made with [Cursor](https://cursor.com)