### PR TITLE
fix(4DO): correct bundle identifier so 3DO appears in console list

### DIFF
--- a/4DO/4DO.xcodeproj/project.pbxproj
+++ b/4DO/4DO.xcodeproj/project.pbxproj
@@ -530,7 +530,7 @@
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.4DO";
 				PRODUCT_NAME = 4DO;
 				USER_HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/core/\" \"$(PROJECT_DIR)/libcue/\"/** \"$(PROJECT_DIR)/libfreedo/\"";
 				WRAPPER_EXTENSION = oecoreplugin;
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.4DO";
 				PRODUCT_NAME = 4DO;
 				USER_HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/core/\" \"$(PROJECT_DIR)/libcue/\"/** \"$(PROJECT_DIR)/libfreedo/\"";
 				WRAPPER_EXTENSION = oecoreplugin;

--- a/4DO/Info.plist
+++ b/4DO/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.2.3</string>
+	<string>2.3.1</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>
@@ -58,6 +58,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/4do_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/4do.xml</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- `CFBundleIdentifier` was resolving to `org.openemu.-DO` — the `${PRODUCT_NAME:rfc1034identifier}` substitution strips the leading digit `4` from `4DO` (RFC 1034 labels must start with a letter). The invalid identifier caused OpenEmu to silently drop the plugin, so **3DO never appeared in the console list**.
- Fixed by hardcoding `PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.4DO"` in both Debug and Release build configurations.
- Updated `SUFeedURL` to point to our appcast (`Appcasts/4do.xml`) instead of the legacy upstream OpenEmu feed.
- Bumped `CFBundleVersion` to `2.3.1` to distinguish from the broken build shipped in `cores-v1.1.0`.

## After merge

Once this lands on `main`, trigger a core re-release to publish a fixed zip and update the appcast:

```bash
gh workflow run release-core.yml \
  --repo nickybmon/OpenEmu-Silicon \
  -f core_name=4DO \
  -f version=2.3.1
```

This replaces the broken asset in `cores-v1.1.0` with a corrected build.

## Test plan

- [ ] Build `OpenEmu + 4DO` scheme — should succeed with `CFBundleIdentifier = org.openemu.4DO`
- [ ] Install the new plugin, launch OpenEmu — **3DO should appear in the console list**
- [ ] Install a 3DO ROM and confirm it launches (requires `panafz10.bin` BIOS)

Fixes #231
Related to #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)