### PR TITLE
docs: add ADR directory with first three architecture decision records

### DIFF
--- a/docs/adr/0001-monorepo-with-flattened-cores.md
+++ b/docs/adr/0001-monorepo-with-flattened-cores.md
@@ -1,0 +1,38 @@
+# ADR-0001: Monorepo with flattened emulator cores
+
+## Status
+
+Accepted
+
+## Context
+
+The original OpenEmu project used a multi-repo structure: a main app repo, separate repos per emulator core plugin under the OpenEmu GitHub organization, and a shared OpenEmu-SDK repo. Each core had its own maintainers and release cadence. Submodules linked everything together.
+
+This fork (OpenEmu-Silicon) began as a solo effort to port everything to Apple Silicon (arm64). The question arose: should this project maintain the same multi-repo structure, or consolidate into a single repo?
+
+Factors considered:
+- **Team size.** This project has one primary maintainer. Multi-repo coordination overhead (cross-repo PRs, submodule sync, per-repo CI setup) scales with team size; it does not provide value with a single maintainer.
+- **Core maintenance model.** The emulator cores in this fork are mostly frozen upstream forks. The work is ARM64 compatibility fixes and macOS version updates, not active feature development on the cores themselves. There is no reason for a core to have independent contributors or a separate issue tracker.
+- **Git submodules.** Active submodule tracking requires discipline to keep in sync and creates confusion when contributors forget to `git submodule update`. For frozen-ish cores, the friction outweighs the benefits.
+- **Independent core releases.** A meaningful benefit of the original structure was being able to ship a core update without a full app release. This benefit is preserved in the current setup via `cores-v*` tags, per-core appcast files under `Appcasts/`, and the `CoreUpdater` mechanism — without requiring separate repos.
+
+## Decision
+
+All emulator cores, the main app, OpenEmu-SDK, OpenEmuKit, and OpenEmu-Shaders live in a single repository (`nickybmon/OpenEmu-Silicon`). Cores are regular tracked directories — not active git submodules. They can receive fixes via normal PRs.
+
+Independent core releases are handled at the release layer: `gh workflow run release-core.yml` builds and ships a single core plugin independently, updating its `Appcasts/<CoreName>.xml`. The `CoreUpdater` mechanism delivers these to users without requiring a full app update.
+
+## Consequences
+
+**Easier:**
+- All work happens in one place — no cross-repo coordination
+- CI/CD is simpler (one workflow file set manages everything)
+- Issues and PRs have a single tracker and a single history
+- Onboarding a contributor means cloning one repo
+
+**Harder:**
+- Pulling upstream fixes from an original core's repo requires a manual cherry-pick or merge, not `git submodule update`
+- If a core ever becomes actively maintained upstream with frequent commits, the flat structure makes tracking that harder
+
+**Risk accepted:**
+If a core in this repo diverges significantly from its upstream, re-merging upstream changes could be complex. This is accepted given the current maintenance model (ARM64/macOS compatibility fixes, not upstream feature tracking).

--- a/docs/adr/0002-pre-built-vendor-frameworks.md
+++ b/docs/adr/0002-pre-built-vendor-frameworks.md
@@ -1,0 +1,42 @@
+# ADR-0002: Commit pre-built vendor frameworks alongside source
+
+## Status
+
+Accepted
+
+## Context
+
+The project depends on two third-party C libraries: **XADMaster** (archive extraction) and **UniversalDetector** (character encoding detection). These are used by the ROM importer.
+
+The repo contains both:
+- `Vendor/XADMaster/` and `Vendor/UniversalDetector/` — full source trees with Xcode projects
+- `OpenEmu/XADMaster.framework/` and `OpenEmu/UniversalDetector.framework/` — pre-compiled macOS framework bundles (Mach-O arm64 + x86_64)
+
+This was audited in May 2026: the `.framework` bundles in `OpenEmu/` are compiled outputs of the `Vendor/` source trees. The relationship is one-way (source → binary). They are not redundant copies — they serve different purposes.
+
+## Decision
+
+Both the source trees (`Vendor/`) and the compiled framework bundles (`OpenEmu/*.framework/`) are committed to the repository.
+
+- **Source trees are kept** so they can be audited, rebuilt, or patched if needed without fetching from external sources.
+- **Pre-built binaries are committed** so the main app can build without requiring contributors to compile the dependencies from scratch. This keeps the build self-contained.
+
+The frameworks are treated as build inputs, not build outputs — they are checked in and not regenerated on every build.
+
+## Consequences
+
+**Easier:**
+- `xcodebuild` builds succeed without any dependency fetch step
+- Source is available for auditing or patching without fetching from GitHub
+- New contributors can build immediately after cloning
+
+**Harder:**
+- When updating XADMaster or UniversalDetector to a new version, both the source tree and the compiled frameworks must be updated together
+- Framework bundles are binary files — diffs are not human-readable and PRs touching them must be reviewed by building from source and comparing behavior
+- Repo size is larger than if only source were tracked
+
+**What to do on update:**
+1. Update `Vendor/<LibraryName>/` source
+2. Build the framework for arm64 (and x86_64 if universal is required)
+3. Replace `OpenEmu/<LibraryName>.framework/` with the new build
+4. Open a PR with both changes; describe what changed and why

--- a/docs/adr/0003-claude-tooling-split.md
+++ b/docs/adr/0003-claude-tooling-split.md
@@ -1,0 +1,45 @@
+# ADR-0003: Three-file split for AI agent instructions
+
+## Status
+
+Accepted
+
+## Context
+
+As Claude Code sessions accumulated over this project, the `.claude/CLAUDE.md` file grew to 566 lines mixing behavioral rules (what Claude should do), reference facts (file layout, build commands, license tables), and domain vocabulary. Every token in CLAUDE.md is read at the start of every Claude Code session — "always-on" context. At that size it was consuming a significant portion of the smart-zone context before any work began.
+
+The risk: large, mixed always-on context degrades session quality. It also duplicates content already in `AGENTS.md` and in the slash commands, creating drift.
+
+Separately, there was no shared domain glossary. Terms like `core`, `plugin`, `oecoreplugin`, `broker`, `appcast`, `libretro bridge`, and `hardcore mode` were used inconsistently across commits, issue titles, and PR descriptions.
+
+## Decision
+
+Agent instructions are split across three files with a clear purpose boundary:
+
+| File | Purpose | Audience |
+|---|---|---|
+| `AGENTS.md` | Canonical project facts: build commands, branch/PR rules, file layout, supported cores, license, what NOT to do. Authoritative. | All agents and human contributors |
+| `.claude/CLAUDE.md` | Claude-specific behavioral rules only: hard rules, verification workflow, autonomy guidance, issue-hygiene reminders, memory discipline. Target: under 200 lines. | Claude Code sessions only |
+| `CONTEXT.md` | Domain glossary: terms used distinctively in this codebase with precise definitions. | All agents and human contributors |
+
+**Rule:** If content belongs in `AGENTS.md` (a fact about the project) or `CONTEXT.md` (a vocabulary term), it must not be duplicated in `CLAUDE.md`. `CLAUDE.md` grows only when a new behavioral pattern is discovered — not when project facts change.
+
+If `.claude/CLAUDE.md` ever exceeds ~200 lines, something has been added that belongs in one of the other two files.
+
+## Consequences
+
+**Easier:**
+- Each session starts with ~1,000 words of always-on context instead of ~3,500
+- Project facts live in one place (`AGENTS.md`) — when something changes, only one file needs updating
+- Vocabulary questions have a single authoritative answer (`CONTEXT.md`)
+- `/grill-with-docs` and `/improve-codebase-architecture` skills (which read `CONTEXT.md` and `docs/adr/`) now have accurate inputs
+
+**Harder:**
+- Three files to maintain instead of one
+- Contributors (human and AI) must know which file to update for a given kind of change
+
+**Maintenance rule:**
+- New behavioral pattern discovered (how Claude should act) → `CLAUDE.md`
+- New project fact (what the project does, how it's built) → `AGENTS.md`
+- New domain term or renamed concept → `CONTEXT.md`
+- Non-obvious architectural decision → new `docs/adr/NNNN-*.md`

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,17 @@
+# ADR-NNNN: [Decision title]
+
+## Status
+
+Accepted | Superseded by ADR-XXXX | Deprecated
+
+## Context
+
+Why this decision was needed. What forces, constraints, or requirements drove it.
+
+## Decision
+
+What was decided. Be specific.
+
+## Consequences
+
+What this makes easier. What it makes harder. Any risks accepted.


### PR DESCRIPTION
## Summary

Adds `docs/adr/` with a template and three ADRs backfilling foundational decisions that previously lived only as commit-message prose.

- **ADR-0001** — monorepo with flattened cores (vs. the original OpenEmu multi-repo/submodule structure): why it's the right call for a solo maintainer, and how independent core releases are preserved
- **ADR-0002** — pre-built vendor frameworks (`Vendor/` source + `OpenEmu/*.framework` binaries both committed): not redundant, one-way build pipeline, update procedure
- **ADR-0003** — the `AGENTS.md` / `.claude/CLAUDE.md` / `CONTEXT.md` three-file split: purpose boundaries and maintenance rules

These are docs-only. No code changes.

## Test plan

- [ ] Read each ADR and confirm it accurately describes current project state
- [ ] Confirm `docs/adr/` is visible in the repo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)