### PR TITLE
chore: add workflow_dispatch to release workflow and update SUPPORT.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.0.7) — must match CFBundleShortVersionString in Info.plist'
+        required: true
 
 jobs:
   release:
@@ -79,13 +84,17 @@ jobs:
           echo "DMG=${{ github.workspace }}/Releases/OpenEmu-Silicon.dmg" >> $GITHUB_ENV
 
       # ── Parse and validate version ──────────────────────────────────────────
-      - name: Parse version from tag
+      - name: Parse version from tag or input
         run: |
-          TAG="${{ github.ref_name }}"
-          VERSION="${TAG#v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            TAG="${{ github.ref_name }}"
+            VERSION="${TAG#v}"
+          fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-            || { echo "ERROR: Tag '$TAG' is not in vX.Y.Z format."; exit 1; }
+            || { echo "ERROR: Version '$VERSION' is not in X.Y.Z format."; exit 1; }
 
       - name: Validate Info.plist version matches tag
         run: |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,3 +1,11 @@
 # Support
 
 ⚠️🕹 In order to reduce duplicate and low information issues opened, please read the [Reporting problems guide](https://github.com/nickybmon/OpenEmu-Silicon/wiki/Troubleshooting:-Reporting-Problems) before opening a new one.
+
+## Response policy
+
+- **Critical bugs** (app won't launch, cores can't load) are patched as fast as possible and released as a patch version.
+- **Non-critical bugs** are batched into periodic patch releases — roughly every 2–4 weeks when fixes are accumulating.
+- **Enhancements and new cores** ship in minor versions (v1.1.0+) and are tracked on the roadmap.
+- Issues are triaged on a best-effort basis; I aim to respond within a few days.
+- This project is maintained solo in my spare time. Your patience is genuinely appreciated.


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `release.yml` so releases can be kicked off manually from the GitHub Actions UI (enter a version like `1.0.7`) — no tag push required
- Adds a response policy section to `SUPPORT.md` setting expectations around critical vs. non-critical bug response times and release cadence

## Test plan

- [ ] Confirm the Actions UI shows a "Run workflow" button on the release workflow with a version input field
- [ ] Verify existing tag-push trigger still works (no regression)
- [ ] Review SUPPORT.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)