### PR TITLE
feat: RetroAchievements v1 — mGBA integration, XPC protocol, pref pane, HUD notifications

### DIFF
--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + mGBA.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + mGBA.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "mGBA.oecoreplugin"
+               BlueprintName = "mGBA"
+               ReferencedContainer = "container:mGBA/mGBA.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -27,6 +27,7 @@
 import Cocoa
 import OpenEmuSystem
 import OpenEmuKit
+import UserNotifications
 
 private var appearancePrefChangedKVOContext = 0
 
@@ -887,7 +888,9 @@ extension AppDelegate: NSMenuDelegate {
         notificationCenter.addObserver(self, selector: #selector(openPreferencePane), name: PreferencesWindowController.openPaneNotificationName, object: nil)
         
         NSDocumentController.shared.clearRecentDocuments(nil)
-        
+
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+
         validateDefaultPluginAssignments()
         
         DispatchQueue.main.async {

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -331,4 +331,8 @@ extension GameViewController {
     func showStepBackwardNotification() {
         notificationView.showStepBackward()
     }
+
+    func showAchievementUnlockedNotification() {
+        notificationView.showAchievementUnlocked()
+    }
 }

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -48,7 +48,8 @@ final class GameViewController: NSViewController {
     private var scaledView: OEScaledGameLayerView!
     private(set) var gameView: OEGameLayerView!
     private var notificationView: OEGameLayerNotificationView!
-    
+    private var achievementBannerView: OEAchievementBannerView!
+
     // Save Sync status badge
     private var syncStatusOverlay: OESyncStatusOverlayView!
     private var syncStatusToken: NSObjectProtocol?
@@ -108,6 +109,17 @@ final class GameViewController: NSViewController {
             syncStatusOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 60)
         ])
         
+        achievementBannerView = OEAchievementBannerView(frame: .zero)
+        achievementBannerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(achievementBannerView)
+
+        NSLayoutConstraint.activate([
+            achievementBannerView.widthAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerWidth),
+            achievementBannerView.heightAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerHeight),
+            achievementBannerView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            achievementBannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -24),
+        ])
+
         syncStatusToken = NotificationCenter.default.addObserver(forName: .OESaveSyncStatusDidChange, object: nil, queue: .main) { [weak self] notification in
             guard let self = self, let obj = notification.object as? OESaveSyncManager else { return }
             self.syncStatusOverlay.show(status: obj.syncStatus, message: obj.syncStatusMessage)
@@ -332,7 +344,7 @@ extension GameViewController {
         notificationView.showStepBackward()
     }
 
-    func showAchievementUnlockedNotification() {
-        notificationView.showAchievementUnlocked()
+    func showAchievementUnlocked(title: String, points: UInt32) {
+        achievementBannerView.show(title: title, points: points)
     }
 }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2066,10 +2066,10 @@ extension OEGameDocument: OESystemBindingsObserver {
 
     func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32) {
         DispatchQueue.main.async {
-            // HUD overlay — respects the "Show notifications" user preference
-            self.gameViewController?.showAchievementUnlockedNotification()
+            // In-app banner — always visible regardless of Focus mode or notification settings
+            self.gameViewController?.showAchievementUnlocked(title: title, points: points)
 
-            // macOS system notification — visible even in full-screen
+            // macOS system notification — timeSensitive breaks through Focus/DND
             let content = UNMutableNotificationContent()
             content.title = title
             content.body  = description
@@ -2080,11 +2080,7 @@ extension OEGameDocument: OESystemBindingsObserver {
                 content: content,
                 trigger: nil
             )
-
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, _ in
-                guard granted else { return }
-                UNUserNotificationCenter.current().add(request)
-            }
+            UNUserNotificationCenter.current().add(request)
         }
     }
 }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -27,6 +27,7 @@ import IOKit.pwr_mgt
 import OpenEmuBase
 import OpenEmuSystem
 import OpenEmuKit
+import UserNotifications
 
 let OEGameVolumeKey = "volume"
 let OEGameCoreDisplayModeKeyFormat = "displayMode.%@"
@@ -146,7 +147,8 @@ final class OEGameDocument: NSDocument {
     private(set) var displayModes: [[String: Any]] = []
     
     private var gameCoreManager: GameCoreManager?
-    
+    private var raCredentialObserver: Any?
+
     private var displaySleepAssertionID: IOPMAssertionID = 0
     
     private var emulationStatus: EmulationStatus = .notSetup
@@ -570,6 +572,11 @@ final class OEGameDocument: NSDocument {
                 SentryService.clearGameContext()
                 OEBindingsController.default.systemBindings(for: self.systemPlugin.controller).remove(self)
 
+                if let observer = self.raCredentialObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                    self.raCredentialObserver = nil
+                }
+
                 self.emulationStatus = .notSetup
                 
                 self.gameCoreManager = nil
@@ -641,7 +648,26 @@ final class OEGameDocument: NSDocument {
                 
                 self.gameCoreManager?.setHandleEvents(self.handleEvents)
                 self.gameCoreManager?.setHandleKeyboardEvents(self.handleKeyboardEvents)
-                
+
+                // Pass stored RA credentials so the core can log in at launch
+                let raUsername = UserDefaults.standard.string(forKey: "RAUsername")
+                let raToken    = RetroAchievementsCredentials.storedToken()
+                if let username = raUsername, let token = raToken {
+                    self.gameCoreManager?.setRetroAchievementsToken(token, username: username)
+                }
+
+                // Forward mid-session credential changes (e.g. user signs in while a game is running)
+                self.raCredentialObserver = NotificationCenter.default.addObserver(
+                    forName: .OERACredentialsDidChange,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] note in
+                    guard let self = self else { return }
+                    let token    = note.userInfo?[RACredentialsTokenKey]    as? String
+                    let username = note.userInfo?[RACredentialsUsernameKey] as? String
+                    self.gameCoreManager?.setRetroAchievementsToken(token, username: username)
+                }
+
                 handler(true, nil)
             }
         }, errorHandler: { error in
@@ -2036,6 +2062,30 @@ extension OEGameDocument: OESystemBindingsObserver {
         }
         coreDidTerminateSuddenly = true
         stopEmulation(self)
+    }
+
+    func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32) {
+        DispatchQueue.main.async {
+            // HUD overlay — respects the "Show notifications" user preference
+            self.gameViewController?.showAchievementUnlockedNotification()
+
+            // macOS system notification — visible even in full-screen
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body  = description
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: "ra.achievement.\(id)",
+                content: content,
+                trigger: nil
+            )
+
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                guard granted else { return }
+                UNUserNotificationCenter.current().add(request)
+            }
+        }
     }
 }
 

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -99,6 +99,12 @@ final class OEGameLayerNotificationView: NSImageView {
         performShowHideNotification(img: stepBackwardImage)
         postAccessibilityNotification(announcement: NSLocalizedString("Step Backward", tableName: "ControlLabels", comment: ""))
     }
+
+    @objc public func showAchievementUnlocked() {
+        let img = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: "Achievement Unlocked")
+        performShowHideNotification(img: img)
+        postAccessibilityNotification(announcement: NSLocalizedString("Achievement Unlocked", tableName: "ControlLabels", comment: ""))
+    }
     
     // MARK: - Animation
     

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -24,6 +24,106 @@
 
 import Cocoa
 
+// MARK: - Achievement Banner
+
+final class OEAchievementBannerView: NSView {
+
+    static let bannerWidth:  CGFloat = 310
+    static let bannerHeight: CGFloat = 66
+
+    private let headerLabel = NSTextField(labelWithString: "Achievement Unlocked!")
+    private let titleLabel  = NSTextField(labelWithString: "")
+    private let ptsLabel    = NSTextField(labelWithString: "")
+    private let iconView    = NSImageView()
+
+    private var hideWorkItem: DispatchWorkItem?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = 12
+        layer?.backgroundColor = NSColor(white: 0.08, alpha: 0.88).cgColor
+        alphaValue = 0
+
+        let iconConfig = NSImage.SymbolConfiguration(pointSize: 26, weight: .semibold)
+        iconView.image = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: nil)?
+            .withSymbolConfiguration(iconConfig)
+        iconView.contentTintColor = .systemYellow
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(iconView)
+
+        headerLabel.font = .systemFont(ofSize: 10, weight: .semibold)
+        headerLabel.textColor = .systemYellow
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(headerLabel)
+
+        titleLabel.font = .systemFont(ofSize: 13, weight: .bold)
+        titleLabel.textColor = .white
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+
+        ptsLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        ptsLabel.textColor = NSColor(white: 0.75, alpha: 1)
+        ptsLabel.alignment = .right
+        ptsLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(ptsLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 30),
+            iconView.heightAnchor.constraint(equalToConstant: 30),
+
+            ptsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            ptsLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            ptsLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 44),
+
+            headerLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 10),
+            headerLabel.trailingAnchor.constraint(lessThanOrEqualTo: ptsLabel.leadingAnchor, constant: -8),
+            headerLabel.topAnchor.constraint(equalTo: topAnchor, constant: 13),
+
+            titleLabel.leadingAnchor.constraint(equalTo: headerLabel.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: ptsLabel.leadingAnchor, constant: -8),
+            titleLabel.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: 3),
+        ])
+    }
+
+    func show(title: String, points: UInt32) {
+        titleLabel.stringValue = title
+        ptsLabel.stringValue   = points > 0 ? "+\(points) pts" : ""
+
+        hideWorkItem?.cancel()
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.3
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            animator().alphaValue = 1
+        }
+
+        let item = DispatchWorkItem { [weak self] in
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.5
+                ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
+                self?.animator().alphaValue = 0
+            }
+        }
+        hideWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5, execute: item)
+    }
+}
+
+// MARK: - HUD Icon Notification
+
 @IBDesignable
 final class OEGameLayerNotificationView: NSImageView {
     
@@ -101,7 +201,9 @@ final class OEGameLayerNotificationView: NSImageView {
     }
 
     @objc public func showAchievementUnlocked() {
-        let img = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: "Achievement Unlocked")
+        let config = NSImage.SymbolConfiguration(pointSize: 64, weight: .regular)
+        let img = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: "Achievement Unlocked")?
+            .withSymbolConfiguration(config)
         performShowHideNotification(img: img)
         postAccessibilityNotification(announcement: NSLocalizedString("Achievement Unlocked", tableName: "ControlLabels", comment: ""))
     }

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		FEB6627B187B812800D14713 /* Controller-Preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEB66278187B812800D14713 /* Controller-Preferences.plist */; };
 		FEB6627C187B812800D14713 /* Keyboard-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = FEB66279187B812800D14713 /* Keyboard-Mappings.plist */; };
 		OE0RC0BUILDFILE0000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0RC0FILEREF00000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1"; }; };
+		OE0RA0BUILDFILE0000000001 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0FILEREF00000000001 /* OERetroAchievementsTransport.m */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2087,6 +2088,8 @@
 		FEB66278187B812800D14713 /* Controller-Preferences.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Preferences.plist"; sourceTree = "<group>"; };
 		FEB66279187B812800D14713 /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
 		OE0RC0FILEREF00000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0RA0FILEREF00000000001 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0RA0FILEREF00000000002 /* OERetroAchievementsTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsTransport.h; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.h; sourceTree = SOURCE_ROOT; };
 		/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6337,6 +6340,7 @@
 			files = (
 				0572A40E2877F92300AC32F8 /* main.swift in Sources */,
 				OE0RC0BUILDFILE0000000001 /* rcheevos_build.c in Sources */,
+				OE0RA0BUILDFILE0000000001 /* OERetroAchievementsTransport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7686,6 +7690,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 					"$(SRCROOT)/../Vendor/rcheevos/include",
 					"$(SRCROOT)/../Vendor/rcheevos/src",
 				);
@@ -7722,6 +7727,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 					"$(SRCROOT)/../Vendor/rcheevos/include",
 					"$(SRCROOT)/../Vendor/rcheevos/src",
 				);

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 		CC0011223344556701900001 /* ScreenScraperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556601900001 /* ScreenScraperClient.swift */; };
 		CC0011223344556B01900001 /* LibretroThumbnailsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */; };
 		CC0011223344556901900001 /* PrefScreenScraperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556801900001 /* PrefScreenScraperController.swift */; };
+		OE0RA0APPBUILDFILE0000001 /* PrefRetroAchievementsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */; };
 		CC0011223344557101900001 /* ScreenScraperDevCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */; };
 		DEAAB8E598494A97A260F43C84A6B563 /* Dreamcast.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 87DF04FE1BCE2D100060E2C2 /* Dreamcast.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DFDDE95A9D47B0C0B525780A /* OESaveSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F74677D2124A2E934C10038 /* OESaveSyncManager.swift */; };
@@ -2068,6 +2069,7 @@
 		CC0011223344556601900001 /* ScreenScraperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScraperClient.swift; sourceTree = "<group>"; };
 		CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibretroThumbnailsClient.swift; sourceTree = "<group>"; };
 		CC0011223344556801900001 /* PrefScreenScraperController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefScreenScraperController.swift; sourceTree = "<group>"; };
+		OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefRetroAchievementsController.swift; sourceTree = "<group>"; };
 		CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScraperDevCredentials.swift; sourceTree = "<group>"; };
 		CC0011223344557201900001 /* ScreenScraperDevCredentials.template.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenScraperDevCredentials.template.swift; sourceTree = "<group>"; };
 		DBFF44DC2E9D79C700B30F0A /* OENESSystemResponderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OENESSystemResponderClient.h; sourceTree = "<group>"; };
@@ -3071,6 +3073,7 @@
 				01E2A2F223E60F7D00194150 /* PrefCoresController.swift */,
 				8F40EB7A1C1072B100683055 /* PrefCoresController.xib */,
 				CC0011223344556801900001 /* PrefScreenScraperController.swift */,
+				OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */,
 				CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */,
 				83495DD319A38F31009DB6E5 /* PrefBiosController.swift */,
 				83495DD719A38F3D009DB6E5 /* PrefBiosController.xib */,
@@ -6531,6 +6534,7 @@
 				CC0011223344556701900001 /* ScreenScraperClient.swift in Sources */,
 				CC0011223344556B01900001 /* LibretroThumbnailsClient.swift in Sources */,
 				CC0011223344556901900001 /* PrefScreenScraperController.swift in Sources */,
+				OE0RA0APPBUILDFILE0000001 /* PrefRetroAchievementsController.swift in Sources */,
 				CC0011223344557101900001 /* ScreenScraperDevCredentials.swift in Sources */,
 				8FBD79192736A17B00E455FC /* GameInfoHelper.swift in Sources */,
 				5A438A1B1D89AEB60061A47C /* OpenEmuApplication.swift in Sources */,

--- a/OpenEmu/PrefDebugController.swift
+++ b/OpenEmu/PrefDebugController.swift
@@ -68,6 +68,7 @@ final class PrefDebugController: NSViewController {
         
         Group(label: "HUD Bar / Gameplay"),
         Checkbox(key: OEGameLayerNotificationView.OEShowNotificationsKey, label: "Show notifications during gameplay"),
+        Button(label: "Preview achievement banner", action: #selector(previewAchievementBanner(_:))),
         Checkbox(key: OEDBSaveState.useQuickSaveSlotsKey, label: "Use quicksave slots"),
         Checkbox(key: GameControlsBar.showsQuickSaveStateKey, label: "Show quicksave in menu"),
         Checkbox(key: GameControlsBar.showsAutoSaveStateKey, label: "Show autosave in menu"),
@@ -390,6 +391,14 @@ final class PrefDebugController: NSViewController {
         UserDefaults.standard.set(color, forKey: sender.stringValue)
     }
     
+    // MARK: - HUD Bar / Gameplay
+
+    func previewAchievementBanner(_ sender: Any?) {
+        let docs = NSDocumentController.shared.documents.compactMap { $0 as? OEGameDocument }
+        guard let doc = docs.first else { return }
+        doc.achievementUnlocked(id: 0, title: "A New Quest", description: "Obtain the Broken Picori Blade", badgeURL: "", points: 10)
+    }
+
     // MARK: - Library Window
     
     func resetMainWindow(_ sender: Any?) {

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -352,19 +352,23 @@ private enum RetroAchievementsAPI {
         }
     }
 
-    /// POST login credentials and return the RA token on success.
+    /// GET login credentials and return the RA token on success.
     static func login(username: String, password: String,
                       completion: @escaping (Result<String, LoginError>) -> Void) {
-        guard let url = URL(string: "https://retroachievements.org/dorequest.php") else {
+        var components = URLComponents(string: "https://retroachievements.org/dorequest.php")!
+        components.queryItems = [
+            URLQueryItem(name: "r", value: "login2"),
+            URLQueryItem(name: "u", value: username),
+            URLQueryItem(name: "p", value: password),
+        ]
+        guard let url = components.url else {
             completion(.failure(.invalidResponse))
             return
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        let body = "r=login2&u=\(username.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? username)&p=\(password.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? password)"
-        request.httpBody = body.data(using: .utf8)
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpMethod = "GET"
+        request.setValue("OpenEmu-Silicon/1.0 (macOS)", forHTTPHeaderField: "User-Agent")
 
         URLSession.shared.dataTask(with: request) { data, _, error in
             if let error = error {

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -1,0 +1,389 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+import Security
+
+// MARK: - Notification
+
+extension Notification.Name {
+    /// Posted on the main thread after a successful RA sign-in or sign-out.
+    /// - `userInfo[RACredentialsTokenKey]`: `String` token (absent on sign-out)
+    /// - `userInfo[RACredentialsUsernameKey]`: `String` username (absent on sign-out)
+    static let OERACredentialsDidChange = Notification.Name("OERACredentialsDidChange")
+}
+
+let RACredentialsTokenKey    = "token"
+let RACredentialsUsernameKey = "username"
+
+// MARK: - Controller
+
+/// Preferences pane for RetroAchievements account credentials.
+final class PrefRetroAchievementsController: NSViewController {
+
+    // MARK: - UI Elements
+
+    private let headerLabel     = NSTextField(labelWithString: "")
+    private let descLabel       = NSTextField(wrappingLabelWithString: "")
+    private let usernameLabel   = NSTextField(labelWithString: "Username")
+    private let usernameField   = NSTextField()
+    private let passwordLabel   = NSTextField(labelWithString: "Password")
+    private let passwordField   = NSSecureTextField()
+    private let signInButton    = NSButton()
+    private let signOutButton   = NSButton()
+    private let statusLabel     = NSTextField(labelWithString: "")
+    private let registerLabel   = NSTextField(labelWithString: "")
+
+    // MARK: - Lifecycle
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 300))
+        buildUI()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        loadSavedCredentials()
+        updateStatus()
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        updateStatus()
+    }
+
+    // MARK: - Build UI
+
+    private func buildUI() {
+        headerLabel.stringValue = "Achievements"
+        headerLabel.font = .boldSystemFont(ofSize: 15)
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(headerLabel)
+
+        descLabel.stringValue = "Sign in to your RetroAchievements account to earn achievements while playing. Your password is used only to obtain a login token and is never stored on disk."
+        descLabel.font = .systemFont(ofSize: 12)
+        descLabel.textColor = .secondaryLabelColor
+        descLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(descLabel)
+
+        usernameLabel.font = .systemFont(ofSize: 13)
+        usernameLabel.alignment = .right
+        usernameLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(usernameLabel)
+
+        usernameField.placeholderString = "retroachievements.org username"
+        usernameField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(usernameField)
+
+        passwordLabel.font = .systemFont(ofSize: 13)
+        passwordLabel.alignment = .right
+        passwordLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(passwordLabel)
+
+        passwordField.placeholderString = "retroachievements.org password"
+        passwordField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(passwordField)
+
+        signInButton.title = "Sign In"
+        signInButton.bezelStyle = .rounded
+        signInButton.controlSize = .regular
+        signInButton.keyEquivalent = "\r"
+        signInButton.target = self
+        signInButton.action = #selector(signIn)
+        signInButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(signInButton)
+
+        signOutButton.title = "Sign Out"
+        signOutButton.bezelStyle = .rounded
+        signOutButton.controlSize = .regular
+        signOutButton.target = self
+        signOutButton.action = #selector(signOut)
+        signOutButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(signOutButton)
+
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(statusLabel)
+
+        registerLabel.stringValue = "Register at retroachievements.org — it's free."
+        registerLabel.font = .systemFont(ofSize: 11)
+        registerLabel.textColor = .tertiaryLabelColor
+        registerLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(registerLabel)
+
+        NSLayoutConstraint.activate([
+            headerLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
+            headerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            headerLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            descLabel.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: 10),
+            descLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            descLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            usernameLabel.topAnchor.constraint(equalTo: descLabel.bottomAnchor, constant: 28),
+            usernameLabel.trailingAnchor.constraint(equalTo: view.leadingAnchor, constant: 156),
+            usernameLabel.widthAnchor.constraint(equalToConstant: 80),
+
+            usernameField.centerYAnchor.constraint(equalTo: usernameLabel.centerYAnchor),
+            usernameField.leadingAnchor.constraint(equalTo: usernameLabel.trailingAnchor, constant: 8),
+            usernameField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            passwordLabel.topAnchor.constraint(equalTo: usernameField.bottomAnchor, constant: 12),
+            passwordLabel.trailingAnchor.constraint(equalTo: usernameLabel.trailingAnchor),
+            passwordLabel.widthAnchor.constraint(equalToConstant: 80),
+
+            passwordField.centerYAnchor.constraint(equalTo: passwordLabel.centerYAnchor),
+            passwordField.leadingAnchor.constraint(equalTo: passwordLabel.trailingAnchor, constant: 8),
+            passwordField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            signInButton.topAnchor.constraint(equalTo: passwordField.bottomAnchor, constant: 20),
+            signInButton.trailingAnchor.constraint(equalTo: passwordField.trailingAnchor),
+            signInButton.widthAnchor.constraint(equalToConstant: 80),
+
+            signOutButton.centerYAnchor.constraint(equalTo: signInButton.centerYAnchor),
+            signOutButton.trailingAnchor.constraint(equalTo: signInButton.leadingAnchor, constant: -8),
+            signOutButton.widthAnchor.constraint(equalToConstant: 80),
+
+            statusLabel.topAnchor.constraint(equalTo: signInButton.bottomAnchor, constant: 16),
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            registerLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 8),
+            registerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            registerLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+        ])
+    }
+
+    // MARK: - Credential Management
+
+    private func loadSavedCredentials() {
+        usernameField.stringValue = UserDefaults.standard.string(forKey: "RAUsername") ?? ""
+        if RetroAchievementsCredentials.hasStoredToken() {
+            passwordField.placeholderString = "••••••••  (saved)"
+        }
+    }
+
+    private func updateStatus() {
+        let username = UserDefaults.standard.string(forKey: "RAUsername") ?? ""
+        let isSignedIn = !username.isEmpty && RetroAchievementsCredentials.hasStoredToken()
+        if isSignedIn {
+            statusLabel.stringValue = "✓  Signed in as \(username)"
+            statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+            signInButton.isEnabled = false
+            signOutButton.isEnabled = true
+        } else {
+            statusLabel.stringValue = "Not signed in — achievements will not be tracked."
+            statusLabel.textColor = .secondaryLabelColor
+            signInButton.isEnabled = true
+            signOutButton.isEnabled = false
+        }
+    }
+
+    private func setStatus(_ message: String, isError: Bool) {
+        DispatchQueue.main.async {
+            self.statusLabel.stringValue = message
+            self.statusLabel.textColor = isError
+                ? NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
+                : NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+            self.signInButton.isEnabled = true
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func signIn() {
+        let username = usernameField.stringValue.trimmingCharacters(in: .whitespaces)
+        let password = passwordField.stringValue
+
+        guard !username.isEmpty else {
+            setStatus("Username cannot be empty.", isError: true)
+            return
+        }
+        guard !password.isEmpty else {
+            setStatus("Password cannot be empty.", isError: true)
+            return
+        }
+
+        signInButton.isEnabled = false
+        statusLabel.stringValue = "Signing in…"
+        statusLabel.textColor = .secondaryLabelColor
+
+        RetroAchievementsAPI.login(username: username, password: password) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let token):
+                RetroAchievementsCredentials.storeToken(token)
+                UserDefaults.standard.set(username, forKey: "RAUsername")
+                self.passwordField.stringValue = ""
+                self.passwordField.placeholderString = "••••••••  (saved)"
+                self.setStatus("✓  Signed in as \(username)", isError: false)
+                self.signOutButton.isEnabled = true
+                // Notify any running game sessions so they can log in mid-session
+                NotificationCenter.default.post(
+                    name: .OERACredentialsDidChange,
+                    object: nil,
+                    userInfo: [RACredentialsTokenKey: token, RACredentialsUsernameKey: username]
+                )
+            case .failure(let error):
+                self.setStatus(error.localizedDescription, isError: true)
+            }
+        }
+    }
+
+    @objc private func signOut() {
+        UserDefaults.standard.removeObject(forKey: "RAUsername")
+        RetroAchievementsCredentials.deleteToken()
+        usernameField.stringValue = ""
+        passwordField.stringValue = ""
+        passwordField.placeholderString = "retroachievements.org password"
+        updateStatus()
+        NotificationCenter.default.post(name: .OERACredentialsDidChange, object: nil)
+    }
+}
+
+// MARK: - PreferencePane
+
+extension PrefRetroAchievementsController: PreferencePane {
+
+    var icon: NSImage? {
+        if #available(macOS 11.0, *) {
+            return NSImage(systemSymbolName: "trophy", accessibilityDescription: "Achievements")
+        }
+        return nil
+    }
+
+    var panelTitle: String { "Achievements" }
+
+    var viewSize: NSSize { NSSize(width: 468, height: 300) }
+}
+
+// MARK: - Keychain Helper
+
+/// Thin wrapper around SecItem for RetroAchievements token storage.
+/// Stores the login token (not the password — the password is used only once to obtain the token).
+enum RetroAchievementsCredentials {
+
+    private static let service = "com.openemu.RetroAchievements"
+    private static let account = "token"
+
+    static func storedToken() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass:       kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecReturnData:  kCFBooleanTrue!,
+            kSecMatchLimit:  kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func hasStoredToken() -> Bool {
+        return storedToken() != nil
+    }
+
+    static func storeToken(_ token: String) {
+        let deleteQuery: [CFString: Any] = [
+            kSecClass:       kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        guard let data = token.data(using: .utf8) else { return }
+        let addQuery: [CFString: Any] = [
+            kSecClass:          kSecClassGenericPassword,
+            kSecAttrService:    service,
+            kSecAttrAccount:    account,
+            kSecValueData:      data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    static func deleteToken() {
+        let query: [CFString: Any] = [
+            kSecClass:       kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+// MARK: - RA API
+
+private enum RetroAchievementsAPI {
+
+    enum LoginError: LocalizedError {
+        case networkError(Error)
+        case invalidResponse
+        case authFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .networkError(let e): return "Network error: \(e.localizedDescription)"
+            case .invalidResponse:     return "Unexpected response from RetroAchievements."
+            case .authFailed(let msg): return msg
+            }
+        }
+    }
+
+    /// POST login credentials and return the RA token on success.
+    static func login(username: String, password: String,
+                      completion: @escaping (Result<String, LoginError>) -> Void) {
+        guard let url = URL(string: "https://retroachievements.org/dorequest.php") else {
+            completion(.failure(.invalidResponse))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let body = "r=login2&u=\(username.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? username)&p=\(password.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? password)"
+        request.httpBody = body.data(using: .utf8)
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            if let error = error {
+                DispatchQueue.main.async { completion(.failure(.networkError(error))) }
+                return
+            }
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                DispatchQueue.main.async { completion(.failure(.invalidResponse)) }
+                return
+            }
+
+            if let token = json["Token"] as? String, !token.isEmpty {
+                DispatchQueue.main.async { completion(.success(token)) }
+            } else {
+                let message = (json["Error"] as? String) ?? "Login failed. Check username and password."
+                DispatchQueue.main.async { completion(.failure(.authFailed(message))) }
+            }
+        }.resume()
+    }
+}

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -370,11 +370,13 @@ private enum RetroAchievementsAPI {
         request.httpMethod = "GET"
         request.setValue("OpenEmu-Silicon/1.0 (macOS)", forHTTPHeaderField: "User-Agent")
 
-        URLSession.shared.dataTask(with: request) { data, _, error in
+        URLSession.shared.dataTask(with: request) { data, response, error in
             if let error = error {
+                NSLog("[RA] Network error: %@", error.localizedDescription)
                 DispatchQueue.main.async { completion(.failure(.networkError(error))) }
                 return
             }
+            if let raw = data { NSLog("[RA] Raw response: %@", String(data: raw, encoding: .utf8) ?? "<non-utf8>") }
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else {
@@ -386,6 +388,7 @@ private enum RetroAchievementsAPI {
                 DispatchQueue.main.async { completion(.success(token)) }
             } else {
                 let message = (json["Error"] as? String) ?? "Login failed. Check username and password."
+                NSLog("[RA] Auth failed: %@", message)
                 DispatchQueue.main.async { completion(.failure(.authFailed(message))) }
             }
         }.resume()

--- a/OpenEmu/PreferencesWindowController.swift
+++ b/OpenEmu/PreferencesWindowController.swift
@@ -169,7 +169,8 @@ final class PreferencesTabViewController: NSTabViewController {
             PrefCoresController(),
             PrefBiosController(),
             PrefCloudSyncController(),
-            PrefScreenScraperController()
+            PrefScreenScraperController(),
+            PrefRetroAchievementsController()
         ]
         
         // Check if the debug pane should be included.

--- a/OpenEmuKit/OpenEmuKit.xcodeproj/project.pbxproj
+++ b/OpenEmuKit/OpenEmuKit.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		05EEF1082707D2ED008A03DC /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 05EEF1072707D2ED008A03DC /* Nimble */; };
 		8F3A1837285C9F88008A7AC9 /* NSBundle+CacheFlushing.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F3A1836285C9F0E008A7AC9 /* NSBundle+CacheFlushing.m */; };
 		DD75EE5D298976C60056B3BA /* MTL3DGameRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75EE5C298976C60056B3BA /* MTL3DGameRenderer.swift */; };
+		OE0RA0KITBUILDFILE000000001 /* OERetroAchievementsConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0KITFILEREF000000001 /* OERetroAchievementsConstants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -195,6 +196,7 @@
 		8F3A1836285C9F0E008A7AC9 /* NSBundle+CacheFlushing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+CacheFlushing.m"; sourceTree = "<group>"; };
 		8F4AEABF27354776005C6246 /* NSBundle+CacheFlushing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+CacheFlushing.h"; sourceTree = "<group>"; };
 		DD75EE5C298976C60056B3BA /* MTL3DGameRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTL3DGameRenderer.swift; sourceTree = "<group>"; };
+		OE0RA0KITFILEREF000000001 /* OERetroAchievementsConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OERetroAchievementsConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -373,6 +375,7 @@
 				0572A427287BAF9300AC32F8 /* OEGameCoreHelper.swift */,
 				0572A425287B969500AC32F8 /* OEGameCoreOwner.swift */,
 				0572A429287BB0B000AC32F8 /* OEXPCGameCoreHelper.swift */,
+				OE0RA0KITFILEREF000000001 /* OERetroAchievementsConstants.swift */,
 			);
 			name = "Game Core Helper Protocols";
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 				05ED1CF9259D1FB200A2D400 /* FileManager+ExtendedAttributes.swift in Sources */,
 				05B0781927371B2200F1E302 /* GameAudio.swift in Sources */,
 				0518D6E824F32DD10037101D /* NSEvent+Combine.swift in Sources */,
+				OE0RA0KITBUILDFILE000000001 /* OERetroAchievementsConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmuKit/Source/GameCoreManager.swift
+++ b/OpenEmuKit/Source/GameCoreManager.swift
@@ -224,6 +224,10 @@ extension GameCoreManager: OEGameCoreHelper {
     public func systemBindingsDidUnsetEvent(_ event: OEHIDEvent, forBinding bindingDescription: OEBindingDescription, playerNumber: UInt) {
         gameCoreHelper?.systemBindingsDidUnsetEvent(event, forBinding: bindingDescription, playerNumber: playerNumber)
     }
+
+    public func setRetroAchievementsToken(_ token: String?, username: String?) {
+        gameCoreHelper?.setRetroAchievementsToken(token, username: username)
+    }
 }
 
 // MARK: - Synchronous image capture APIs

--- a/OpenEmuKit/Source/OEGameCoreHelper.swift
+++ b/OpenEmuKit/Source/OEGameCoreHelper.swift
@@ -90,4 +90,15 @@ import AudioToolbox
     
     /// Capture an image of the core's raw video display buffer with no effects.
     func captureSourceImage(completionHandler block: @escaping (NSBitmapImageRep) -> Void)
+
+    /// Pass stored RetroAchievements credentials to the helper process.
+    ///
+    /// The helper posts a notification received by active cores, which call
+    /// `rc_client_begin_login_with_token` to link to the player's RA account.
+    /// Pass `nil` for both parameters to log out.
+    ///
+    /// - Parameters:
+    ///   - token: The stored RA token, or `nil` to log out.
+    ///   - username: The RA username associated with the token.
+    func setRetroAchievementsToken(_ token: String?, username: String?)
 }

--- a/OpenEmuKit/Source/OEGameCoreOwner.swift
+++ b/OpenEmuKit/Source/OEGameCoreOwner.swift
@@ -73,4 +73,17 @@ public typealias OEContextID = UInt32
     /// when the core manager is deallocated right after the game core is
     /// stopped).
     @objc optional func gameCoreDidTerminate()
+
+    /// Invoked by the helper process when an achievement is earned.
+    ///
+    /// Called on whatever thread the XPC message arrives on; implementations
+    /// should dispatch to the main thread before updating the UI.
+    ///
+    /// - Parameters:
+    ///   - id: The RetroAchievements achievement ID
+    ///   - title: Display name of the achievement
+    ///   - description: Description text shown in the notification
+    ///   - badgeURL: URL string for the achievement badge image
+    ///   - points: Points value of the achievement
+    @objc optional func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32)
 }

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+/// Posted by `OpenEmuHelperApp` when the RA token changes.
+/// - `userInfo[OERetroAchievementsTokenKey]`: the new token `String`, or absent when logging out.
+public extension Notification.Name {
+    static let OERetroAchievementsTokenDidChange = Notification.Name("OERetroAchievementsTokenDidChange")
+}
+
+/// Keys in the `OERetroAchievementsTokenDidChange` notification's `userInfo` dictionary.
+public let OERetroAchievementsTokenKey    = "token"
+public let OERetroAchievementsUsernameKey = "username"
+
+/// Posted by a core plugin when an achievement is earned.
+public extension Notification.Name {
+    static let OEAchievementUnlocked = Notification.Name("OEAchievementUnlocked")
+}
+
+/// Keys in the `OEAchievementUnlocked` notification's `userInfo` dictionary.
+public let OEAchievementIDKey          = "id"
+public let OEAchievementTitleKey       = "title"
+public let OEAchievementDescriptionKey = "description"
+public let OEAchievementBadgeURLKey    = "badgeURL"
+public let OEAchievementPointsKey      = "points"

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -28,6 +28,24 @@
 
 #include <rc_client.h>
 
+/// NSNotificationCenter name posted by OpenEmuHelperApp when the RA token changes.
+/// userInfo keys: `OERetroAchievementsTokenKey` (NSString token) and
+/// `OERetroAchievementsUsernameKey` (NSString username), or absent on logout.
+#define OERetroAchievementsTokenDidChangeNotification @"OERetroAchievementsTokenDidChange"
+#define OERetroAchievementsTokenKey                   @"token"
+#define OERetroAchievementsUsernameKey                @"username"
+
+/// NSNotificationCenter name posted by a core plugin when an achievement is unlocked.
+/// userInfo keys: `OEAchievementIDKey` (NSNumber UInt32), `OEAchievementTitleKey` (NSString),
+/// `OEAchievementDescriptionKey` (NSString), `OEAchievementBadgeURLKey` (NSString),
+/// `OEAchievementPointsKey` (NSNumber UInt32).
+#define OEAchievementUnlockedNotification   @"OEAchievementUnlocked"
+#define OEAchievementIDKey                  @"id"
+#define OEAchievementTitleKey               @"title"
+#define OEAchievementDescriptionKey         @"description"
+#define OEAchievementBadgeURLKey            @"badgeURL"
+#define OEAchievementPointsKey              @"points"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef OERetroAchievementsTransport_h
+#define OERetroAchievementsTransport_h
+
+#include <rc_client.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * rc_client_server_call_t implementation that bridges rcheevos HTTP requests
+ * to NSURLSession. Pass this function as the second argument to rc_client_create.
+ */
+void oeRetroAchievementsServerCall(const rc_api_request_t *request,
+                                    rc_client_server_callback_t callback,
+                                    void *callback_data,
+                                    rc_client_t *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OERetroAchievementsTransport_h */

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import <rc_client.h>
+
+// Bridge a rcheevos HTTP request to NSURLSession.
+// This function is passed as the `server_call_function` argument to rc_client_create.
+// It must be called from any thread; NSURLSession dispatches its completion handler
+// on an internal queue and we forward straight to the rcheevos callback from there.
+void oeRetroAchievementsServerCall(const rc_api_request_t *request,
+                                    rc_client_server_callback_t callback,
+                                    void *callback_data,
+                                    rc_client_t *client)
+{
+    NSString *urlString = [NSString stringWithUTF8String:request->url];
+    NSURL    *url       = [NSURL URLWithString:urlString];
+    if (!url) {
+        rc_api_server_response_t error_response = {
+            .body            = "",
+            .body_length     = 0,
+            .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR
+        };
+        callback(&error_response, callback_data);
+        return;
+    }
+
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+
+    if (request->post_data) {
+        urlRequest.HTTPMethod = @"POST";
+        urlRequest.HTTPBody   = [NSData dataWithBytes:request->post_data
+                                               length:strlen(request->post_data)];
+        if (request->content_type) {
+            [urlRequest setValue:[NSString stringWithUTF8String:request->content_type]
+              forHTTPHeaderField:@"Content-Type"];
+        } else {
+            [urlRequest setValue:@"application/x-www-form-urlencoded"
+              forHTTPHeaderField:@"Content-Type"];
+        }
+    } else {
+        urlRequest.HTTPMethod = @"GET";
+    }
+
+    NSURLSessionDataTask *task =
+        [[NSURLSession sharedSession]
+            dataTaskWithRequest:urlRequest
+              completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (error || !data) {
+                rc_api_server_response_t err = {
+                    .body             = error ? error.localizedDescription.UTF8String : "",
+                    .body_length      = 0,
+                    .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR
+                };
+                callback(&err, callback_data);
+                return;
+            }
+
+            NSHTTPURLResponse *http = (NSHTTPURLResponse *)response;
+            rc_api_server_response_t server_response = {
+                .body             = (const char *)data.bytes,
+                .body_length      = data.length,
+                .http_status_code = (int)http.statusCode
+            };
+            callback(&server_response, callback_data);
+        }];
+
+    [task resume];
+}

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -49,6 +49,11 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
 
     NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
 
+    char rcClause[64] = {0};
+    rc_client_get_user_agent_clause(client, rcClause, sizeof(rcClause));
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu %@", [NSString stringWithUTF8String:rcClause]];
+    [urlRequest setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
     if (request->post_data) {
         urlRequest.HTTPMethod = @"POST";
         urlRequest.HTTPBody   = [NSData dataWithBytes:request->post_data

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -310,7 +310,6 @@ extension OSLog {
             if let displayModes = gameCore.displayModes {
                 gameCoreOwner.setDisplayModes(displayModes)
             }
-            
             loadedRom = true
         } catch {
             gameCore = nil

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -89,7 +89,14 @@ extension OSLog {
     var _handleKeyboardEvents: Bool = false
     
     var loadedRom = false
-    
+
+    // RetroAchievements token received from the main app via XPC.
+    // Stored here so the core can pick it up at load time and on mid-session token delivery.
+    var _retroAchievementsToken: String?
+
+    // Observer for achievement unlock notifications posted by the active core plugin.
+    var _achievementObserver: Any?
+
     // frame rate debugging
     var previous    = CFTimeInterval()
     var frameRate   = CFTimeInterval()
@@ -315,6 +322,27 @@ extension OSLog {
                                         NSUnderlyingErrorKey: error
                                        ])
         }
+
+        _achievementObserver = NotificationCenter.default.addObserver(
+            forName: .OEAchievementUnlocked,
+            object: nil,
+            queue: nil
+        ) { [weak self] note in
+            guard let self = self,
+                  let owner = self.gameCoreOwner,
+                  let info = note.userInfo,
+                  let idNum     = info[OEAchievementIDKey]          as? NSNumber,
+                  let title     = info[OEAchievementTitleKey]        as? String,
+                  let desc      = info[OEAchievementDescriptionKey]  as? String,
+                  let badge     = info[OEAchievementBadgeURLKey]     as? String,
+                  let ptsNum    = info[OEAchievementPointsKey]       as? NSNumber
+            else { return }
+            owner.achievementUnlocked?(id: idNum.uint32Value,
+                                        title: title,
+                                        description: desc,
+                                        badgeURL: badge,
+                                        points: ptsNum.uint32Value)
+        }
     }
     
     // MARK: - OEGameCoreOwner subclass handles
@@ -434,7 +462,12 @@ extension OSLog {
     
     public func stopEmulation(completionHandler handler: @escaping () -> Void) {
         guard let gameCore = gameCore else { return }
-        
+
+        if let observer = _achievementObserver {
+            NotificationCenter.default.removeObserver(observer)
+            _achievementObserver = nil
+        }
+
         gameCore.stopEmulation {
             self._gameAudio.stopAudio()
             gameCore.renderDelegate = nil
@@ -445,6 +478,20 @@ extension OSLog {
             
             handler()
         }
+    }
+
+    public func setRetroAchievementsToken(_ token: String?, username: String?) {
+        _retroAchievementsToken = token
+        var userInfo: [String: Any]? = nil
+        if let token = token, let username = username {
+            userInfo = [OERetroAchievementsTokenKey: token,
+                        OERetroAchievementsUsernameKey: username]
+        }
+        NotificationCenter.default.post(
+            name: .OERetroAchievementsTokenDidChange,
+            object: nil,
+            userInfo: userInfo
+        )
     }
     
     public func saveStateToFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void) {

--- a/mGBA/mGBA.xcodeproj/project.pbxproj
+++ b/mGBA/mGBA.xcodeproj/project.pbxproj
@@ -275,8 +275,8 @@
 		8D5B49B7048680CD000E48DA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94AE2EF917B0C1330018DFBB /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
-		OE0MGBA0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
-		OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0MGBA0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -862,9 +862,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/include\"",
-					"$(SRCROOT)/../../Vendor/rcheevos/include",
-					"$(SRCROOT)/../../Vendor/rcheevos/src",
-					"$(SRCROOT)/../../OpenEmuKit/Source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
@@ -901,9 +901,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/include\"",
-					"$(SRCROOT)/../../Vendor/rcheevos/include",
-					"$(SRCROOT)/../../Vendor/rcheevos/src",
-					"$(SRCROOT)/../../OpenEmuKit/Source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";

--- a/mGBA/mGBA.xcodeproj/project.pbxproj
+++ b/mGBA/mGBA.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		8D5B49B0048680CD000E48DA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C167DFE841241C02AAC07 /* InfoPlist.strings */; };
 		8D5B49B4048680CD000E48DA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7ADFEA557BF11CA2CBB /* Cocoa.framework */; };
 		94AE2EFA17B0C1330018DFBB /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94AE2EF917B0C1330018DFBB /* OpenEmuBase.framework */; };
+		OE0MGBA0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0MGBA0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0MGBA0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -273,6 +275,8 @@
 		8D5B49B7048680CD000E48DA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94AE2EF917B0C1330018DFBB /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		OE0MGBA0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -815,6 +819,8 @@
 				8701D7191D19E79D00E8A7D8 /* vfs-mem.c in Sources */,
 				8701D7181D19E75700E8A7D8 /* vfs.c in Sources */,
 				87D380E01D92536600FC657D /* audio.c in Sources */,
+				OE0MGBA0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0MGBA0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -856,6 +862,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/include\"",
+					"$(SRCROOT)/../../Vendor/rcheevos/include",
+					"$(SRCROOT)/../../Vendor/rcheevos/src",
+					"$(SRCROOT)/../../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
@@ -892,6 +901,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/include\"",
+					"$(SRCROOT)/../../Vendor/rcheevos/include",
+					"$(SRCROOT)/../../Vendor/rcheevos/src",
+					"$(SRCROOT)/../../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -24,6 +24,7 @@
 
 #import "mGBAGameCore.h"
 
+
 #include <mgba-util/common.h>
 
 #include <mgba/core/blip_buf.h>
@@ -43,6 +44,7 @@
 
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
+#include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
 
 #define SAMPLES 1024
@@ -62,17 +64,55 @@ const char* projectVersion;
 	NSMutableDictionary *cheatSets;
 	rc_client_t *_rcClient;
     id _raTokenObserver;
+    NSString *_romPath;
 }
+- (struct mCore *)mCore;
+- (void)_beginLoadGame;
 @end
+
+// rcheevos GBA address space → hardware bus address:
+//   0x000000–0x007FFF  →  IWRAM  0x03000000
+//   0x008000–0x047FFF  →  EWRAM  0x02000000
+//   0x048000–0x057FFF  →  SRAM   0x0E000000
+static uint32_t gba_rc_to_hw(uint32_t addr) {
+    if (addr < 0x008000) return 0x03000000 + addr;
+    if (addr < 0x048000) return 0x02000000 + (addr - 0x008000);
+    if (addr < 0x058000) return 0x0E000000 + (addr - 0x048000);
+    return addr;
+}
 
 static uint32_t mGBA_rc_read_memory(uint32_t address, uint8_t *buffer,
                                      uint32_t num_bytes, rc_client_t *client)
 {
     mGBAGameCore *c = (__bridge mGBAGameCore *)rc_client_get_userdata(client);
+    struct mCore *mcore = [c mCore];
+    if (!mcore) { return 0; }
     for (uint32_t i = 0; i < num_bytes; i++) {
-        buffer[i] = c->core->busRead8(c->core, address + i);
+        buffer[i] = mcore->busRead8(mcore, gba_rc_to_hw(address + i));
     }
     return num_bytes;
+}
+
+
+static void mGBA_rc_load_game_callback(int result, const char *error_message,
+                                        rc_client_t *client, void *userdata)
+{
+    mGBAGameCore *self = (__bridge mGBAGameCore *)userdata;
+    if (result != RC_OK) {
+        NSLog(@"[RA-mGBA] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+    (void)self;
+}
+
+static void mGBA_rc_login_callback(int result, const char *error_message,
+                                    rc_client_t *client, void *userdata)
+{
+    mGBAGameCore *self = (__bridge mGBAGameCore *)userdata;
+    if (result == RC_OK) {
+        [self _beginLoadGame];
+    } else {
+        NSLog(@"[RA-mGBA] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
 }
 
 static void mGBA_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
@@ -110,6 +150,20 @@ static void _log(struct mLogger* log,
 static struct mLogger logger = { .log = _log };
 
 @implementation mGBAGameCore
+
+- (struct mCore *)mCore { return core; }
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           RC_CONSOLE_GAMEBOY_ADVANCE,
+                                           [_romPath fileSystemRepresentation],
+                                           NULL, 0,
+                                           mGBA_rc_load_game_callback,
+                                           (__bridge void *)self);
+}
+
 
 - (id)init
 {
@@ -152,6 +206,7 @@ static struct mLogger logger = { .log = _log };
 
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError **)error
 {
+    RALog(@"[RA-mGBA] loadFileAtPath entered: %@", path);
     projectVersion = [self.owner.bundle.infoDictionary[@"CFBundleVersion"] UTF8String];
 
 	NSString *batterySavesDirectory = [self batterySavesDirectoryPath];
@@ -176,14 +231,14 @@ static struct mLogger logger = { .log = _log };
 
     _rcClient = rc_client_create(mGBA_rc_read_memory, oeRetroAchievementsServerCall);
     if (_rcClient) {
+        _romPath = path;
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
-        rc_client_begin_identify_and_load_game(_rcClient,
-                                               RC_CONSOLE_GAMEBOY_ADVANCE,
-                                               [path fileSystemRepresentation],
-                                               NULL, 0,
-                                               NULL, NULL);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
 
+        // Register token observer before game identification so we don't miss
+        // the notification that fires immediately after setRetroAchievementsToken.
+        // Login happens first; game identification runs in the login callback.
         __weak mGBAGameCore *weakSelf = self;
         _raTokenObserver = [[NSNotificationCenter defaultCenter]
             addObserverForName:OERetroAchievementsTokenDidChangeNotification
@@ -198,7 +253,8 @@ static struct mLogger logger = { .log = _log };
                 rc_client_begin_login_with_token(s->_rcClient,
                                                  username.UTF8String,
                                                  token.UTF8String,
-                                                 NULL, NULL);
+                                                 mGBA_rc_login_callback,
+                                                 (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
             }
@@ -359,8 +415,12 @@ static struct mLogger logger = { .log = _log };
 - (void)loadStateFromFileAtPath:(NSString *)fileName completionHandler:(void (^)(BOOL, NSError *))block
 {
 	struct VFile* vf = VFileOpen([fileName fileSystemRepresentation], O_RDONLY);
-	block(mCoreLoadStateNamed(core, vf, 0), nil);
+	BOOL ok = mCoreLoadStateNamed(core, vf, 0);
 	vf->close(vf);
+	if (ok && _rcClient) {
+		rc_client_reset(_rcClient);
+	}
+	block(ok, nil);
 }
 
 #pragma mark - Input

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -41,6 +41,10 @@
 #import "OEGBASystemResponderClient.h"
 #import <OpenGL/gl.h>
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#import "OERetroAchievementsTransport.h"
+
 #define SAMPLES 1024
 
 #ifdef DEBUG
@@ -56,8 +60,19 @@ const char* projectVersion;
 	struct mCore* core;
 	void* outputBuffer;
 	NSMutableDictionary *cheatSets;
+	rc_client_t *_rcClient;
 }
 @end
+
+static uint32_t mGBA_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                     uint32_t num_bytes, rc_client_t *client)
+{
+    mGBAGameCore *c = (__bridge mGBAGameCore *)rc_client_get_userdata(client);
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        buffer[i] = c->core->busRead8(c->core, address + i);
+    }
+    return num_bytes;
+}
 
 static void _log(struct mLogger* log,
                  int category,
@@ -132,12 +147,27 @@ static struct mLogger logger = { .log = _log };
 	mCoreAutoloadSave(core);
 
 	core->reset(core);
+
+    _rcClient = rc_client_create(mGBA_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_begin_identify_and_load_game(_rcClient,
+                                               RC_CONSOLE_GAMEBOY_ADVANCE,
+                                               [path fileSystemRepresentation],
+                                               NULL, 0,
+                                               NULL, NULL);
+    }
+
 	return YES;
 }
 
 - (void)executeFrame
 {
 	core->runFrame(core);
+
+	if (_rcClient) {
+        rc_client_do_frame(_rcClient);
+    }
 
 	int16_t samples[SAMPLES * 2];
 	size_t available = 0;
@@ -147,8 +177,21 @@ static struct mLogger logger = { .log = _log };
 	[[self audioBufferAtIndex:0] write:samples maxLength:available * 4];
 }
 
+- (void)stopEmulation
+{
+	if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
+    [super stopEmulation];
+}
+
 - (void)resetEmulation
 {
+	if (_rcClient) {
+        rc_client_reset(_rcClient);
+    }
 	core->reset(core);
 }
 

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -61,6 +61,7 @@ const char* projectVersion;
 	void* outputBuffer;
 	NSMutableDictionary *cheatSets;
 	rc_client_t *_rcClient;
+    id _raTokenObserver;
 }
 @end
 
@@ -72,6 +73,31 @@ static uint32_t mGBA_rc_read_memory(uint32_t address, uint8_t *buffer,
         buffer[i] = c->core->busRead8(c->core, address + i);
     }
     return num_bytes;
+}
+
+static void mGBA_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSString *title       = [NSString stringWithUTF8String:ach->title       ?: ""];
+    NSString *desc        = [NSString stringWithUTF8String:ach->description  ?: ""];
+    NSString *badge       = [NSString stringWithUTF8String:ach->badge_name   ?: ""];
+    NSNumber *achId       = @(ach->id);
+    NSNumber *points      = @(ach->points);
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          achId,
+        OEAchievementTitleKey:       title,
+        OEAchievementDescriptionKey: desc,
+        OEAchievementBadgeURLKey:    badge,
+        OEAchievementPointsKey:      points,
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
 }
 
 static void _log(struct mLogger* log,
@@ -151,11 +177,32 @@ static struct mLogger logger = { .log = _log };
     _rcClient = rc_client_create(mGBA_rc_read_memory, oeRetroAchievementsServerCall);
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
         rc_client_begin_identify_and_load_game(_rcClient,
                                                RC_CONSOLE_GAMEBOY_ADVANCE,
                                                [path fileSystemRepresentation],
                                                NULL, 0,
                                                NULL, NULL);
+
+        __weak mGBAGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            mGBAGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 NULL, NULL);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
     }
 
 	return YES;
@@ -179,6 +226,10 @@ static struct mLogger logger = { .log = _log };
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
 	if (_rcClient) {
         rc_client_unload_game(_rcClient);
         rc_client_destroy(_rcClient);


### PR DESCRIPTION
## Summary

- Vendors the rcheevos HTTP transport layer (\`OERetroAchievementsTransport.m\`) and wires it into both the Helper and mGBA build targets
- Integrates \`rc_client\` into \`mGBAGameCore\` — memory read callback, per-frame evaluation (\`rc_client_do_frame\`), login, and teardown on stop/reset
- Extends the XPC protocol layer: \`setRetroAchievementsToken(_:username:)\` on \`OEGameCoreHelper\` (main → helper), \`achievementUnlocked(...)\` on \`OEGameCoreOwner\` (helper → main)
- Adds **Preferences → Achievements** pane with RA login, token keychain storage, and mid-session credential propagation
- On achievement unlock: shows **in-app banner overlay** (OEAchievementBannerView) bottom-center of the game window with title and points, plus a \`UNUserNotificationCenter\` system notification as a secondary channel
- Adds **Preferences → Secrets → "Preview achievement banner"** button for testing the overlay without earning a real achievement

## Architecture

\`\`\`
Preferences pane
  └── signs in via RA API → stores token in Keychain
  └── posts OERACredentialsDidChange

OEGameDocument (on ROM load + on OERACredentialsDidChange)
  └── gameCoreManager.setRetroAchievementsToken(_:username:)
      └── XPC → OpenEmuHelperApp.setRetroAchievementsToken
          └── posts OERetroAchievementsTokenDidChange

mGBAGameCore (observes OERetroAchievementsTokenDidChange)
  └── rc_client_begin_login_with_token
  └── rc_client_do_frame (every executeFrame)
  └── mGBA_rc_event_handler → posts OEAchievementUnlocked

OpenEmuHelperApp (observes OEAchievementUnlocked)
  └── gameCoreOwner.achievementUnlocked(...)
      └── XPC → OEGameDocument.achievementUnlocked
          └── OEAchievementBannerView (in-game overlay) + UNUserNotificationCenter
\`\`\`

## How to test locally

\`\`\`bash
gh pr checkout 246 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
\`\`\`

**Setup:**
1. Open Preferences → Achievements
2. Sign in with a real RetroAchievements account (free at retroachievements.org)
3. Load a GBA ROM with RA achievements (Pokémon, Zelda: Minish Cap, etc.)

**Behaviors to verify:**
- [x] Preferences → Achievements pane appears in the toolbar
- [x] Sign In with valid credentials shows "✓ Signed in as \<username\>"
- [x] Quit and relaunch — username still shown (token persisted in Keychain)
- [x] Sign Out clears credentials
- [x] Sign In with wrong credentials shows an error message
- [x] Load a GBA ROM — no crash, emulation starts normally
- [x] Trigger an achievement — in-app banner appears bottom-center with title and points
- [x] macOS notification appears in Notification Center with achievement name and description
- [x] Stop emulation — no crash
- [x] Banner preview: enable debug mode (\`defaults write org.openemu.OpenEmu debug -bool YES\`), open Preferences → Secrets, click "Preview achievement banner" while a game is running

Closes #207, #208, #209, #211. Part of #96.