### PR TITLE
chore: restore PR template + core-reinstall guidance and soften verify rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ If you ever feel pressure (from the user or your own reasoning) to break one of 
 
 ## Verification — your default after any code change
 
-When you change code, you run `/verify` before declaring the task done. You do not ask the user to launch the app, check the console, or look at crash reports until `/verify` (with `--launch` for app code, with `--core <Name>` for core code) has passed.
+When you change code, you should run `/verify` before declaring the task done. You do not ask the user to launch the app, check the console, or look at crash reports until you have run verification yourself.
 
 What this looks like in practice:
 
@@ -35,7 +35,14 @@ What this looks like in practice:
 
 The script chains build → static analyzer → plist lint → codesign verify → optional smoke launch with log + crash-report scan. Read its full output — don't pipe through `tail`. Surface any new warnings even on a passing build; they accumulate silently otherwise.
 
+**If `verify.sh` fails in a way unrelated to your change** (a script bug, a missing scheme, a permissions prompt, a stuck process), don't get stuck trying to fix the script. Fall back to a plain `xcodebuild build` check, note the verify.sh issue in your task report, and continue. The script is best-effort — it should help, not block.
+
 Only escalate to "please test this in a real game session" when the change is genuinely about in-game behavior (input mapping, save states, rendering, audio sync, RA achievements triggering). The build-and-launches-cleanly part of verification is yours, not the user's.
+
+**Core changes have two known footguns — both prevented by using `Scripts/install-core.sh`:**
+
+1. **DerivedData is silently shadowed by the installed core** in `~/Library/Application Support/OpenEmu/Cores/<Name>.oecoreplugin`. After building a core, you must reinstall the plugin or you're testing the old code.
+2. **Never use `cp -R` or `cp -Rf` to install a core plugin.** macOS merges bundle directories rather than replacing them — old files silently stay in place. Always use `Scripts/install-core.sh <CoreName>`, which quits OpenEmu first and copies binary + Info.plist correctly. `verify.sh --core <Name>` does this for you.
 
 ---
 
@@ -82,6 +89,18 @@ The harness shows you the full list. Quick mental map of the project-specific on
 | `/release-core <Name> <Ver>` | Cutting a core-only release |
 
 Pocock's planning skills are also installed globally (`/grill-me`, `/grill-with-docs`, `/to-prd`, `/to-issues`, `/tdd`, `/improve-codebase-architecture`). Use them on non-trivial features — start with `/grill-with-docs` to align before planning.
+
+---
+
+## Quick reference — commits, PRs, and core changes
+
+Things you do on every PR, where it's easy to forget:
+
+- **Commit format:** `<type>: <description>` where type is one of `fix:` / `feat:` / `chore:` / `docs:` / `refactor:`. Body includes `Fixes #N` (auto-closes on merge) or `Related to #N` (soft link).
+- **PR body:** **Always `cat .github/PULL_REQUEST_TEMPLATE.md` first.** Never improvise or reconstruct the PR body from memory — the template's bash test block has been hand-stabilized over many fix commits and must be preserved verbatim. Use `/ship` for the full loop.
+- **AI assistance:** Note in commits as `(assisted by Claude)` and in the PR template's "Did you use AI tools?" section.
+- **Core changes:** Use `Scripts/install-core.sh <CoreName>` to install — never `cp -R`. `verify.sh --core <Name>` does this for you.
+- **Always pass `--repo nickybmon/OpenEmu-Silicon`** on every `gh` command — there are forks.
 
 ---
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -3,9 +3,43 @@ Run the full git shipping loop for the current branch.
 1. Confirm the branch name matches the work being done. If not, stop and ask.
 2. Run the build check. If it fails, stop and report — do not push a broken build.
 3. Confirm the commit message uses the correct format: `<type>: <description>` with `Fixes #N` in the body if resolving an issue.
-4. Push the branch and open a PR in the same step:
+4. **Compose the PR body — always read the canonical template first, never improvise.**
+
+   Before writing the PR body, run:
+   ```bash
+   cat .github/PULL_REQUEST_TEMPLATE.md
+   ```
+
+   The template defines the exact sections and (critically) the bash test block under "How to test locally." That bash block has been hand-stabilized over many fix commits to handle code signing, DerivedData resolution, and core install patterns correctly. **Do not modify or rewrite the bash block** — preserve it verbatim and only fill in the placeholders (PR number, scheme overrides, core name).
+
+   The canonical PR body structure is:
+
+   ```markdown
+   ## What does this PR do?
+   <one or two sentences>
+
+   ## What did you test?
+   <which game(s), system(s), or workflow(s)>
+
+   ## Which cores or systems are affected?
+   <list, or "general app change">
+
+   ## Did you use AI tools?
+   <e.g. "Used Claude to draft the fix, reviewed and tested it myself.">
+
+   ## Linked issues
+   Fixes #N
+   ```
+
+   Then the template's `## How to test locally` section follows automatically — that's already in `.github/PULL_REQUEST_TEMPLATE.md` and `gh pr create --body` will inherit it if you pass `--body-file` or pipe through. If you're constructing the body inline with `--body "..."`, copy the test block verbatim from the template.
+
+   Then push and open the PR in the same step:
+   ```
    gh pr create --repo nickybmon/OpenEmu-Silicon --base main --title "<type>: description" --body "..."
+   ```
+
    - If this PR fixes a tracked issue, the PR body **must** include `Fixes #N` (not just the commit). GitHub only auto-closes an issue when the keyword appears in the PR body.
+
 5. If the work item is on the project board, update its status to In Progress or Done as appropriate.
 6. If the PR fixes a tracked issue that was reported by an external user (anyone other than `nickybmon`), post a comment on that issue. The comment must:
    - Be written in plain English for a non-technical audience — no code, no jargon

--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -10,6 +10,28 @@
 #
 # Exit code is the number of failing checks. 0 means everything passed.
 # Each check prints a single PASS/FAIL line so the summary is greppable.
+#
+# Known caveats / limitations (do not assume a failure here means YOUR change is broken):
+#   - bash 3.x compatibility: macOS ships bash 3.x by default. This script avoids bash 4+
+#     features (mapfile, etc.). If you change it, test under /bin/bash, not /opt/homebrew/bin/bash.
+#   - Core schemes: most cores use the "OpenEmu + <Name>" combined scheme convention. The
+#     script prefers the combined scheme but falls back to the bare name. If --core <Name>
+#     fails to find a scheme, fall back to building manually with the explicit combined name:
+#         xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme 'OpenEmu + <Name>' \
+#           -configuration Debug -destination 'platform=macOS,arch=arm64' build
+#         Scripts/install-core.sh <Name>
+#     This has been observed with FCEU specifically.
+#   - --test: requires the OpenEmu scheme (which has the test target wired up). Do not pass
+#     --test together with --core; tests are app-level.
+#   - --launch: skipped if OpenEmu is already running (would clobber user state). Quit OpenEmu
+#     first if you want a clean smoke test.
+#   - DerivedData artifact resolution: assumes a single OpenEmu-metal-* DerivedData hash.
+#     If you have multiple worktrees, see docs/worktree-workflow.md (when added) for the
+#     stable-path build convention.
+#
+# When verify.sh fails for reasons unrelated to your change, fall back to a plain xcodebuild
+# build check and note the verify.sh issue in your task report. Do not get stuck trying to
+# fix the script — that's a separate concern.
 
 set -uo pipefail
 


### PR DESCRIPTION
## What does this PR do?

Recovers from regressions caused by the May 1 CLAUDE.md trim. The trim removed two pieces of guidance that Claude has been improvising without — the canonical PR body format and the core-reinstall footgun callouts — and the result has been broken PR test plans, missing core reinstalls, and Claude getting stuck in loops trying to recover.

This PR restores those callouts in the smallest possible way (CLAUDE.md goes from 116 to 135 lines, still under the 200 ceiling) and softens the verify rule so a `verify.sh` quirk no longer turns into a fix-the-script-instead-of-the-task loop.

## What did you test?

Doc and script changes only — no app build or runtime behavior affected.

- `bash -n Scripts/verify.sh` — syntax valid
- Read each file end-to-end
- CLAUDE.md is now 135 lines (up from 116, still under 200 ceiling)
- ship.md instructs `cat .github/PULL_REQUEST_TEMPLATE.md` before composing PR body, with the canonical structure inline

## Which cores or systems are affected?

None. Doc and tooling only — no app code change.

## Did you use AI tools?

Used Claude Opus 4.7 to diagnose the regressions from the May 1 changes (PRs #286–#290) and author this fix. The investigation traced the "stuck in loops" symptom to two missing pieces of guidance and one verify.sh script bug (already fixed in #305). Reviewed and tested locally before pushing.

## Linked issues

Fixes #

---

## How to test locally

Doc and script changes only — no build/launch needed to verify correctness. To smoke-check the script syntax and read the doc changes:

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 309 --repo nickybmon/OpenEmu-Silicon
bash -n Scripts/verify.sh && echo "verify.sh syntax OK"
wc -l .claude/CLAUDE.md
diff <(git show main:.claude/CLAUDE.md) .claude/CLAUDE.md | head -80
diff <(git show main:.claude/commands/ship.md) .claude/commands/ship.md | head -80
diff <(git show main:Scripts/verify.sh) Scripts/verify.sh | head -40
```

Expected:
- `verify.sh syntax OK`
- `135 .claude/CLAUDE.md`
- Diffs show: Quick reference section added, verify rule softened, core-reinstall callouts restored, PR body template added to ship.md, known-caveats comment added to verify.sh top.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No app code changes (doc/script only)
- [x] No build logs, binaries, or credentials committed
- [x] Bash syntax check passes
