### PR TITLE
chore: auto-resolve Apple Development signing identity in PR test steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,9 +36,12 @@ xcodebuild \
   -destination 'platform=macOS,arch=arm64' \
   build 2>&1 | tail -20
 DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
-codesign --force --deep --sign - "$DEBUG_DIR/OpenEmu.app"
+SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
+codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
 open "$DEBUG_DIR/OpenEmu.app"
 ```
+
+The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.
 
 If this PR touches a core, install it before the `open` line:
 


### PR DESCRIPTION
## What does this PR do?

Replaces ad-hoc signing (`codesign --sign -`) in the PR template's local-test block with a one-liner that auto-discovers the tester's local Apple Development identity via `security find-identity`.

**Why this matters:** the project hardcodes `CODE_SIGN_IDENTITY = "-"` for all configurations, so terminal-built debug binaries ship with no stable identity. Every rebuild produced a fresh ad-hoc signature, which macOS treats as a brand-new app for both TCC (Privacy permissions) and Keychain ACL purposes. Testers were hitting:

- Input Monitoring resetting on every rebuild
- Keychain re-prompts on every launch (RetroAchievements, ScreenScraper)
- Mysterious permission popups that looked like PR regressions but weren't

Signing with a stable Apple Development identity makes macOS recognize the same app across rebuilds. Permissions persist.

Fallback: if a tester has no Apple Development cert, the script falls back to ad-hoc (`-`) so nothing breaks for new contributors.

## Which cores or systems are affected?

Docs / tooling only — no code changes.

## Did you use AI tools?

Yes — Claude diagnosed the cascade of permission issues and wrote the fix.

## Linked issues

Related to #299 #302