### PR TITLE
chore: fix PR template test steps for current workspace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,18 +24,19 @@ Fixes #
 
 ## How to test locally
 
-Navigate to your local clone, then paste this block. Replace `<PR_NUMBER>` with this PR's number. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.
+Replace `NUMBER` with this PR's number, then paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.
 
 ```bash
 cd ~/Documents/Cursor/Open\ Emu
-gh pr checkout <PR_NUMBER> --repo nickybmon/OpenEmu-Silicon
+gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
 xcodebuild \
-  -workspace OpenEmu-metal.xcworkspace \
+  -workspace OpenEmu.xcworkspace \
   -scheme OpenEmu \
   -configuration Debug \
   -destination 'platform=macOS,arch=arm64' \
   build 2>&1 | tail -20
-DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug 2>/dev/null | head -1)
+DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
+codesign --force --deep --sign - "$DEBUG_DIR/OpenEmu.app"
 open "$DEBUG_DIR/OpenEmu.app"
 ```
 
@@ -55,7 +56,7 @@ codesign --force --sign - \
 ## PR checklist
 
 - [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
-- [ ] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
+- [ ] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
 - [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
 - [ ] No build logs, binaries, or credentials committed
 - [ ] Copyright headers preserved on all modified files


### PR DESCRIPTION
## What does this PR do?

Three stale issues in the "How to test locally" block that caused failures when testing PR #299:

1. Workspace name was `OpenEmu-metal.xcworkspace` — the repo is `OpenEmu.xcworkspace`
2. DerivedData glob was `OpenEmu-metal-*` — the actual pattern is `OpenEmu-*`
3. `<PR_NUMBER>` angle-bracket placeholder caused a `zsh: no such file or directory` error when pasted verbatim — replaced with bare `NUMBER` so the error is obvious
4. Added `codesign --force --deep --sign -` before `open` — without it, macOS shows "executable is missing" on the freshly built debug app

## Which cores or systems are affected?

Template / docs only — no code changes.

## Did you use AI tools?

Yes — Claude flagged and drafted the fix.

## Linked issues

Related to #299