### PR TITLE
feat: RetroAchievements — Phase 1 complete (FCEU, Nestopia, SNES9x, BSNES, Gambatte)

### DIFF
--- a/BSNES/BSNES.xcodeproj/project.pbxproj
+++ b/BSNES/BSNES.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		C6D120EC1711307900E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120EB1711307900E868A8 /* OpenEmuBase.framework */; };
                 CC00000123B985A800F0B36E /* debugger.c in Sources */ = {isa = PBXBuildFile; fileRef = 0167A44C23B9843600F0B36E /* debugger.c */; };
                 CC00000223B985A800F0B36E /* sm83_disassembler.c in Sources */ = {isa = PBXBuildFile; fileRef = 0167A45B23B9843600F0B36E /* sm83_disassembler.c */; };
+		OE0BSNS0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0BSNS0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0BSNS0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0BSNS0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -754,6 +756,8 @@
 		C6480FFB1364B2E10094FA33 /* OESNESSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OESNESSystemResponderClient.h; path = ../OpenEmu/SystemPlugins/SuperNES/OESNESSystemResponderClient.h; sourceTree = "<group>"; };
 		C6D120EB1711307900E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
+		OE0BSNS0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0BSNS0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2372,6 +2376,8 @@
 				0167A54B23B984E000F0B36E /* ppu.cpp in Sources */,
 				0167A54923B984D400F0B36E /* smp.cpp in Sources */,
 				94D9257314CA9879008F697D /* BSNESGameCore.mm in Sources */,
+				OE0BSNS0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0BSNS0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				0167A56023B985A800F0B36E /* printer.c in Sources */,
 				0167A55323B9856C00F0B36E /* wdc65816.cpp in Sources */,
 				0167A55F23B985A800F0B36E /* sgb.c in Sources */,
@@ -2440,7 +2446,12 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_UNROLL_LOOPS = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/bsnes\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)/bsnes\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				MARKETING_VERSION = 115;
@@ -2467,7 +2478,12 @@
 				GCC_OPTIMIZATION_LEVEL = fast;
 				GCC_UNROLL_LOOPS = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/bsnes\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)/bsnes\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				MARKETING_VERSION = 115;

--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -34,6 +34,11 @@
 
 #include "program.mm"
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
+
 
 /*
  * TODO
@@ -42,9 +47,80 @@
  */
 
 
+@interface BSNESGameCore (RetroAchievements)
+- (void)_beginLoadGame;
+@end
+
+// rcheevos memory callback.
+//
+// rcheevos SNES address space (consoleinfo.c):
+//   0x000000–0x01FFFF → 128 KB WRAM (bus 0x7E0000–0x7FFFFF)
+//
+// Reads via Emulator::Interface::read() which internally calls
+// cpu.readDisassembler(address) — the same bus read used for the debugger.
+//
+static uint32_t bsnes_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                      uint32_t num_bytes, rc_client_t *client)
+{
+    if (!emulator) { return 0; }
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr <= 0x01FFFF)
+            buffer[i] = emulator->read(0x7E0000 + addr);
+        else
+            return i;
+    }
+    return num_bytes;
+}
+
+static void bsnes_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void bsnes_rc_load_game_callback(int result, const char *error_message,
+                                         rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-BSNES] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void bsnes_rc_login_callback(int result, const char *error_message,
+                                     rc_client_t *client, void *userdata)
+{
+    BSNESGameCore *s = (__bridge BSNESGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-BSNES] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
+
 @implementation BSNESGameCore {
     NSMutableSet <NSString *> *_activeCheats;
     NSMutableDictionary <NSString *, id> *_displayModes;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    NSString *_romPath;
 }
 
 - (id)init
@@ -56,6 +132,17 @@
     _displayModes = [[NSMutableDictionary alloc] init];
     screenRect = OEIntRectMake(0, 0, 256, 224);
     return self;
+}
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           RC_CONSOLE_SUPER_NINTENDO,
+                                           _romPath.fileSystemRepresentation,
+                                           NULL, 0,
+                                           bsnes_rc_load_game_callback,
+                                           (__bridge void *)self);
 }
 
 - (void)dealloc
@@ -220,7 +307,37 @@
     emulator->connect(SuperFamicom::ID::Port::Controller1, SuperFamicom::ID::Device::Gamepad);
     emulator->connect(SuperFamicom::ID::Port::Controller2, SuperFamicom::ID::Device::Gamepad);
     [self loadCheats];
-    
+
+    _romPath = path;
+    _rcClient = rc_client_create(bsnes_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, bsnes_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, bsnes_rc_log);
+
+        __weak BSNESGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            BSNESGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 bsnes_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -242,6 +359,8 @@
                 NSLocalizedDescriptionKey: @"The save state data could not be read.",
                 NSLocalizedRecoverySuggestionErrorKey: @"When the BSNES core is updated, existing save states may stop working. This is normal and unavoidable.\n\nPlease use in-game saves as much as possible instead."
             }];
+    if (res && _rcClient)
+        rc_client_reset(_rcClient);
     return res;
 }
 
@@ -312,15 +431,28 @@
 - (void)executeFrame
 {
     emulator->run();
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
 }
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     emulator->reset();
 }
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
     program->save();
     [super stopEmulation];
 }

--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -34,6 +34,7 @@
 
 #include "program.mm"
 
+#include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
 #include <rc_consoles.h>
@@ -75,7 +76,7 @@ static uint32_t bsnes_rc_read_memory(uint32_t address, uint8_t *buffer,
 
 static void bsnes_rc_log(const char *message, const rc_client_t *client)
 {
-    NSLog(@"[rcheevos] %s", message);
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
 }
 
 static void bsnes_rc_load_game_callback(int result, const char *error_message,

--- a/FCEU/FCEU.xcodeproj/project.pbxproj
+++ b/FCEU/FCEU.xcodeproj/project.pbxproj
@@ -275,6 +275,8 @@
 		949BBB521A9EFF4B007B49CC /* wave.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 949BBA351A9EED5B007B49CC /* wave.cpp */; };
 		949BBB531A9EFF4B007B49CC /* x6502.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 949BBA371A9EED5B007B49CC /* x6502.cpp */; };
 		C62301A61712264100576081 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120EF171130A200E868A8 /* OpenEmuBase.framework */; };
+		OE0FCEU0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0FCEU0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0FCEU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0FCEU0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -677,6 +679,8 @@
 		B5008DAE0E8BFB3E005AECAF /* FCEUGameCore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FCEUGameCore.mm; sourceTree = "<group>"; };
 		C6D120EF171130A200E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		OE0FCEU0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0FCEU0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1301,6 +1305,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				82EC40A30FD9EC5A0017FC19 /* FCEUGameCore.mm in Sources */,
+				OE0FCEU0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0FCEU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				949BBB381A9EFF4A007B49CC /* asm.cpp in Sources */,
 				8F28FD5129FD3E7D008FC4A9 /* coolgirl.cpp in Sources */,
 				949BBB391A9EFF4A007B49CC /* cart.cpp in Sources */,
@@ -1571,7 +1577,12 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/src\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)/src\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				OTHER_CFLAGS = (
@@ -1593,7 +1604,12 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/src\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)/src\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				OTHER_CFLAGS = (

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -38,6 +38,11 @@
 #include "src/cheat.h"
 #include "zlib.h"
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
+
 extern uint8 *XBuf;
 static uint32_t palette[256];
 
@@ -68,11 +73,76 @@ static uint32_t palette[256];
     BOOL      _isVertOverscanCropped;
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    NSString *_romPath;
 }
 
 - (void)loadDisplayModeOptions;
+- (void)_beginLoadGame;
 
 @end
+
+// rcheevos memory callback.
+//
+// rcheevos NES address space (consoleinfo.c):
+//   0x0000–0x07FF → 2 KB NES work RAM (mirrored at 0x0800–0x1FFF on hardware,
+//                    but rcheevos only requests the base 2 KB range)
+//
+static uint32_t fceu_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                     uint32_t num_bytes, rc_client_t *client)
+{
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr <= 0x07FF)
+            buffer[i] = RAM[addr];
+        else
+            return i;
+    }
+    return num_bytes;
+}
+
+static void fceu_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void fceu_rc_load_game_callback(int result, const char *error_message,
+                                        rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-FCEU] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void fceu_rc_login_callback(int result, const char *error_message,
+                                    rc_client_t *client, void *userdata)
+{
+    FCEUGameCore *s = (__bridge FCEUGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-FCEU] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void fceu_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
 
 @implementation FCEUGameCore
 
@@ -90,6 +160,17 @@ static __weak FCEUGameCore *_current;
 	return self;
 }
 
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           RC_CONSOLE_NINTENDO,
+                                           _romPath.fileSystemRepresentation,
+                                           NULL, 0,
+                                           fceu_rc_load_game_callback,
+                                           (__bridge void *)self);
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);
@@ -99,6 +180,7 @@ static __weak FCEUGameCore *_current;
 
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError **)error
 {
+    _romPath = path;
     _pad = 0;
     memset(_arkanoid, 0, sizeof(_arkanoid));
     memset(_zapper, 0, sizeof(_zapper));
@@ -220,6 +302,35 @@ static __weak FCEUGameCore *_current;
         [self loadDisplayModeOptions];
     }
 
+    _rcClient = rc_client_create(fceu_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, fceu_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, fceu_rc_log);
+
+        __weak FCEUGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            FCEUGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 fceu_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -230,6 +341,9 @@ static __weak FCEUGameCore *_current;
 
     FCEUI_Emulate(&pXBuf, &_soundBuffer, &_soundSize, 0);
 
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
+
     for (int i = 0; i < _soundSize; i++)
         _soundBuffer[i] = (_soundBuffer[i] << 16) | (_soundBuffer[i] & 0xffff);
 
@@ -238,11 +352,23 @@ static __weak FCEUGameCore *_current;
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     ResetNES();
 }
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
+
     FCEUI_CloseGame();
     FCEUI_Kill();
 
@@ -358,7 +484,10 @@ static __weak FCEUGameCore *_current;
     BOOL result = FCEUSS_LoadFP(emuFile, SSLOADPARAM_NOBACKUP);
     
     delete emuFile;
-    
+
+    if (result && _rcClient)
+        rc_client_reset(_rcClient);
+
     return result;
 }
 

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -38,6 +38,7 @@
 #include "src/cheat.h"
 #include "zlib.h"
 
+#include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
 #include <rc_consoles.h>
@@ -104,7 +105,7 @@ static uint32_t fceu_rc_read_memory(uint32_t address, uint8_t *buffer,
 
 static void fceu_rc_log(const char *message, const rc_client_t *client)
 {
-    NSLog(@"[rcheevos] %s", message);
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
 }
 
 static void fceu_rc_load_game_callback(int result, const char *error_message,

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -35,6 +35,7 @@
 #include "resamplerinfo.h"
 #include "resampler.h"
 
+#include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
 #include <rc_consoles.h>
@@ -109,7 +110,7 @@ static uint32_t gambatte_rc_read_memory(uint32_t address, uint8_t *buffer,
 
 static void gambatte_rc_log(const char *message, const rc_client_t *client)
 {
-    NSLog(@"[rcheevos] %s", message);
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
 }
 
 static void gambatte_rc_load_game_callback(int result, const char *error_message,

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -35,6 +35,11 @@
 #include "resamplerinfo.h"
 #include "resampler.h"
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
+
 #define OptionDefault(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @YES, }
 #define Option(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @NO, }
 #define OptionIndented(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @NO, OEGameCoreDisplayModeIndentationLevelKey : @(1), }
@@ -64,6 +69,10 @@ public:
     double _sampleRate;
     NSMutableDictionary <NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    NSString *_romPath;
+    int _rcConsole;
 }
 
 - (void)applyCheat:(NSString *)code;
@@ -74,8 +83,71 @@ public:
 - (void)loadPalette;
 - (void)loadPaletteDefault;
 - (void)changePalette:(NSString *)palette;
+- (void)_beginLoadGame;
 
 @end
+
+// rcheevos memory callback.
+//
+// rcheevos GB/GBC address space (consoleinfo.c):
+//   0x0000–0xFFFF → full 16-bit Game Boy bus
+//
+// Reads via gambatte::GB::busRead8() — wraps Memory::read(addr, 0).
+//
+static uint32_t gambatte_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                         uint32_t num_bytes, rc_client_t *client)
+{
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr <= 0xFFFF)
+            buffer[i] = gb.busRead8((uint16_t)addr);
+        else
+            return i;
+    }
+    return num_bytes;
+}
+
+static void gambatte_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void gambatte_rc_load_game_callback(int result, const char *error_message,
+                                            rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-Gambatte] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void gambatte_rc_login_callback(int result, const char *error_message,
+                                        rc_client_t *client, void *userdata)
+{
+    GBGameCore *s = (__bridge GBGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-Gambatte] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
 
 @implementation GBGameCore
 
@@ -89,6 +161,17 @@ public:
     }
 
 	return self;
+}
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           (uint32_t)_rcConsole,
+                                           _romPath.fileSystemRepresentation,
+                                           NULL, 0,
+                                           gambatte_rc_load_game_callback,
+                                           (__bridge void *)self);
 }
 
 - (void)dealloc
@@ -133,6 +216,38 @@ public:
 
     [self loadDisplayModeOptions];
 
+    _romPath = path;
+    _rcConsole = gb.isCgb() ? RC_CONSOLE_GAMEBOY_COLOR : RC_CONSOLE_GAMEBOY;
+
+    _rcClient = rc_client_create(gambatte_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, gambatte_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, gambatte_rc_log);
+
+        __weak GBGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            GBGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 gambatte_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -145,16 +260,31 @@ public:
         samples = 2064;
     }
 
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
+
     [self outputAudio:samples];
 }
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     gb.reset();
 }
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
+
     gb.saveSavedata();
 
     delete resampler;
@@ -262,8 +392,11 @@ public:
     std::streamsize size = state.length;
     stream.write(bytes, size);
 
-    if(gb.deserializeState(stream))
+    if(gb.deserializeState(stream)) {
+        if (_rcClient)
+            rc_client_reset(_rcClient);
         return YES;
+    }
 
     if(outError) {
         *outError = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadStateError userInfo:@{

--- a/Gambatte/Gambatte.xcodeproj/project.pbxproj
+++ b/Gambatte/Gambatte.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		9499B6081AB242B300276D21 /* video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9499B5D41AB242B200276D21 /* video.cpp */; };
 		94ABD7DA16534BE800035061 /* GBGameCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5EC4D420E6312DF0046BD93 /* GBGameCore.mm */; };
 		C6D120EE1711308C00E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120ED1711308C00E868A8 /* OpenEmuBase.framework */; };
+		OE0GAMB0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0GAMB0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0GAMB0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0GAMB0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -225,6 +227,8 @@
 		B5F6D8A80E66914F001CA5D3 /* gameboy.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = gameboy.icns; sourceTree = "<group>"; };
 		C6B947DE1364FD0C00A425F0 /* OEGBSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OEGBSystemResponderClient.h; path = ../OpenEmu/SystemPlugins/GameBoy/OEGBSystemResponderClient.h; sourceTree = "<group>"; };
 		C6D120ED1711308C00E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OE0GAMB0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0GAMB0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -578,6 +582,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				94ABD7DA16534BE800035061 /* GBGameCore.mm in Sources */,
+				OE0GAMB0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0GAMB0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				9499B5D81AB242B200276D21 /* chainresampler.cpp in Sources */,
 				9499B5D91AB242B200276D21 /* i0.cpp in Sources */,
 				9499B5DA1AB242B200276D21 /* kaiser50sinc.cpp in Sources */,
@@ -655,6 +661,9 @@
 					"\"$(PROJECT_DIR)/gambatte\"",
 					"\"$(SRCROOT)/libgambatte/src\"",
 					"\"$(SRCROOT)/libgambatte/include\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
@@ -677,6 +686,9 @@
 					"\"$(PROJECT_DIR)/gambatte\"",
 					"\"$(SRCROOT)/libgambatte/src\"",
 					"\"$(SRCROOT)/libgambatte/include\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";

--- a/Gambatte/src/libgambatte/cpu.h
+++ b/Gambatte/src/libgambatte/cpu.h
@@ -77,6 +77,10 @@ public:
 	void setGameGenie(std::string const &codes) { mem_.setGameGenie(codes); }
 	void setGameShark(std::string const &codes) { mem_.setGameShark(codes); }
 
+	uint8_t busRead8(uint16_t addr) const {
+		return static_cast<uint8_t>(const_cast<Memory &>(mem_).read(addr, 0));
+	}
+
 private:
 	Memory mem_;
 	unsigned long cycleCounter_;

--- a/Gambatte/src/libgambatte/gambatte.cpp
+++ b/Gambatte/src/libgambatte/gambatte.cpp
@@ -182,6 +182,10 @@ bool GB::deserializeState(std::istream &stream) {
     return false;
 }
 
+uint8_t GB::busRead8(uint16_t address) const {
+    return p_->cpu.busRead8(address);
+}
+
 //< OpenEmu
 bool GB::loadState(std::string const &filepath) {
 	if (p_->cpu.loaded()) {

--- a/Gambatte/src/libgambatte/gambatte.h
+++ b/Gambatte/src/libgambatte/gambatte.h
@@ -142,6 +142,12 @@ public:
      */
     bool deserializeState(std::istream &stream);
 
+    /**
+      * Reads a byte from the Game Boy memory bus at the given address.
+      * Used by RetroAchievements (rcheevos) to inspect emulator state.
+      */
+    uint8_t busRead8(uint16_t address) const;
+
 //< OpenEmu
 	/**
 	  * Saves emulator state to the state slot selected with selectState().

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -31,6 +31,11 @@
 #import "OEFDSSystemResponderClient.h"
 #import <OpenGL/gl.h>
 
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
+
 #include <NstBase.hpp>
 #include <NstApiEmulator.hpp>
 #include <NstApiMachine.hpp>
@@ -82,11 +87,79 @@ static void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event,
 
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    int _rcConsole;
 }
 
 - (void)loadDisplayModeOptions;
+- (void)_beginLoadGame;
+- (const uint8_t *)_nesRamBytesForRC;
 
 @end
+
+// rcheevos memory callback.
+//
+// rcheevos NES/FDS address space (consoleinfo.c):
+//   0x0000–0x07FF → 2 KB NES work RAM
+//
+static uint32_t nestopia_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                         uint32_t num_bytes, rc_client_t *client)
+{
+    NESGameCore *s = (__bridge NESGameCore *)rc_client_get_userdata(client);
+    const uint8_t *ram = [s _nesRamBytesForRC];
+    if (!ram) { return 0; }
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr <= 0x07FF)
+            buffer[i] = ram[addr];
+        else
+            return i;
+    }
+    return num_bytes;
+}
+
+static void nestopia_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void nestopia_rc_load_game_callback(int result, const char *error_message,
+                                            rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-Nestopia] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void nestopia_rc_login_callback(int result, const char *error_message,
+                                        rc_client_t *client, void *userdata)
+{
+    NESGameCore *s = (__bridge NESGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-Nestopia] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void nestopia_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
 
 @implementation NESGameCore
 
@@ -104,6 +177,23 @@ static __weak NESGameCore *_current;
     }
 
     return self;
+}
+
+- (const uint8_t *)_nesRamBytesForRC
+{
+    Nes::Core::Machine &machine = _emu;
+    return (const uint8_t *)machine.cpu.GetRam();
+}
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romURL) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           (uint32_t)_rcConsole,
+                                           _romURL.fileSystemRepresentation,
+                                           NULL, 0,
+                                           nestopia_rc_load_game_callback,
+                                           (__bridge void *)self);
 }
 
 - (void)dealloc
@@ -207,6 +297,39 @@ static __weak NESGameCore *_current;
         [self loadDisplayModeOptions];
     }
 
+    _rcConsole = [self.systemIdentifier isEqualToString:@"openemu.system.fds"]
+        ? RC_CONSOLE_FAMICOM_DISK_SYSTEM
+        : RC_CONSOLE_NINTENDO;
+
+    _rcClient = rc_client_create(nestopia_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, nestopia_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, nestopia_rc_log);
+
+        __weak NESGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NESGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 nestopia_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -270,11 +393,17 @@ static __weak NESGameCore *_current;
 {
     _emu.Execute(_nesVideo, _nesSound, _controls);
 
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
+
     [[self audioBufferAtIndex:0] write:_soundBuffer maxLength:self.channelCount * _bufFrameSize * sizeof(int16_t)];
 }
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
+
     Nes::Api::Machine machine(_emu);
     machine.Reset(true);
 
@@ -289,6 +418,16 @@ static __weak NESGameCore *_current;
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
+
     Nes::Api::Machine machine(_emu);
     //machine.Power(false);
     machine.Unload(); // this allows FDS to save
@@ -551,6 +690,9 @@ static __weak NESGameCore *_current;
 
         return NO;
     }
+
+    if (_rcClient)
+        rc_client_reset(_rcClient);
 
     return YES;
 }

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -31,6 +31,7 @@
 #import "OEFDSSystemResponderClient.h"
 #import <OpenGL/gl.h>
 
+#include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
 #include <rc_consoles.h>
@@ -121,7 +122,7 @@ static uint32_t nestopia_rc_read_memory(uint32_t address, uint8_t *buffer,
 
 static void nestopia_rc_log(const char *message, const rc_client_t *client)
 {
-    NSLog(@"[rcheevos] %s", message);
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
 }
 
 static void nestopia_rc_load_game_callback(int result, const char *error_message,

--- a/Nestopia/Nestopia.xcodeproj/project.pbxproj
+++ b/Nestopia/Nestopia.xcodeproj/project.pbxproj
@@ -334,6 +334,8 @@
 		94CB656018791A5400A19D7D /* NstBoardUnlA9746.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94CB655B18791A5400A19D7D /* NstBoardUnlA9746.cpp */; };
 		94CB656118791A5400A19D7D /* NstBoardUnlN625092.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94CB655D18791A5400A19D7D /* NstBoardUnlN625092.cpp */; };
 		C6D120F91711313900E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120F81711313900E868A8 /* OpenEmuBase.framework */; };
+		OE0NEST0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0NEST0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0NEST0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0NEST0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1036,6 +1038,8 @@
 		C6B3E692136525EB00D34947 /* OENESSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OENESSystemResponderClient.h; path = ../OpenEmu/SystemPlugins/NES/OENESSystemResponderClient.h; sourceTree = "<group>"; };
 		C6D120F81711313900E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		OE0NEST0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0NEST0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2233,6 +2237,8 @@
 				82789AE50E70CFD100C01C82 /* NstVsSystem.cpp in Sources */,
 				82789AE60E70CFD100C01C82 /* NstVsTkoBoxing.cpp in Sources */,
 				82789B710E70D27D00C01C82 /* NESGameCore.mm in Sources */,
+				OE0NEST0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0NEST0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2283,6 +2289,12 @@
 					NST_NO_XBR,
 				);
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					"core/**",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.${PRODUCT_NAME:identifier}";
@@ -2305,6 +2317,12 @@
 					NST_NO_XBR,
 				);
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					"core/**",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.${PRODUCT_NAME:identifier}";

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + FCEU.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + FCEU.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "FCEU.oecoreplugin"
+               BlueprintName = "FCEU"
+               ReferencedContainer = "container:FCEU/FCEU.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + Gambatte.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + Gambatte.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "828387800E6CDB2200A96E2C"
+               BuildableName = "Gambatte.oecoreplugin"
+               BlueprintName = "Gambatte"
+               ReferencedContainer = "container:Gambatte/Gambatte.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + Nestopia.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + Nestopia.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "Nestopia.oecoreplugin"
+               BlueprintName = "Nestopia"
+               ReferencedContainer = "container:Nestopia/Nestopia.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + SNES9x.xcscheme
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/xcschemes/OpenEmu + SNES9x.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D5B49AC048680CD000E48DA"
+               BuildableName = "SNES9x.oecoreplugin"
+               BlueprintName = "SNES9x"
+               ReferencedContainer = "container:SNES9x/SNES9x.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+               BuildableName = "OpenEmu.app"
+               BlueprintName = "OpenEmu"
+               ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D15AC270486D014006FF6A4"
+            BuildableName = "OpenEmu.app"
+            BlueprintName = "OpenEmu"
+            ReferencedContainer = "container:OpenEmu/OpenEmu.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SNES9x/SNES9x.xcodeproj/project.pbxproj
+++ b/SNES9x/SNES9x.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		94790DBA14C0C46900B30798 /* srtc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94790D6614C0C46900B30798 /* srtc.cpp */; };
 		94790DBC14C0C46900B30798 /* tile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94790D6A14C0C46900B30798 /* tile.cpp */; };
 		C6D120FB1711314D00E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120FA1711314D00E868A8 /* OpenEmuBase.framework */; };
+		OE0SNS90BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0SNS90FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
+		OE0SNS90BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0SNS90FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -260,6 +262,8 @@
 		C6480FFA1364B1CF0094FA33 /* OESNESSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OESNESSystemResponderClient.h; path = ../OpenEmu/SystemPlugins/SuperNES/OESNESSystemResponderClient.h; sourceTree = "<group>"; };
 		C6D120FA1711314D00E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		OE0SNS90FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0SNS90FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -637,6 +641,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				826C1B1F0F420C2200FB9014 /* SNESGameCore.mm in Sources */,
+				OE0SNS90BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0SNS90BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				94790D7A14C0C46900B30798 /* apu.cpp in Sources */,
 				8725B0B91E933E1B00F68CA5 /* sdsp.cpp in Sources */,
 				8725B0BB1E933E2B00F68CA5 /* smp.cpp in Sources */,
@@ -728,6 +734,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/src/apu/bapu\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
@@ -759,6 +768,9 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/src\"",
 					"\"$(SRCROOT)/src/apu/bapu\"",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+					"$(SRCROOT)/../OpenEmuKit/Source",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -31,6 +31,11 @@
 
 #include "snes9x.h"
 #include "memmap.h"
+
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
 #include "pixform.h"
 #include "gfx.h"
 #include "display.h"
@@ -57,12 +62,83 @@
     uint16_t *_soundBufferCurrent;
     NSURL    *_romURL;
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
 }
 
 - (void)finalizeAudioSamples;
 - (void)mapButtons;
+- (void)_beginLoadGame;
 
 @end
+
+// rcheevos memory callback.
+//
+// rcheevos SNES address space (consoleinfo.c):
+//   0x000000–0x01FFFF → 128 KB WRAM (Memory.RAM)
+//   0x020000–0x09FFFF → Cartridge SRAM (Memory.SRAM, up to 512 KB)
+//
+static uint32_t snes9x_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                       uint32_t num_bytes, rc_client_t *client)
+{
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr <= 0x01FFFF) {
+            buffer[i] = Memory.RAM[addr];
+        } else if (addr <= 0x09FFFF && Memory.SRAM) {
+            uint32_t sramOffset = addr - 0x020000;
+            if (sramOffset <= Memory.SRAMMask)
+                buffer[i] = Memory.SRAM[sramOffset];
+            else
+                buffer[i] = 0;
+        } else {
+            return i;
+        }
+    }
+    return num_bytes;
+}
+
+static void snes9x_rc_log(const char *message, const rc_client_t *client)
+{
+    NSLog(@"[rcheevos] %s", message);
+}
+
+static void snes9x_rc_load_game_callback(int result, const char *error_message,
+                                          rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-SNES9x] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void snes9x_rc_login_callback(int result, const char *error_message,
+                                      rc_client_t *client, void *userdata)
+{
+    SNESGameCore *s = (__bridge SNESGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-SNES9x] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void snes9x_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
 
 @implementation SNESGameCore
 
@@ -140,6 +216,8 @@ static __weak SNESGameCore *_current;
         NSLog(@"[Snes9x] Couldn't init sound");
     
     S9xSetSamplesAvailableCallback(FinalizeSamplesAudioCallback, (__bridge void *)self);
+
+    _romURL = [NSURL fileURLWithPath:path];
 
     if(Memory.LoadROM(path.fileSystemRepresentation))
     {
@@ -633,10 +711,50 @@ static __weak SNESGameCore *_current;
             S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
         }
 
+        _rcClient = rc_client_create(snes9x_rc_read_memory, oeRetroAchievementsServerCall);
+        if (_rcClient) {
+            rc_client_set_userdata(_rcClient, (__bridge void *)self);
+            rc_client_set_event_handler(_rcClient, snes9x_rc_event_handler);
+            rc_client_set_hardcore_enabled(_rcClient, 0);
+            rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, snes9x_rc_log);
+
+            __weak SNESGameCore *weakSelf = self;
+            _raTokenObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *note) {
+                SNESGameCore *s = weakSelf;
+                if (!s || !s->_rcClient) { return; }
+                NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+                NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+                if (token && username) {
+                    rc_client_begin_login_with_token(s->_rcClient,
+                                                     username.UTF8String,
+                                                     token.UTF8String,
+                                                     snes9x_rc_login_callback,
+                                                     (__bridge void *)s);
+                } else {
+                    rc_client_logout(s->_rcClient);
+                }
+            }];
+        }
+
         return YES;
     }
 
     return NO;
+}
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romURL) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           RC_CONSOLE_SUPER_NINTENDO,
+                                           _romURL.fileSystemRepresentation,
+                                           NULL, 0,
+                                           snes9x_rc_load_game_callback,
+                                           (__bridge void *)self);
 }
 
 - (void)executeFrame
@@ -644,6 +762,10 @@ static __weak SNESGameCore *_current;
     IPPU.RenderThisFrame = true;
     _soundBufferCurrent = _soundBuffer;
     S9xMainLoop();
+
+    if (_rcClient)
+        rc_client_do_frame(_rcClient);
+
     NSUInteger samples = _soundBufferCurrent - _soundBuffer;
     [[self audioBufferAtIndex:0] write:_soundBuffer maxLength:samples * 2];
 }
@@ -658,11 +780,23 @@ static __weak SNESGameCore *_current;
 
 - (void)resetEmulation
 {
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     S9xSoftReset();
 }
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
+
     // Save SRAM
     NSURL *url = [NSURL fileURLWithPath:@(Memory.ROMFilename.c_str())];
     NSString *extensionlessFilename = url.lastPathComponent.stringByDeletingPathExtension;
@@ -778,8 +912,11 @@ static void FinalizeSamplesAudioCallback(void *context)
     const uint8_t *stateBytes = (const uint8_t *)state.bytes;
     uint32 stateLength = (uint32)state.length;
 
-    if(S9xUnfreezeGameMem(stateBytes, stateLength) == SUCCESS)
+    if(S9xUnfreezeGameMem(stateBytes, stateLength) == SUCCESS) {
+        if (_rcClient)
+            rc_client_reset(_rcClient);
         return YES;
+    }
 
     if(outError) {
         *outError = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadStateError userInfo:@{

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -32,6 +32,7 @@
 #include "snes9x.h"
 #include "memmap.h"
 
+#include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
 #include <rc_consoles.h>
@@ -100,7 +101,7 @@ static uint32_t snes9x_rc_read_memory(uint32_t address, uint8_t *buffer,
 
 static void snes9x_rc_log(const char *message, const rc_client_t *client)
 {
-    NSLog(@"[rcheevos] %s", message);
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
 }
 
 static void snes9x_rc_load_game_callback(int result, const char *error_message,


### PR DESCRIPTION
## Summary

This PR completes the Phase 1 RetroAchievements rollout by adding `rc_client` integration to the five remaining cores.

- **FCEU** — NES (closes #249)
- **Nestopia** — NES + Famicom Disk System (closes #276)
- **SNES9x** — Super Nintendo (closes #250)
- **BSNES** — Super Nintendo (closes #277)
- **Gambatte** — Game Boy / Game Boy Color (closes #251)

Every core follows the same pattern established by mGBA (#252) and GenesisPlus (#273):
- `rc_client` created on game load, destroyed on stop
- Login token observed via `OERetroAchievementsTokenDidChangeNotification`
- `rc_client_do_frame()` called every emulated frame
- `rc_client_reset()` called on soft reset and save-state load
- `OEAchievementUnlockedNotification` posted when an achievement triggers

## Memory callback details

| Core | What's mapped |
|------|---------------|
| FCEU | NES 2 KB work RAM — `extern uint8 *RAM` (0x0000–0x07FF) |
| Nestopia | NES 2 KB work RAM via `Nes::Core::Machine::cpu.GetRam()` (exposed through a helper method to avoid C++ access control issues in ObjC++) |
| SNES9x | SNES 128 KB WRAM (`Memory.RAM`) + cart SRAM (`Memory.SRAM`) |
| BSNES | SNES 128 KB WRAM via `Emulator::Interface::read(0x7E0000 + offset)` — the same bus-read path used by the BSNES debugger, no direct access to private CPU internals needed |
| Gambatte | Full 16-bit Game Boy bus via new `gambatte::GB::busRead8()` — a thin public helper added to `gambatte.h`/`gambatte.cpp`/`cpu.h` that wraps `Memory::read(addr, 0)`; console type (GB vs GBC) auto-detected via `gb.isCgb()` |

## Notable decisions

- **SNES9x scheme uses Release** — the core has a `#ifdef DEBUG #error` guard in its source. The new `OpenEmu + SNES9x.xcscheme` targets Release for both build and launch, consistent with how the core was already being used.
- **BSNES uses the emulator interface read path** — `SuperFamicom::cpu` is not exposed through the interface headers included by `program.mm`. `Emulator::Interface::read(busAddr)` is the correct, supported way to inspect SNES memory from outside the core.
- **Gambatte `busRead8`** — the public gambatte API had no memory-read facility. The new method is minimal (3 lines) and follows the same pattern as the existing `isCgb()` and `loaded()` helpers.

## New workspace schemes

- `OpenEmu + FCEU.xcscheme`
- `OpenEmu + Nestopia.xcscheme`
- `OpenEmu + SNES9x.xcscheme` (Release)
- `OpenEmu + Gambatte.xcscheme`

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build each core — use the new combined scheme
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + FCEU" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -5

# Repeat for: "OpenEmu + Nestopia", "OpenEmu + BSNES"
# For SNES9x and Gambatte use -configuration Release

# 3. Install each core
./Scripts/install-core.sh FCEU
./Scripts/install-core.sh Nestopia
./Scripts/install-core.sh SNES9x
./Scripts/install-core.sh BSNES
./Scripts/install-core.sh Gambatte

# 4. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

To verify achievements fire: log into RetroAchievements in OpenEmu preferences, load a ROM that has achievements on the RA site, and confirm that achievement popups appear. Test save-state load (should not double-count) and soft reset (should reset tracking).

## QA Spec

- [ ] FCEU: achievements unlock on a NES ROM that has RA entries
- [ ] Nestopia: achievements unlock on a NES ROM (and an FDS ROM if available)
- [ ] SNES9x: achievements unlock on a SNES ROM that has RA entries
- [ ] BSNES: achievements unlock on the same SNES ROM
- [ ] Gambatte: achievements unlock on a GB ROM; GBC ROM uses GBC console ID
- [ ] Loading a save state does not trigger already-unlocked achievements again
- [ ] Soft reset does not break achievement tracking
- [ ] Stopping emulation (closing game) does not crash
- [ ] No regressions in cores that already had RA (mGBA, GenesisPlus, Mednafen)

Made with [Cursor](https://cursor.com)