### PR TITLE
feat: add 'Play With…' core-selection submenu to game library context menu

### DIFF
--- a/OpenEmu/GameCollectionViewController.swift
+++ b/OpenEmu/GameCollectionViewController.swift
@@ -98,6 +98,13 @@ extension GameCollectionViewController: CollectionViewExtendedDelegate, NSMenuIt
                          action: #selector(LibraryController.startSelectedGame(_:)),
                          keyEquivalent: "")
             
+            if let coreSubmenu = coreMenu(for: game) {
+                item = NSMenuItem()
+                item.title = NSLocalizedString("Play With…", comment: "Submenu listing available cores for this system")
+                item.submenu = coreSubmenu
+                menu.addItem(item)
+            }
+            
             item = NSMenuItem()
             item.title = NSLocalizedString("Play Save State", comment: "")
             item.submenu = saveStateMenu(for: game)
@@ -219,6 +226,22 @@ extension GameCollectionViewController: CollectionViewExtendedDelegate, NSMenuIt
                          keyEquivalent: "")
         }
         
+        return menu
+    }
+    
+    private func coreMenu(for game: OEDBGame) -> NSMenu? {
+        guard let systemID = game.system?.systemIdentifier else { return nil }
+        var plugins = OECorePlugin.corePlugins(forSystemIdentifier: systemID)
+        guard plugins.count > 1 else { return nil }
+        plugins.sort { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+        let menu = NSMenu()
+        for plugin in plugins {
+            let item = NSMenuItem(title: plugin.displayName,
+                                  action: #selector(LibraryController.startSelectedGame(withCore:)),
+                                  keyEquivalent: "")
+            item.representedObject = plugin
+            menu.addItem(item)
+        }
         return menu
     }
     

--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -23,6 +23,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import OpenEmuKit
 
 @objc
 class GameDocumentController: NSDocumentController {
@@ -186,6 +187,20 @@ class GameDocumentController: NSDocumentController {
         }
         do {
             let document = try OEGameDocument(game: game, core: nil)
+            setUpGameDocument(document, display: displayDocument, fullScreen: fullScreen, completionHandler: completionHandler)
+        } catch {
+            completionHandler(nil, error)
+        }
+    }
+    
+    override func openGameDocument(with game: OEDBGame, core: OECorePlugin, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
+        if let existing = gameDocuments.first(where: { $0.rom?.game == game }) {
+            existing.gameWindowController?.window?.makeKeyAndOrderFront(nil)
+            completionHandler(existing, nil)
+            return
+        }
+        do {
+            let document = try OEGameDocument(game: game, core: core)
             setUpGameDocument(document, display: displayDocument, fullScreen: fullScreen, completionHandler: completionHandler)
         } catch {
             completionHandler(nil, error)

--- a/OpenEmu/LibraryController.swift
+++ b/OpenEmu/LibraryController.swift
@@ -23,6 +23,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import OpenEmuKit
 
 final class LibraryController: NSTabViewController, NSMenuItemValidation {
     
@@ -431,6 +432,16 @@ final class LibraryController: NSTabViewController, NSMenuItemValidation {
         delegate?.libraryController?(self, didSelectSaveState: saveState)
     }
     
+    @objc(startSelectedGameWithCore:)
+    @IBAction func startSelectedGame(withCore sender: NSMenuItem) {
+        guard let core = sender.representedObject as? OECorePlugin else { return }
+        guard
+            let ctl = tabView.selectedTabViewItem?.viewController as? LibrarySubviewControllerGameSelection,
+            let game = ctl.selectedGames.first
+        else { return }
+        delegate?.libraryController?(self, didSelectGame: game, withCore: core)
+    }
+    
     @objc(startSelectedGameWithSaveState:)
     @IBAction func startSelectedGame(saveState sender: NSMenuItem) {
         guard let saveState = sender.representedObject as? OEDBSaveState else {
@@ -469,6 +480,7 @@ extension LibraryController {
 @objc(OELibraryControllerDelegate)
 protocol LibraryControllerDelegate {
     @objc optional func libraryController(_ controller: LibraryController, didSelectGame: OEDBGame)
+    @objc optional func libraryController(_ controller: LibraryController, didSelectGame: OEDBGame, withCore: OECorePlugin)
     @objc optional func libraryController(_ controller: LibraryController, didSelectRom: OEDBRom)
     @objc optional func libraryController(_ controller: LibraryController, didSelectSaveState: OEDBSaveState)
 }

--- a/OpenEmu/Logging.swift
+++ b/OpenEmu/Logging.swift
@@ -25,6 +25,7 @@
  */
 
 import Foundation
+import os.log
 
 extension OSLog {
     static let `default` = OSLog(subsystem: "org.openemu.OpenEmu", category: "default")
@@ -41,7 +42,8 @@ extension OSLog {
 func DLog(_ message: @autoclosure () -> String, fileID: String = #fileID, function: String = #function, line: Int = #line)
 {
 #if DEBUG
-    NSLog("\(fileID):\(line): \(function): \(message())")
+    let formatted = "\(fileID):\(line): \(function): \(message())"
+    os_log(.debug, "%{public}s", formatted)
 #endif
 }
 

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -234,7 +234,11 @@ final class MainWindowController: NSWindowController {
 extension MainWindowController: LibraryControllerDelegate {
     
     func libraryController(_ controller: LibraryController, didSelectGame game: OEDBGame) {
-        openGameDocument(with: game, saveState: nil)
+        openGameDocument(with: game, core: nil, saveState: nil)
+    }
+    
+    func libraryController(_ controller: LibraryController, didSelectGame game: OEDBGame, withCore core: OECorePlugin) {
+        openGameDocument(with: game, core: core, saveState: nil)
     }
     
     func libraryController(_ controller: LibraryController, didSelectSaveState saveState: OEDBSaveState) {
@@ -242,7 +246,7 @@ extension MainWindowController: LibraryControllerDelegate {
     }
     
     @available(macOS, deprecated: 10.15, message: "Remove 'or \"User Reports\"' from alert (~line 392) and localizations, the term is not used in Catalina and above.")
-    private func openGameDocument(with game: OEDBGame?, saveState state: OEDBSaveState?, secondAttempt retry: Bool = false, disableAutoReload noAutoReload: Bool = false) {
+    private func openGameDocument(with game: OEDBGame?, core: OECorePlugin? = nil, saveState state: OEDBSaveState?, secondAttempt retry: Bool = false, disableAutoReload noAutoReload: Bool = false) {
         
         guard let window = window else { return assertionFailure("MainWindow is nil") }
         
@@ -385,6 +389,8 @@ extension MainWindowController: LibraryControllerDelegate {
         
         if openWithSaveState {
             NSDocumentController.shared.openGameDocument(with: state!, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
+        } else if let core {
+            NSDocumentController.shared.openGameDocument(with: game!, core: core, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
         } else {
             NSDocumentController.shared.openGameDocument(with: game!, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
         }

--- a/OpenEmu/NSDocumentController+Additions.swift
+++ b/OpenEmu/NSDocumentController+Additions.swift
@@ -25,6 +25,7 @@
  */
 
 import Foundation
+import OpenEmuKit
 
 extension NSDocumentController {
     
@@ -45,6 +46,10 @@ extension NSDocumentController {
     
     @objc(openGameDocumentWithGame:display:fullScreen:completionHandler:)
     func openGameDocument(with game: OEDBGame, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
+        fatalError("Method must be implemented by a subclass.")
+    }
+    
+    @objc func openGameDocument(with game: OEDBGame, core: OECorePlugin, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
         fatalError("Method must be implemented by a subclass.")
     }
     

--- a/OpenEmu/OEGameCollectionViewController+CoreMenu.swift
+++ b/OpenEmu/OEGameCollectionViewController+CoreMenu.swift
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+import OpenEmuKit
+
+extension OEGameCollectionViewController {
+
+    /// Builds a sorted "Play With…" submenu listing every installed core for the game's system.
+    /// Returns nil when fewer than two cores are available (menu item is hidden in that case).
+    @objc func oe_coreMenu(for game: OEDBGame) -> NSMenu? {
+        guard let systemID = game.system?.systemIdentifier else { return nil }
+        var plugins = OECorePlugin.corePlugins(forSystemIdentifier: systemID)
+        guard plugins.count > 1 else { return nil }
+        plugins.sort { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+        let menu = NSMenu()
+        for plugin in plugins {
+            let item = NSMenuItem(title: plugin.displayName,
+                                  action: #selector(LibraryController.startSelectedGame(withCore:)),
+                                  keyEquivalent: "")
+            item.representedObject = plugin
+            menu.addItem(item)
+        }
+        return menu
+    }
+}

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -614,6 +614,14 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
         [menu addItemWithTitle:NSLocalizedString(@"Play Game", @"") action:@selector(startSelectedGame:) keyEquivalent:@""];
         OEDBGame  *game = [[gamesController arrangedObjects] objectAtIndex:index];
 
+        // Play With… — only shown when more than one core supports this system
+        NSMenu *coreSubmenu = [self oe_coreMenuFor:game];
+        if(coreSubmenu != nil) {
+            NSMenuItem *coreMenuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Play With\u2026", @"Submenu listing available cores for this system") action:NULL keyEquivalent:@""];
+            [coreMenuItem setSubmenu:coreSubmenu];
+            [menu addItem:coreMenuItem];
+        }
+
         // Create Save State Menu
         menuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Play Save State", @"") action:NULL keyEquivalent:@""];
         [menuItem setSubmenu:[self OE_saveStateMenuForGame:game]];
@@ -710,6 +718,7 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
     [menu setAutoenablesItems:YES];
     return menu;
 }
+
 
 - (NSMenu *)OE_saveStateMenuForGame:(OEDBGame *)game
 {

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		5A575DFD1E92D23600491B0D /* Cheats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A575DFC1E92D23600491B0D /* Cheats.swift */; };
 		5A6C157C1DC96C3700839986 /* OEMediaViewController+TouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6C157B1DC96C3700839986 /* OEMediaViewController+TouchBar.swift */; };
 		5A6E80A71DCA6B210022F2AE /* OEGameCollectionViewController+TouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6E80A61DCA6B210022F2AE /* OEGameCollectionViewController+TouchBar.swift */; };
+		OE0001AA0001AA0001AA0001 /* OEGameCollectionViewController+CoreMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = OE0001AA0001BB0001AA0001 /* OEGameCollectionViewController+CoreMenu.swift */; };
 		5A79F7951C15F542003124D5 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A79F7941C15F542003124D5 /* PreferencesWindowController.swift */; };
 		5A9606D21C0A5A570089B494 /* NSManagedObjectContext+LibraryDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9606D11C0A5A570089B494 /* NSManagedObjectContext+LibraryDatabase.swift */; };
 		5A9606D41C0A63740089B494 /* NSMutableDictionary+Pop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9606D31C0A63740089B494 /* NSMutableDictionary+Pop.swift */; };
@@ -1471,6 +1472,7 @@
 		5A575DFC1E92D23600491B0D /* Cheats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cheats.swift; sourceTree = "<group>"; };
 		5A6C157B1DC96C3700839986 /* OEMediaViewController+TouchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEMediaViewController+TouchBar.swift"; sourceTree = "<group>"; };
 		5A6E80A61DCA6B210022F2AE /* OEGameCollectionViewController+TouchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEGameCollectionViewController+TouchBar.swift"; sourceTree = "<group>"; };
+		OE0001AA0001BB0001AA0001 /* OEGameCollectionViewController+CoreMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEGameCollectionViewController+CoreMenu.swift"; sourceTree = "<group>"; };
 		5A79F7941C15F542003124D5 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
 		5A9606D11C0A5A570089B494 /* NSManagedObjectContext+LibraryDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+LibraryDatabase.swift"; sourceTree = "<group>"; };
 		5A9606D31C0A63740089B494 /* NSMutableDictionary+Pop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableDictionary+Pop.swift"; sourceTree = "<group>"; };
@@ -3251,6 +3253,7 @@
 				8306CD3B1BD3DB180025BC6C /* OEGameCollectionViewController.h */,
 				8306CD3C1BD3DB180025BC6C /* OEGameCollectionViewController.m */,
 				5A6E80A61DCA6B210022F2AE /* OEGameCollectionViewController+TouchBar.swift */,
+				OE0001AA0001BB0001AA0001 /* OEGameCollectionViewController+CoreMenu.swift */,
 				8306CD3D1BD3DB180025BC6C /* OEGameCollectionViewItemProtocol.h */,
 				5AFD06BC2058893B00DFE765 /* GameScannerViewController.swift */,
 				8F40EB811C1072B200683055 /* GameScanner.xib */,
@@ -6566,6 +6569,7 @@
 				8FEC1BA024F7D37700DBBF72 /* TextButton.swift in Sources */,
 				83CB0C7A1A3F000700409FB2 /* BlankSlateSpinnerView.swift in Sources */,
 				5A6E80A71DCA6B210022F2AE /* OEGameCollectionViewController+TouchBar.swift in Sources */,
+				OE0001AA0001AA0001AA0001 /* OEGameCollectionViewController+CoreMenu.swift in Sources */,
 				14F6A926168180D00071386D /* GameWindowController.swift in Sources */,
 				8F957B4225227175008A9BC9 /* GlossButton.swift in Sources */,
 				0519A89F25AA4CD800D71C21 /* ShaderControl.swift in Sources */,

--- a/OpenEmuKit/Source/OECorePlugin.swift
+++ b/OpenEmuKit/Source/OECorePlugin.swift
@@ -57,7 +57,7 @@ public class OECorePlugin: OEPlugin {
         })
     }
     
-    public static func corePlugins(forSystemIdentifier identifier: String) -> [OECorePlugin] {
+    @objc public static func corePlugins(forSystemIdentifier identifier: String) -> [OECorePlugin] {
         return allPlugins.filter { $0.systemIdentifiers.contains(identifier) }
     }
     


### PR DESCRIPTION
## Summary

- Right-clicking a game in the library now shows a **Play With…** submenu listing every installed core for that game's system
- Selecting a core launches the game immediately with that specific core, bypassing the system default
- The submenu only appears when more than one core is installed for the system (consistent with the in-game core switcher)

## What's different

Before: right-clicking a game gave no way to choose which core to use — you had to change the default in Preferences → Cores, launch, then change it back.

After: core selection is one right-click away, non-destructive (doesn't change your default), and consistent with how the in-game control bar already works.

## How this works

- **`GameCollectionViewController`** — new `coreMenu(for:)` private helper queries `OECorePlugin.corePlugins(forSystemIdentifier:)` and builds a sorted submenu. Each item targets the new `startSelectedGame(withCore:)` action via the responder chain.
- **`LibraryController`** — new `@IBAction startSelectedGame(withCore:)` reads the chosen `OECorePlugin` from the sender's `representedObject` and forwards via a new optional delegate method `libraryController(_:didSelectGame:withCore:)`.
- **`MainWindowController`** — implements the new delegate method, threading the core through to `openGameDocument`.
- **`NSDocumentController+Additions` / `GameDocumentController`** — new `openGameDocument(with:core:display:fullScreen:completionHandler:)` overload passes the explicit core to `OEGameDocument(game:core:)` (which already existed and handled it correctly).

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

**To verify:**
1. Make sure you have at least two cores installed for one system (e.g. NES has both FCEU and Nestopia, SNES has both SNES9x and BSNES)
2. Right-click any game for that system in the library
3. Confirm **Play With…** appears between **Play Game** and **Play Save State**
4. Confirm the submenu lists both core names
5. Select the non-default core — the game should launch with it (check the window title bar or in-game core switcher to confirm)
6. For a system with only one core installed, confirm **Play With…** does **not** appear in the menu

## QA Spec

- [ ] "Play With…" submenu appears for multi-core systems (NES, SNES)
- [ ] "Play With…" is absent for single-core systems (e.g. GBA → mGBA only)
- [ ] Selecting a non-default core launches with that core
- [ ] Selecting the default core launches normally
- [ ] Default Preferences → Cores setting is unchanged after using Play With…
- [ ] No crash when right-clicking a game with no ROM file on disk

Made with [Cursor](https://cursor.com)