### PR TITLE
feat: RetroAchievements — Mupen64Plus (Nintendo 64)

### DIFF
--- a/Mupen64Plus/Mupen64Plus.xcodeproj/project.pbxproj
+++ b/Mupen64Plus/Mupen64Plus.xcodeproj/project.pbxproj
@@ -297,6 +297,8 @@
 		EE2BBC46225AD5380007BF6F /* iob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE2BBC45225AD5370007BF6F /* iob.cpp */; };
 		EE2BBC48225AD6520007BF6F /* MemoryStatus_mupenplus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE2BBC47225AD6510007BF6F /* MemoryStatus_mupenplus.cpp */; };
                 8784175F25994FEF002ED39D /* linkage_arm64.S in Sources */ = {isa = PBXBuildFile; fileRef = 8784175E25994FEF002ED39D /* linkage_arm64.S */; };
+		OE0M64P0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0M64P0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1 -Dmd5_init=rc_md5_init -Dmd5_append=rc_md5_append -Dmd5_finish=rc_md5_finish"; }; };
+		OE0M64P0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0M64P0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1155,6 +1157,8 @@
 		EE2BBC44225AD5370007BF6F /* MemoryStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemoryStatus.h; path = ../../../Mupen64plus/GLideN64/src/MemoryStatus.h; sourceTree = "<group>"; };
 		EE2BBC45225AD5370007BF6F /* iob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = iob.cpp; path = ../../../Mupen64plus/GLideN64/src/iob.cpp; sourceTree = "<group>"; };
 		EE2BBC47225AD6510007BF6F /* MemoryStatus_mupenplus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MemoryStatus_mupenplus.cpp; path = ../../../../Mupen64plus/GLideN64/src/mupenplus/MemoryStatus_mupenplus.cpp; sourceTree = "<group>"; };
+		OE0M64P0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0M64P0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3296,6 +3300,8 @@
 				878419A325995AFB002ED39D /* dynamiclib_unix.c in Sources */,
 				878419AD25995AFF002ED39D /* files_unix.c in Sources */,
 				3D208F821182B00300BEAA42 /* MupenGameCore.m in Sources */,
+				OE0M64P0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
+				OE0M64P0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
 				3D8B35D812260F9D00C4C844 /* main.m in Sources */,
 				3D00F06D1183E4AA002995A1 /* eventloop.m in Sources */,
 				3D00F06E1183E4AA002995A1 /* osd.m in Sources */,
@@ -3398,6 +3404,9 @@
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/md5\"",
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/xxhash\"",
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/minizip\"",
+					"\"$(SRCROOT)/../Vendor/rcheevos/include\"",
+					"\"$(SRCROOT)/../Vendor/rcheevos/src\"",
+					"\"$(SRCROOT)/../OpenEmuKit/Source\"",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";
@@ -3459,6 +3468,9 @@
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/md5\"",
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/xxhash\"",
 					"\"$(SRCROOT)/mupen64plus-core/subprojects/minizip\"",
+					"\"$(SRCROOT)/../Vendor/rcheevos/include\"",
+					"\"$(SRCROOT)/../Vendor/rcheevos/src\"",
+					"\"$(SRCROOT)/../OpenEmuKit/Source\"",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(USER_LIBRARY_DIR)/Application Support/OpenEmu/Cores\"";

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -83,6 +83,7 @@ NSString *MupenControlNames[] = {
     rc_client_t *_rcClient;
     id _raTokenObserver;
     NSString *_romPath;
+    NSUInteger _raFrameCounter;
 }
 
 - (void)OE_didReceiveStateChangeForParamType:(m64p_core_param)paramType value:(int)newValue;
@@ -425,7 +426,7 @@ static void MupenSetAudioSpeed(int percent)
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, mupen_rc_event_handler);
         rc_client_set_hardcore_enabled(_rcClient, 0);
-        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mupen_rc_log);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_WARN, mupen_rc_log);
 
         __weak MupenGameCore *weakSelf = self;
         _raTokenObserver = [[NSNotificationCenter defaultCenter]
@@ -535,13 +536,18 @@ static void MupenSetAudioSpeed(int percent)
 
 - (void)videoInterrupt
 {
-    // Mupen runs M64CMD_EXECUTE on a separate emu thread, so executeFrame is empty.
-    // videoInterrupt fires once per VI on the emu thread — the right place to advance
-    // rcheevos one emulated frame.
-    if (_rcClient) {
+    // Signal "frame ready" first so the renderer presents on time.
+    // rcheevos work runs in the leftover budget before the next VI.
+    [self.renderDelegate didRenderFrameOnAlternateThread];
+
+    // Throttle rcheevos to every other VI (~30 Hz). RA condition timing
+    // measures in do_frame ticks, not wall-clock seconds, so this just
+    // means each "rcheevos frame" equals 2 emulated VIs. Mupen runs
+    // M64CMD_EXECUTE on a separate emu thread and executeFrame is a no-op,
+    // so videoInterrupt is the right place to advance rcheevos.
+    if (_rcClient && (++_raFrameCounter & 1) == 0) {
         rc_client_do_frame(_rcClient);
     }
-    [self.renderDelegate didRenderFrameOnAlternateThread];
 }
 
 - (void)swapBuffers

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -47,12 +47,18 @@
 #import "main/main.h"
 //#import "r4300/r4300.h"
 #import "device/r4300/r4300_core.h"
-//#import "device/rdram/rdram.h"
+#import "device/rdram/rdram.h"
+#import "device/device.h"
 #import "device/rcp/vi/vi_controller.h"
 
 #import "plugin/plugin.h"
 
 #import <dlfcn.h>
+#include <os/log.h>
+#define RC_CLIENT_SUPPORTS_HASH 1
+#include <rc_client.h>
+#include <rc_consoles.h>
+#import "OERetroAchievementsTransport.h"
 
 NSString *MupenControlNames[] = {
     @"N64_DPadU", @"N64_DPadD", @"N64_DPadL", @"N64_DPadR",
@@ -73,9 +79,14 @@ NSString *MupenControlNames[] = {
 
     dispatch_queue_t _callbackQueue;
     NSMutableDictionary *_callbackHandlers;
+
+    rc_client_t *_rcClient;
+    id _raTokenObserver;
+    NSString *_romPath;
 }
 
 - (void)OE_didReceiveStateChangeForParamType:(m64p_core_param)paramType value:(int)newValue;
+- (void)_beginLoadGame;
 
 @end
 
@@ -115,7 +126,84 @@ static void MupenStateCallback(void *context, m64p_core_param paramType, int new
     [((__bridge MupenGameCore *)context) OE_didReceiveStateChangeForParamType:paramType value:newValue];
 }
 
+#pragma mark - RetroAchievements
+
+// rcheevos N64 address space (Vendor/rcheevos/src/rcheevos/consoleinfo.c lines 728-733):
+//   0x000000-0x1FFFFF  RDRAM 1 (2 MB, always present)
+//   0x200000-0x3FFFFF  RDRAM 2 (2 MB, expansion pak only)
+//   0x400000-0x7FFFFF  padding for expansion pak
+//
+// Mupen stores RDRAM as host-native 32-bit words in g_dev.rdram.dram. RA hashes
+// and conditions assume big-endian byte ordering, so each byte read needs the
+// standard N64 byte-swap (addr ^ 3) on a little-endian host.
+static uint32_t mupen_rc_read_memory(uint32_t address, uint8_t *buffer,
+                                     uint32_t num_bytes, rc_client_t *client)
+{
+    uint8_t *ram = (uint8_t *)g_dev.rdram.dram;
+    size_t   sz  = g_dev.rdram.dram_size;
+    if (!ram || sz == 0) { return 0; }
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        uint32_t addr = address + i;
+        if (addr >= sz) { return i; }
+        buffer[i] = ram[addr ^ 3];
+    }
+    return num_bytes;
+}
+
+static void mupen_rc_log(const char *message, const rc_client_t *client)
+{
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
+}
+
+static void mupen_rc_load_game_callback(int result, const char *error_message,
+                                         rc_client_t *client, void *userdata)
+{
+    if (result != RC_OK)
+        NSLog(@"[RA-Mupen64Plus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+}
+
+static void mupen_rc_login_callback(int result, const char *error_message,
+                                     rc_client_t *client, void *userdata)
+{
+    MupenGameCore *s = (__bridge MupenGameCore *)userdata;
+    if (result == RC_OK) {
+        [s _beginLoadGame];
+    } else {
+        NSLog(@"[RA-Mupen64Plus] login failed — result=%d error=%s", result, error_message ?: "(none)");
+    }
+}
+
+static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
+    const rc_client_achievement_t *ach = event->achievement;
+    if (!ach) { return; }
+
+    NSDictionary *info = @{
+        OEAchievementIDKey:          @(ach->id),
+        OEAchievementTitleKey:       @(ach->title       ?: ""),
+        OEAchievementDescriptionKey: @(ach->description ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_name  ?: ""),
+        OEAchievementPointsKey:      @(ach->points),
+    };
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:OEAchievementUnlockedNotification
+                      object:nil
+                    userInfo:info];
+}
+
 @implementation MupenGameCore
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           RC_CONSOLE_NINTENDO_64,
+                                           _romPath.fileSystemRepresentation,
+                                           NULL, 0,
+                                           mupen_rc_load_game_callback,
+                                           (__bridge void *)self);
+}
 
 - (instancetype)init
 {
@@ -328,6 +416,39 @@ static void MupenSetAudioSpeed(int percent)
     if (CoreDoCommand(M64CMD_ROM_OPEN, (int)romData.length, (void *)romData.bytes) != M64ERR_SUCCESS)
         return NO;
 
+    // RetroAchievements: create rc_client and observe the OE token. Game identification
+    // happens in the login callback so we never miss the token notification that fires
+    // immediately after setRetroAchievementsToken.
+    _romPath = path;
+    _rcClient = rc_client_create(mupen_rc_read_memory, oeRetroAchievementsServerCall);
+    if (_rcClient) {
+        rc_client_set_userdata(_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(_rcClient, mupen_rc_event_handler);
+        rc_client_set_hardcore_enabled(_rcClient, 0);
+        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mupen_rc_log);
+
+        __weak MupenGameCore *weakSelf = self;
+        _raTokenObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            MupenGameCore *s = weakSelf;
+            if (!s || !s->_rcClient) { return; }
+            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 mupen_rc_login_callback,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -414,6 +535,12 @@ static void MupenSetAudioSpeed(int percent)
 
 - (void)videoInterrupt
 {
+    // Mupen runs M64CMD_EXECUTE on a separate emu thread, so executeFrame is empty.
+    // videoInterrupt fires once per VI on the emu thread — the right place to advance
+    // rcheevos one emulated frame.
+    if (_rcClient) {
+        rc_client_do_frame(_rcClient);
+    }
     [self.renderDelegate didRenderFrameOnAlternateThread];
 }
 
@@ -432,6 +559,15 @@ static void MupenSetAudioSpeed(int percent)
 
 - (void)stopEmulation
 {
+    if (_raTokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
+        _raTokenObserver = nil;
+    }
+    if (_rcClient) {
+        rc_client_unload_game(_rcClient);
+        rc_client_destroy(_rcClient);
+        _rcClient = NULL;
+    }
     CoreDoCommand(M64CMD_STOP, 0, NULL);
     [super stopEmulation];
 }
@@ -441,6 +577,9 @@ static void MupenSetAudioSpeed(int percent)
     // FIXME: do we want/need soft reset? It doesn’t seem to work well with sending M64CMD_RESET alone
     // FIXME: might need to explicitly kick other thread
     CoreDoCommand(M64CMD_RESET, 1 /* hard reset */, NULL);
+    if (_rcClient) {
+        rc_client_reset(_rcClient);
+    }
 }
 
 - (NSTimeInterval)frameInterval
@@ -577,6 +716,9 @@ static void MupenSetAudioSpeed(int percent)
     {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1000 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
             int success = CoreDoCommand(M64CMD_STATE_LOAD, 1, (void *)fileName.fileSystemRepresentation);
+            if (success == M64ERR_SUCCESS && self->_rcClient) {
+                rc_client_reset(self->_rcClient);
+            }
             if(block) block(success==M64ERR_SUCCESS, nil);
        });
     }
@@ -600,6 +742,9 @@ static void MupenSetAudioSpeed(int percent)
                      return;
                  }
 
+                 if (self->_rcClient) {
+                     rc_client_reset(self->_rcClient);
+                 }
                  block(YES, nil);
              });
              return NO;


### PR DESCRIPTION
## What does this PR do?

Wires rcheevos `rc_client` into Mupen64Plus following the established Phase 1 pattern. N64 ROMs now earn RetroAchievements (~1,500 sets). Phase 2 of the RA rollout from #258.

## What did you test?

**Build** — clean Debug build for `arm64`, zero linker errors after namespacing the rcheevos `md5_*` symbols (Mupen and rcheevos both ship the same Peter Deutsch `md5.c`, which previously collided at link time). `_rc_client_*` and `_oeRetroAchievementsServerCall` symbols verified present in the linked `Mupen64Plus.oecoreplugin` binary.

**Manual smoke test on Apple Silicon (logged in to RA, ROMs from a personal library):**

| Game | RA set status | Result |
|------|---------------|--------|
| GoldenEye 007 | ~161 active achievements | Smooth. Achievements unlock + banner + notification all fire correctly. |
| Zelda: Ocarina of Time | Unsupported ROM version (2 warning achievements only) | Smooth. |
| Star Fox 64 | Unsupported ROM version (2 warning achievements only) | Smooth. |
| Super Mario 64 | ~180 active achievements (3 subsets) | Plays fine for the first ~5 seconds, then steady-state lag once the full achievement set activates. Achievements still unlock correctly. **See follow-up issue below.** |

**Performance work in this PR.** Initial integration called `rc_client_do_frame` on every VI (60 Hz) inline before the renderer's "frame ready" signal, which produced consistent audio/video sputter on N64. Three small changes inside the existing integration recovered most of the budget without leaving the proven Phase 1 lockstep pattern (mGBA, GenesisPlus, FCEU, Nestopia, SNES9x, BSNES, Gambatte, Mednafen all call `do_frame` in lockstep with emulation):

1. Move `rc_client_do_frame` **after** `didRenderFrameOnAlternateThread` so the renderer presents on time and rcheevos runs in the leftover inter-VI budget.
2. Throttle to every other VI (~30 Hz). rcheevos' `frames_processed` counter ticks per `do_frame` call, so achievement timing logic measured in "frames" still works correctly — each "rcheevos frame" just equals 2 emulated VIs. 30 Hz observation is well above the precision RA achievement authors design for.
3. Drop rcheevos log level from `INFO` to `WARN` to cut per-frame chatter.

This was enough to unblock Phase 2 for the rest of the supported N64 library. **Super Mario 64 still has a noticeable steady-state perf cost** with the full achievement set active — tracked separately so this PR can land without further delay. GoldenEye's similar achievement count (~161) without the same regression suggests the cost is per-condition complexity rather than count alone.

## What we tried and rolled back

A handful of additional optimization attempts (recursive mutex around all `rc_client_*` calls, 4-byte aligned fast-path in the memory callback, deferring the achievement-unlocked notification to the main queue) were prototyped to address the SM64 case. None reliably improved frame pacing in Debug builds, and the mutex + main-queue defer combination introduced a deadlock risk via the synchronous XPC call in `OpenEmuHelperApp._achievementObserver`. Reverted in favor of the minimal three-line throttle above. Findings captured in the follow-up issue.

## Which cores or systems are affected?

Mupen64Plus only (Nintendo 64). No effect on any other core.

## Did you use AI tools?

Yes — Claude (Opus 4.7) drafted the integration following the established Phase 1 pattern, and the throttle/render-order fix. I reviewed the diff, ran the build, and tested manually on the four ROMs above before pushing.

## Linked issues

Fixes #252
Follow-up: #319 — Super Mario 64 steady-state slowdown with full RA achievement set active.

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 314 --repo nickybmon/OpenEmu-Silicon

# Build the core scheme (the main OpenEmu scheme does not build core plugins)
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + Mupen64Plus' \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# Install the core (quits OpenEmu first, then copies binary + Info.plist)
./Scripts/install-core.sh Mupen64Plus

# Launch
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

**Manual test:**
1. Open Preferences → Achievements, log in to your RetroAchievements account.
2. Launch an N64 ROM with an achievement set. **Suggested:** GoldenEye 007 for the happy path, Super Mario 64 to reproduce the known perf caveat.
3. Confirm `[rcheevos]` log lines appear in Console.app.
4. Trigger an early achievement (collect first star in SM64, first body armor in GoldenEye, etc.).
5. Confirm the in-app banner appears AND the system notification fires.
6. On SM64: expect smooth gameplay for the first ~5 seconds, then steady-state slowdown once all achievement conditions activate. This is the documented edge case, not a build regression.

---

## Implementation notes

- **Memory callback** maps the rcheevos N64 normalized address space (`0x000000–0x7FFFFF`) to RDRAM via `g_dev.rdram.dram`. Mupen stores RDRAM as host-native 32-bit words, so each byte read uses the standard N64 byte-swap (`addr ^ 3`) so RA hashes and conditions see big-endian byte order. Address space map is from `Vendor/rcheevos/src/rcheevos/consoleinfo.c`.
- **Frame hook** is in `videoInterrupt` rather than `executeFrame` because Mupen runs `M64CMD_EXECUTE` on a separate emulator thread and `executeFrame` is a no-op in this core. `videoInterrupt` fires once per VI on the emu thread. `rc_client_do_frame` runs after `didRenderFrameOnAlternateThread` and only every other VI (see "Performance work" above).
- **Lifecycle** mirrors mGBA / GenesisPlus: token observer registered before login so we never miss the notification, login callback fires `rc_client_begin_identify_and_load_game`, `rc_client_do_frame` per (throttled) VI, `rc_client_unload_game` + `rc_client_destroy` in `stopEmulation`, `rc_client_reset` on reset and on save-state load.
- **Logging** uses `os_log(%{public}s)` so messages aren't redacted as `<private>` on macOS 12+ (lesson from PR #279). Level is `WARN` in the shipped build to keep per-frame chatter off the emu thread.
- **md5 namespace** — Mupen ships its own `md5.c` with the same `md5_init` / `md5_append` / `md5_finish` symbols rcheevos uses. Per-file compiler defines on the rcheevos unity build (`-Dmd5_init=rc_md5_init` etc.) rename the rcheevos copy and avoid the duplicate-symbol link error. Both implementations are functionally identical (both from the same upstream Peter Deutsch source).

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes (`OpenEmu + Mupen64Plus` Debug arm64)
- [x] Tested on Apple Silicon — see results table above
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files

Made with [Cursor](https://cursor.com)
