### PR TITLE
fix(verify): resolve --core <Name> to combined workspace scheme

### DIFF
--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -44,7 +44,15 @@ info() { echo "----  $1"; }
 # --- Build ---------------------------------------------------------------
 
 if [ -n "$CORE" ]; then
-  SCHEME="$CORE"
+  # Workspace schemes are named "OpenEmu + <Core>" for the combined host+core build.
+  # Some cores also have a bare scheme (e.g. "4DO", "BSNES") — prefer the combined one.
+  COMBINED_SCHEME="OpenEmu + $CORE"
+  AVAILABLE=$(xcodebuild -workspace "$WORKSPACE" -list 2>/dev/null | awk '/Schemes:/,0' | tail -n +2)
+  if echo "$AVAILABLE" | grep -qxF "        $COMBINED_SCHEME"; then
+    SCHEME="$COMBINED_SCHEME"
+  else
+    SCHEME="$CORE"
+  fi
   info "Building core scheme: $SCHEME"
 else
   SCHEME="OpenEmu"
@@ -88,7 +96,9 @@ if [ -z "$CORE" ]; then
   PLISTS=("$APP_PLIST" "$APP_ENTITLEMENTS")
 else
   # Each core has its own Info.plist somewhere in its directory.
-  mapfile -t PLISTS < <(find "$CORE" -maxdepth 3 -name 'Info.plist' 2>/dev/null)
+  # Use while-read instead of mapfile to stay compatible with macOS bash 3.x.
+  PLISTS=()
+  while IFS= read -r p; do PLISTS+=("$p"); done < <(find "$CORE" -maxdepth 3 -name 'Info.plist' 2>/dev/null)
 fi
 
 for p in "${PLISTS[@]:-}"; do


### PR DESCRIPTION
## What does this PR do?

`./Scripts/verify.sh --core Mednafen` (and any other core) was failing immediately because line 44 set `SCHEME="$CORE"` — passing the bare core name to xcodebuild. The workspace only has combined schemes like `OpenEmu + Mednafen`, `OpenEmu + Flycast`, etc. (bare schemes like `Mednafen` don't exist for most cores).

The fix queries `xcodebuild -list` at runtime to detect whether `OpenEmu + <Core>` exists and uses it; falls back to the bare name for cores that do have standalone schemes (e.g. `4DO`, `BSNES`).

Also replaces `mapfile` (bash 4+ only) with a `while IFS= read` loop in the plist scan path, fixing a secondary `mapfile: command not found` error on macOS's default bash 3.x.

## What did you test?

- Reproduced the failure: `./Scripts/verify.sh --core Mednafen` returned `FAIL build (Mednafen)` (xcodebuild: scheme not found)
- After fix: scheme is correctly resolved to `OpenEmu + Mednafen`; build progresses past the scheme-selection step
- `./Scripts/verify.sh --launch` (main app path): build PASS, codesign PASS, smoke launch PASS, no crash reports — pre-existing analyze timeout on SPIRV C++ is unrelated to this change
- Scheme detection logic verified for both existing (`OpenEmu + Mednafen` → matches) and non-existent (`OpenEmu + FakeCore` → falls back) cases

## Which cores or systems are affected?

Scripts / CI only — no emulation core changes. Affects `--core <Name>` invocations for all cores that lack a bare scheme: Mednafen, FCEU, Flycast, Gambatte, GenesisPlus, mGBA, Mupen64Plus, Nestopia, SNES9x, Stella (and any future cores added without a standalone scheme).

## Did you use AI tools?

Yes — fix drafted and tested with Claude Code (Sonnet 4.6).

## Linked issues

Fixes #

---

## How to test locally

Replace `NUMBER` with this PR's number, then paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

Then verify scheme resolution works:

```bash
./Scripts/verify.sh --core Mednafen 2>&1 | head -5
# Should print: ----  Building core scheme: OpenEmu + Mednafen
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header