### PR TITLE
feat: RetroAchievements — GenesisPlus (Genesis, SMS, GG, SG-1000, Sega CD)

### DIFF
--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -35,6 +35,11 @@
 
 #include "shared.h"
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
+
 #define OptionDefault(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @YES, }
 #define Option(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @NO, }
 #define OptionIndented(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @NO, OEGameCoreDisplayModeIndentationLevelKey : @(1), }
@@ -115,16 +120,98 @@ typedef NS_ENUM(NSInteger, MultiTapType)
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
     NSURL *_romFile;
     MultiTapType _multiTapType;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    int _rcConsole;
 }
 - (void)applyCheat:(NSString *)code;
 - (void)resetCheats;
 - (void)configureOptions;
 - (void)configureInput;
+- (void)_beginLoadGame;
 @end
+
+// rcheevos memory callback — dispatches on system_hw to serve the correct RAM region.
+// Genesis/CD: 68K work RAM at 0xFF0000–0xFFFFFF; Z80 RAM at 0xA00000–0xA01FFF.
+// SMS/GG/SG: 8 KB work RAM at 0xC000–0xDFFF.
+static uint32_t genplus_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                        uint32_t num_bytes, rc_client_t *client)
+{
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if ((system_hw & SYSTEM_PBC) == SYSTEM_MD || system_hw == SYSTEM_MCD) {
+            if (addr >= 0xFF0000 && addr <= 0xFFFFFF)
+                buffer[i] = work_ram[addr & 0xFFFF];
+            else if (addr >= 0xA00000 && addr <= 0xA01FFF)
+                buffer[i] = zram[addr - 0xA00000];
+            else
+                return i;
+        } else {
+            if (addr >= 0xC000 && addr <= 0xDFFF)
+                buffer[i] = work_ram[addr & 0x1FFF];
+            else
+                return i;
+        }
+    }
+    return num_bytes;
+}
+
+static void genplus_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void genplus_rc_load_game_callback(int result, const char *error_message,
+                                           rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-GenPlus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void genplus_rc_login_callback(int result, const char *error_message,
+                                       rc_client_t *client, void *userdata)
+{
+    GenPlusGameCore *s = (__bridge GenPlusGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-GenPlus] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void genplus_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
 
 @implementation GenPlusGameCore
 
 static __weak GenPlusGameCore *_current;
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romFile) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           (uint32_t)_rcConsole,
+                                           _romFile.fileSystemRepresentation,
+                                           NULL, 0,
+                                           genplus_rc_load_game_callback,
+                                           (__bridge void *)self);
+}
 
 - (id)init
 {
@@ -191,6 +278,47 @@ static __weak GenPlusGameCore *_current;
     if (system_hw == SYSTEM_MCD)
         bram_load();
 
+    // Determine RA console from the system this ROM was identified as.
+    if ([self.systemIdentifier isEqualToString:@"openemu.system.sms"])
+        _rcConsole = RC_CONSOLE_MASTER_SYSTEM;
+    else if ([self.systemIdentifier isEqualToString:@"openemu.system.gg"])
+        _rcConsole = RC_CONSOLE_GAME_GEAR;
+    else if ([self.systemIdentifier isEqualToString:@"openemu.system.sg"])
+        _rcConsole = RC_CONSOLE_SG1000;
+    else if ([self.systemIdentifier isEqualToString:@"openemu.system.scd"])
+        _rcConsole = RC_CONSOLE_SEGA_CD;
+    else
+        _rcConsole = RC_CONSOLE_MEGA_DRIVE;
+
+    _rcClient = rc_client_create(genplus_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, genplus_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, genplus_rc_log);
+
+        __weak GenPlusGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            GenPlusGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 genplus_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     // Set battery saves dir and load sram
     NSString *extensionlessFilename = _romFile.lastPathComponent.stringByDeletingPathExtension;
     NSURL *batterySavesDirectory = [NSURL fileURLWithPath:self.batterySavesDirectoryPath];
@@ -224,12 +352,17 @@ static __weak GenPlusGameCore *_current;
     else
         system_frame_sms(0);
 
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
+
     int samples = audio_update(_soundBuffer);
     [[self audioBufferAtIndex:0] write:_soundBuffer maxLength:samples << 2];
 }
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     system_reset();
 }
 
@@ -274,6 +407,16 @@ static __weak GenPlusGameCore *_current;
         bram_save();
 
     audio_shutdown();
+
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
 
     [super stopEmulation];
 }
@@ -405,6 +548,9 @@ static __weak GenPlusGameCore *_current;
         block(NO, error);
         return;
     }
+
+    if (_rcClient)
+        rc_client_reset(_rcClient);
 
     block(YES, nil);
 }

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -131,24 +131,27 @@ typedef NS_ENUM(NSInteger, MultiTapType)
 - (void)_beginLoadGame;
 @end
 
-// rcheevos memory callback — dispatches on system_hw to serve the correct RAM region.
-// Genesis/CD: 68K work RAM at 0xFF0000–0xFFFFFF; Z80 RAM at 0xA00000–0xA01FFF.
-// SMS/GG/SG: 8 KB work RAM at 0xC000–0xDFFF.
+// rcheevos memory callback.
+//
+// rcheevos uses a normalized address space, not the 68000/Z80 bus addresses.
+// Mapping (from Vendor/rcheevos/src/rcheevos/consoleinfo.c):
+//
+//   Genesis / Mega CD  — RC 0x000000–0x00FFFF → work_ram[] (64 KB 68K RAM)
+//   SMS / GG / SG-1000 — RC 0x000000–0x001FFF → work_ram[] (8 KB RAM at real C000)
+//
 static uint32_t genplus_rc_read_memory(uint32_t address, uint8_t *buffer,
                                         uint32_t num_bytes, rc_client_t *client)
 {
     for (uint32_t i = 0; i < num_bytes; i++) {
         uint32_t addr = address + i;
         if ((system_hw & SYSTEM_PBC) == SYSTEM_MD || system_hw == SYSTEM_MCD) {
-            if (addr >= 0xFF0000 && addr <= 0xFFFFFF)
-                buffer[i] = work_ram[addr & 0xFFFF];
-            else if (addr >= 0xA00000 && addr <= 0xA01FFF)
-                buffer[i] = zram[addr - 0xA00000];
+            if (addr <= 0x00FFFF)
+                buffer[i] = work_ram[addr];
             else
                 return i;
         } else {
-            if (addr >= 0xC000 && addr <= 0xDFFF)
-                buffer[i] = work_ram[addr & 0x1FFF];
+            if (addr <= 0x001FFF)
+                buffer[i] = work_ram[addr];
             else
                 return i;
         }

--- a/GenesisPlus/GenesisPlus.xcodeproj/project.pbxproj
+++ b/GenesisPlus/GenesisPlus.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		OE0GPLU0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0GPLU0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0GPLU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0GPLU0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 		82287C39101E9DB40072172D /* GenPlusGameCore.m in Sources */ = {isa = PBXBuildFile; fileRef = 82287C34101E9DB40072172D /* GenPlusGameCore.m */; };
 		87709EF32950DA090084AEE0 /* megasd.c in Sources */ = {isa = PBXBuildFile; fileRef = 87709EF22950DA090084AEE0 /* megasd.c */; };
 		879243AE1C0D044B0064C515 /* xe_1ap.c in Sources */ = {isa = PBXBuildFile; fileRef = 879243AC1C0D044B0064C515 /* xe_1ap.c */; };
@@ -134,6 +136,8 @@
 		82287C08101E9C2C0072172D /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		82287C33101E9DB40072172D /* GenPlusGameCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenPlusGameCore.h; sourceTree = "<group>"; };
 		82287C34101E9DB40072172D /* GenPlusGameCore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GenPlusGameCore.m; sourceTree = "<group>"; };
+		OE0GPLU0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0GPLU0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 		825C7E44101FAB7F0072187B /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		87709EF12950DA080084AEE0 /* megasd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = megasd.h; sourceTree = "<group>"; };
 		87709EF22950DA090084AEE0 /* megasd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = megasd.c; sourceTree = "<group>"; };
@@ -646,6 +650,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				OE0GPLU0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0GPLU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				82287C39101E9DB40072172D /* GenPlusGameCore.m in Sources */,
 				879243B11C0D05120064C515 /* graphic_board.c in Sources */,
 				94ED8A9214CF933700FF8901 /* areplay.c in Sources */,
@@ -734,6 +740,12 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/genplusgx_source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				OTHER_CFLAGS = (
@@ -756,6 +768,12 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/genplusgx_source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				OTHER_CFLAGS = (

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + GenesisPlus.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + GenesisPlus.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "GenesisPlus.oecoreplugin"
+               BlueprintName = "GenesisPlus"
+               ReferencedContainer = "container:GenesisPlus/GenesisPlus.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -38,7 +38,7 @@ extension OEDBRom: CachedLastPlayedInfoItem {}
 @NSApplicationMain
 @objc(OEApplicationDelegate)
 @objcMembers
-class AppDelegate: NSObject {
+class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
     
     static let websiteAddress = "https://github.com/nickybmon/OpenEmu-Silicon"
     static let userGuideAddress = "https://github.com/nickybmon/OpenEmu-Silicon/wiki"
@@ -889,6 +889,7 @@ extension AppDelegate: NSMenuDelegate {
         
         NSDocumentController.shared.clearRecentDocuments(nil)
 
+        UNUserNotificationCenter.current().delegate = self
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
 
         validateDefaultPluginAssignments()
@@ -1150,5 +1151,15 @@ extension AppDelegate: NSMenuDelegate {
         } else {
             block()
         }
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                 willPresent notification: UNNotification,
+                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // macOS suppresses banners for foreground apps by default; opt back in so
+        // achievement notifications pop up while a game is running.
+        completionHandler([.banner, .sound])
     }
 }

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -327,6 +327,7 @@ extension OSLog {
             object: nil,
             queue: nil
         ) { [weak self] note in
+            NSLog("[RA-Helper] OEAchievementUnlocked notification received, gameCoreOwner=%@", self?.gameCoreOwner != nil ? "set" : "nil")
             guard let self = self,
                   let owner = self.gameCoreOwner,
                   let info = note.userInfo,
@@ -335,7 +336,14 @@ extension OSLog {
                   let desc      = info[OEAchievementDescriptionKey]  as? String,
                   let badge     = info[OEAchievementBadgeURLKey]     as? String,
                   let ptsNum    = info[OEAchievementPointsKey]       as? NSNumber
-            else { return }
+            else {
+                NSLog("[RA-Helper] guard failed — self=%@ owner=%@ info=%@",
+                      self != nil ? "ok" : "nil",
+                      self?.gameCoreOwner != nil ? "ok" : "nil",
+                      note.userInfo != nil ? "ok" : "nil")
+                return
+            }
+            NSLog("[RA-Helper] calling achievementUnlocked id=%u title=%@", idNum.uint32Value, title)
             owner.achievementUnlocked?(id: idNum.uint32Value,
                                         title: title,
                                         description: desc,

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -94,6 +94,11 @@ static uint32_t mGBA_rc_read_memory(uint32_t address, uint8_t *buffer,
 }
 
 
+static void mGBA_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
 static void mGBA_rc_load_game_callback(int result, const char *error_message,
                                         rc_client_t *client, void *userdata)
 {
@@ -126,6 +131,8 @@ static void mGBA_rc_event_handler(const rc_client_event_t *event, rc_client_t *c
     NSString *badge       = [NSString stringWithUTF8String:ach->badge_name   ?: ""];
     NSNumber *achId       = @(ach->id);
     NSNumber *points      = @(ach->points);
+
+    NSLog(@"[RA-mGBA] achievement triggered: id=%u title=%s", ach->id, ach->title ?: "(nil)");
 
     NSDictionary *info = @{
         OEAchievementIDKey:          achId,
@@ -206,7 +213,6 @@ static struct mLogger logger = { .log = _log };
 
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError **)error
 {
-    RALog(@"[RA-mGBA] loadFileAtPath entered: %@", path);
     projectVersion = [self.owner.bundle.infoDictionary[@"CFBundleVersion"] UTF8String];
 
 	NSString *batterySavesDirectory = [self batterySavesDirectoryPath];
@@ -235,6 +241,7 @@ static struct mLogger logger = { .log = _log };
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
         rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mGBA_rc_log);
 
         // Register token observer before game identification so we don't miss
         // the notification that fires immediately after setRetroAchievementsToken.


### PR DESCRIPTION
## Summary

Adds RetroAchievements support to the GenesisPlus core, covering Genesis, Sega CD, Master System, Game Gear, and SG-1000.

- Integrates `rc_client` into `GenPlusGameCore.m`: login, game identification, per-frame evaluation, teardown
- Memory callback correctly maps rcheevos normalized addresses → `work_ram[]` for all five systems
- Adds `rcheevos_build.c` and `OERetroAchievementsTransport.m` to the GenesisPlus Xcode target
- Creates `OpenEmu + GenesisPlus.xcscheme` workspace scheme for building the core
- Fixes foreground notification suppression so achievement banners appear while playing
- Adds rcheevos logging to mGBAGameCore (mirrors GenPlusGameCore)
- Closes #248

## Key implementation note — rcheevos address space

rcheevos uses a normalized address space, not the 68000 bus addresses. Genesis work RAM is at real address `0xFF0000`, but rcheevos sends `0x000000–0x00FFFF`. The memory callback must map directly: `work_ram[addr]`. The mapping for every console is in `Vendor/rcheevos/src/rcheevos/consoleinfo.c` — check there first when wiring up any new core.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout 273 --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + GenesisPlus" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Install the core
./Scripts/install-core.sh GenesisPlus

# 4. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Load a Sonic the Hedgehog (Genesis) ROM with a RetroAchievements account logged in. Clear Green Hill Zone Act 1. An in-game HUD banner and a macOS banner notification should both appear.

## QA Spec
- [x] Genesis: achievement notifications fire in-game (Sonic 1, Green Hill Zone Act 1 confirmed)
- [x] RA profile shows unlocked achievements after session
- [x] macOS banner notification appears while app is in foreground
- [x] SMS / GG / SG-1000 ROMs load without crash
- [x] Stopping emulation does not crash (rc_client teardown)
- [x] Loading a save state does not crash
- [x] mGBA achievements still work (rc_client.c unchanged from upstream)