### PR TITLE
fix: restore Controls panel wood texture broken by onboarding redesign (#282)

### DIFF
--- a/OpenEmu/BackgroundImageView.swift
+++ b/OpenEmu/BackgroundImageView.swift
@@ -24,28 +24,21 @@
 
 import Cocoa
 
-/// Modern frosted-glass panel used as content cards in the setup assistant.
-/// Replaces the old nine-part stretched image approach with a system-native
-/// NSVisualEffectView embedded in a layer-backed container.
 final class BackgroundImageView: NSView {
 
-    // Kept for XIB compatibility — no longer used for drawing
     @IBInspectable var background: NSImage?
     @IBInspectable var image: NSImage?
 
-    private var didSetup = false
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setup()
+    // After IB wires up IBInspectable properties: use image drawing when images
+    // are set (Controls panel wood texture), frosted glass otherwise (setup assistant).
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        if background == nil && image == nil {
+            setupFrostedGlass()
+        }
     }
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        setup()
-    }
-
-    private func setup() {
+    private func setupFrostedGlass() {
         wantsLayer = true
         layer?.cornerRadius = 12
         layer?.cornerCurve = .continuous
@@ -65,4 +58,11 @@ final class BackgroundImageView: NSView {
             fx.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
     }
+
+    override func draw(_ dirtyRect: NSRect) {
+        background?.draw(in: dirtyRect, from: .zero, operation: .sourceOver, fraction: 1, respectFlipped: isFlipped, hints: nil)
+        image?.draw(in: dirtyRect, from: dirtyRect, operation: .sourceOver, fraction: 1, respectFlipped: isFlipped, hints: nil)
+    }
+
+    override var isFlipped: Bool { false }
 }


### PR DESCRIPTION
## What does this PR do?

Commit 6f47e40 (#282) replaced `BackgroundImageView`'s original `draw()` with a frosted-glass `NSVisualEffectView` for the setup assistant. `PrefControlsController.xib` and `PrefControlsController2.xib` both use the same class and depended on `draw()` to render the wood grain background — that texture silently disappeared as collateral damage.

**Root cause:** `setup()` was called in `init(coder:)`, before IB had wired the `@IBInspectable` `background`/`image` properties, so there was no way to distinguish the two use cases at init time.

**Fix:** Move the decision to `awakeFromNib()`, which fires after IB properties are set:
- If no images are wired (setup assistant) → install the frosted glass panel
- If images are wired (Controls panel) → use the original `draw()` path

No XIB changes required.

## What did you test?

- Opened Controls preferences — wood texture is restored
- Opened setup assistant — frosted glass panels still display correctly
- Build passes on Apple Silicon (M2)

## Which cores or systems are affected?

App UI only — no emulation code touched.

## Did you use AI tools?

Yes — Claude identified the regression source and drafted the fix.

## Linked issues

Regression introduced in #282

---

## How to test locally

Replace `301` with this PR's number if needed, then paste the whole block.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 301 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
codesign --force --deep --sign - "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

Then open **Preferences → Controls** and confirm the wood texture is visible. Also open the setup assistant (delete `~/Library/Application Support/OpenEmu/SetupAssistant.db` to re-trigger it) and confirm frosted glass panels still appear.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes
- [x] Tested on Apple Silicon (M2)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved