### PR TITLE
fix: render FCEU pixels in executeFrame so Release host shows the picture

### DIFF
--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -61,6 +61,7 @@ static uint32_t palette[256];
 @interface FCEUGameCore () <OENESSystemResponderClient>
 {
     uint32_t *_videoBuffer;
+    uint32_t *_videoBufferHint;
     int32_t  *_soundBuffer;
     int32_t   _soundSize;
     uint32_t  _pad;
@@ -342,6 +343,18 @@ static __weak FCEUGameCore *_current;
 
     FCEUI_Emulate(&pXBuf, &_soundBuffer, &_soundSize, 0);
 
+    // Translate the freshly-emulated XBuf (palette-indexed) into the renderer's
+    // 32-bit BGRA buffer. Doing this here (rather than in -getVideoBufferWithHint:)
+    // ensures the buffer contains the latest frame whenever the renderer reads it,
+    // matching the contract used by every other 2D pixel-buffer core.
+    if (_videoBufferHint) {
+        const uint8_t *src = XBuf;
+        uint32_t *dst = _videoBufferHint;
+        for (unsigned y = 0; y < 240; y++)
+            for (unsigned x = 0; x < 256; x++, src++)
+                dst[y * 256 + x] = palette[*src];
+    }
+
     if (_rcClient)
         rc_client_do_frame(_rcClient);
 
@@ -390,12 +403,14 @@ static __weak FCEUGameCore *_current;
         hint = _videoBuffer;
     }
 
-    // TODO: support paletted video in OE
-    uint8_t *pXBuf = XBuf;
-    uint32_t *pOBuf = (uint32_t *)hint;
-    for (unsigned y = 0; y < 240; y++)
-        for (unsigned x = 0; x < 256; x++, pXBuf++)
-            pOBuf[y * 256 + x] = palette[*pXBuf];
+    // Cache the renderer's buffer pointer; -executeFrame writes pixels here.
+    _videoBufferHint = (uint32_t *)hint;
+
+    // Clear the buffer to black for the first frame, before any emulation has
+    // run. This avoids briefly displaying uninitialised memory through the
+    // palette table (which previously appeared as a solid grey screen in
+    // builds that called this method only at renderer setup).
+    memset(hint, 0, 256 * 240 * sizeof(uint32_t));
 
     return hint;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the long-standing FCEU grey-screen bug. NES ROMs launched with the FCEU core now render correctly in Release builds. The fix is one file (`FCEU/FCEUGameCore.mm`) and ~15 lines.

## Root cause

The FCEU plugin's `-getVideoBufferWithHint:` was doing two jobs at once: negotiating the renderer's buffer pointer **and** performing the per-frame palette translation from `XBuf` into that buffer. The renderer's contract for 2D cores is "during `executeFrame`, write your latest pixels into the buffer the renderer gave you." Every other 2D core (Nestopia, etc.) follows that contract. FCEU did not.

The renderer only calls `-getVideoBufferWithHint:` when it needs the pointer — during setup, plus inside a Swift `assert(...)` that runs every frame in Debug. **Swift compiles `assert(...)` out under `-O`**, so in Release builds `-getVideoBufferWithHint:` was called exactly once, at renderer setup, before any frame had been emulated. After that the renderer kept reading the same buffer every frame, but the buffer was only ever written once with `palette[*XBuf]` of uninitialised memory. That's the grey screen.

This explains every observation:

- Why Debug rendered: `assert(...)` was active, so the translation ran every frame.
- Why Release grey-screened: `assert(...)` was a no-op, so the translation never re-ran.
- Why Nestopia worked: its `-getVideoBufferWithHint:` is already a pure getter; pixel writing happens inside `executeFrame` where it should.
- Why the bug "appeared" with FCEU 2.6.6: it didn't. The contract bug has been latent. The 2.6.6 palette change (#228) made the symptom *more* uniform (everything flatly grey), which is why it surfaced as a clear bug report.

## What changed

- `-executeFrame`: after `FCEUI_Emulate` populates `XBuf`, do the palette translation into the cached renderer buffer.
- `-getVideoBufferWithHint:`: cache the renderer's buffer pointer; `memset` to black on first call so the very first frame is solid black instead of a flash of uninitialised memory.

The earlier hypothesis on issue #214 (palette mapping in 2.6.6) was correct that the *visible flat grey colour* came from the palette table. But the deeper bug is the one fixed here — even with a fully populated palette, the buffer was never being re-written between frames in Release. The palette fix in #228 already shipped and is preserved; this PR is the missing piece.

## What did you test?

Tested locally on Apple Silicon with a clean Release build:

- FCEU NES ROM boots and renders correctly (was previously grey).
- Nestopia still renders correctly (no regression).
- In-game reset on FCEU works.
- Save state / load state on FCEU works.
- Both Debug and Release configurations of the `OpenEmu + FCEU` scheme build cleanly.

## Which cores or systems are affected?

- **FCEU** (NES) — fixed.
- All other cores untouched.
- No changes to `OpenEmuKit`, `OpenEmu-Shaders`, `OpenEmu-SDK`, or the host app. All host code stays at full Release `-O` optimisation.

## Did you use AI tools?

Yes. Used Claude (via Cursor) for the investigation, hypothesis generation, and bisection. The bisect work explored several wrong hypotheses (Swift compiler codegen bug, FilterChain UV regression) before locating the actual render-contract bug in the core wrapper. All code and the final fix were reviewed and tested manually.

## Linked issues

Fixes #214

---

## How to test locally

```bash
cd ~/Documents/Cursor/OpenEmu-fceu-grey-fix
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

# Build host + FCEU core in Release (Release is where the bug appeared)
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + FCEU" \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -5

# Install the freshly built FCEU plugin into the user cores directory
osascript -e 'tell application "OpenEmu" to quit' 2>/dev/null; sleep 2
SRC=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Release/FCEU.oecoreplugin | head -1)
DST=~/Library/Application\ Support/OpenEmu/Cores/FCEU.oecoreplugin
cp -f "$SRC/Contents/MacOS/FCEU" "$DST/Contents/MacOS/FCEU"
cp -f "$SRC/Contents/Info.plist" "$DST/Contents/Info.plist"

# Launch the freshly built host
open "$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Release/OpenEmu.app | head -1)"
```

Then in OpenEmu:

1. Open any NES ROM with the FCEU core selected. Confirm it renders (was previously a solid grey screen).
2. Open a NES ROM with Nestopia. Confirm no regression.
3. In an FCEU game, hit reset (System → Reset). Confirm picture comes back cleanly.
4. In an FCEU game, save state and load state. Confirm picture still renders after restore.

> Note: OpenEmu loads cores from `~/Library/Application Support/OpenEmu/Cores/`, **not** from the build's bundled location. Skipping the install step will result in testing whatever stale plugin is already there.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + FCEU" -configuration Release -destination 'platform=macOS,arch=arm64' build`
- [x] Also passes Debug build of same scheme
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright header preserved on the modified file
- [x] No new files added

Made with [Cursor](https://cursor.com)