### PR TITLE
docs: add libretro bridge contributor callout and workflow guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,9 @@ Use the **Bug report** issue template. Include:
 5. Open a PR against `main` with a clear description of what it fixes — reference the issue with `Fixes #N`
 
 See `AGENTS.md` for the full workflow and coding rules.
+
+## Contributing to the libretro bridge
+
+**If your change touches `OELibretroCoreTranslator`, `OELibretroGameCore`, or other bridge files, do not branch from `main`.** The bridge lives on `feat/libretro-bridge`, which diverged from `main` ~30 commits ago. Branching from `main` will produce a PR with thousands of unintended changed files.
+
+See [`docs/bridge-contributors.md`](docs/bridge-contributors.md) for the correct workflow, including how to recover if you branched from the wrong base.

--- a/docs/bridge-contributors.md
+++ b/docs/bridge-contributors.md
@@ -1,0 +1,56 @@
+# Contributing to the Libretro Bridge
+
+The libretro bridge (`feat/libretro-bridge`) is developed on its own long-running integration branch, separate from `main`. If your change touches bridge code, follow the rules below — the standard "branch from `main`" workflow in `CONTRIBUTING.md` does not apply here.
+
+## Branch rules
+
+| Rule | Why |
+|------|-----|
+| Branch from `feat/libretro-bridge`, not `main` | `main` and `feat/libretro-bridge` diverged at `35581e7e`. Branching from `main` pulls in ~30 unrelated commits and makes your diff unreadable. |
+| Open your PR against `feat/libretro-bridge` | PRs against `main` will be closed — bridge work lands on `main` in one batch when the bridge ships. |
+| Keep PRs scoped to one concern | The bridge is already a large diff; unfocused PRs make review harder. |
+
+## What counts as "bridge code"
+
+- `OELibretroCoreTranslator.m` and its header
+- `OELibretroGameCore.m` and its header
+- Anything under `OpenEmu-SDK/OpenEmuBase/` that uses `libretro.h` types
+- The `OELibretroGameCoreHelper` protocol and related broker/IPC plumbing
+
+If your change only touches a standalone emulator core (e.g. Flycast, mGBA) and doesn't touch the translator or core protocol, branch from `main` as normal.
+
+## Workflow
+
+```bash
+# 1. Sync the bridge branch
+git fetch origin
+git checkout feat/libretro-bridge
+git merge origin/feat/libretro-bridge
+
+# 2. Create your branch from the bridge branch
+git checkout -b feat/your-description
+
+# 3. Make your change, build, commit
+xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu \
+  -configuration Debug -destination 'platform=macOS,arch=arm64' build
+git add -p
+git commit -m "feat: your description"
+
+# 4. Push and open a PR targeting feat/libretro-bridge
+git push -u origin feat/your-description
+gh pr create --repo nickybmon/OpenEmu-Silicon \
+  --base feat/libretro-bridge \
+  --title "feat: your description" \
+  --body "..."
+```
+
+## Recovering from a wrong base branch
+
+If you branched from `main` by mistake and your PR shows thousands of changed files:
+
+1. Find the commits that contain only your actual changes: `git log feat/libretro-bridge..HEAD`
+2. Note those commit SHAs
+3. Close the current PR
+4. Create a new branch from `feat/libretro-bridge`
+5. Cherry-pick your commits: `git cherry-pick <sha1> <sha2> ...`
+6. Push the new branch and open a fresh PR against `feat/libretro-bridge`


### PR DESCRIPTION
## Summary

- Adds a warning to `CONTRIBUTING.md` directing bridge contributors to branch from `feat/libretro-bridge`, not `main`
- Creates `docs/bridge-contributors.md` with the full bridge-specific workflow: correct base branch, PR target, cherry-pick recovery steps for the wrong-base mistake

## Motivation

PR #233 (`feat/pixel-buffer-allocation`) showed 6,757 changed files because the contributor branched from `main` instead of `feat/libretro-bridge`. The two branches diverged ~30 commits ago and `CONTRIBUTING.md` had no mention of the bridge workflow. This closes that documentation gap so the next contributor doesn't hit the same problem.

## Test plan

- [ ] Read `CONTRIBUTING.md` — bridge callout is visible and links correctly to `docs/bridge-contributors.md`
- [ ] Read `docs/bridge-contributors.md` — workflow steps are accurate, recovery recipe is clear
- [ ] No build changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)