### PR TITLE
chore: catch stale-installed-core test results before they ship

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@ When you change code, you should run `/verify` before declaring the task done. Y
 What this looks like in practice:
 
 - Main app change → `./Scripts/verify.sh --launch`
-- Core change → `./Scripts/verify.sh --core <CoreName>`
+- Core change → `./Scripts/verify.sh --core <CoreName>` (add `--release` when reproducing a Release-only bug). **Before reporting any in-game test result — yours or the user's — you must have run `./Scripts/verify-core-installed.sh <CoreName>` and seen `OK` since the last build.** If you haven't, the result is invalid and you say so. The most expensive failure mode in this repo is "still broken" / "now working" claims that were actually testing a stale installed plugin from a previous session.
 - Both → run both
 - Scripts / CI / docs only → no verify needed
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -8,7 +8,7 @@ This is the default check after any code change. Do not ask the user to test thi
 |---|---|
 | Main app code (`OpenEmu/`, `OpenEmuKit/`, `OpenEmu-SDK/`, `OpenEmu-Shaders/`) | `./Scripts/verify.sh --launch` |
 | Code with coverage in `OpenEmu/OpenEmuTests/` | `./Scripts/verify.sh --launch --test` |
-| A core plugin (`Dolphin/`, `Flycast/`, `mGBA/`, etc.) | `./Scripts/verify.sh --core <CoreName>` |
+| A core plugin (`Dolphin/`, `Flycast/`, `mGBA/`, etc.) | `./Scripts/verify.sh --core <CoreName>` (add `--release` for a Release-only bug) |
 | Both | run both, in that order |
 | Scripts, CI, docs only | skip — no code to verify |
 
@@ -16,7 +16,9 @@ This is the default check after any code change. Do not ask the user to test thi
 
 For the main app: build → static analyzer → plist lint → codesign verify on the built `.app`. With `--launch`: also launches the app for 5 seconds, scans the unified log for faults/errors, and checks `~/Library/Logs/DiagnosticReports/` for new crash reports.
 
-For a core: builds the core scheme → plist lint → installs via `Scripts/install-core.sh` → verifies codesign on the installed plugin.
+For a core: builds the core scheme → plist lint → installs via `Scripts/install-core.sh` → verifies codesign on the installed plugin → final preflight via `Scripts/verify-core-installed.sh` to confirm the installed plugin's MD5 matches the build (the most expensive failure mode in this repo is testing against a stale installed plugin).
+
+You can also run the preflight by itself, sub-second, before reporting any in-game test result: `./Scripts/verify-core-installed.sh <CoreName> [--release]`.
 
 ## What you do with the output
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ test_dlopen
 # Cursor IDE config
 .cursor/
 
+# Agent artifacts — plans, scratchpads, notes (kept out of PR diffs by convention)
+tmp/agent/
+
 # PPSSPP third-party ext libraries (not committed — large C++ dependencies)
 PPSSPP/PPSSPP-Core/ppsspp/ext/SPIRV-Cross/
 PPSSPP/PPSSPP-Core/ppsspp/ext/armips/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ The issue tracker at `nickybmon/OpenEmu-Silicon` is the primary place for bug re
 - Do not add debug `+load` / `+initialize` methods that write to `/tmp` or hardcode local paths
 - Do not commit large binaries (`.zip`, `.tar.gz`, compiled executables) — these belong in GitHub Releases
 - Do not commit directly to `main` under any circumstances
+- Do not declare a core test result without running `./Scripts/verify-core-installed.sh <CoreName>` since the last build — testing against a stale installed plugin is the single most expensive failure mode in this repo
 
 ---
 
@@ -241,6 +242,16 @@ The main app is **BSD 2-Clause**. Emulator cores are mostly **GPL v2**. Key rule
 ---
 
 ## Testing PRs Locally Before Merging
+
+> **Core plugin work has a process gate.**
+>
+> OpenEmu loads cores from `~/Library/Application Support/OpenEmu/Cores/`, **not** from the build directory. Building a core does *not* affect what OpenEmu loads. Before claiming any test result on a core change:
+>
+> 1. Build the core scheme (or run `./Scripts/verify.sh --core <CoreName>` which does this for you, with `--release` if testing a Release-only behavior).
+> 2. Run `./Scripts/install-core.sh <CoreName>` (use `--release` for Release builds). This is automatic when you use `verify.sh --core`.
+> 3. Run `./Scripts/verify-core-installed.sh <CoreName>` and confirm `OK`. If it prints `FAIL`, the installed plugin doesn't match the build and your test result is invalid.
+>
+> The most common silent failure is testing against a stale installed plugin from a previous session. The preflight script catches this in under a second; run it before reporting any "still broken" or "now working" result.
 
 Before merging any PR, check it out locally, build, and verify the behaviors described in the PR's test plan.
 

--- a/Scripts/install-core.sh
+++ b/Scripts/install-core.sh
@@ -3,11 +3,12 @@
 # install-core.sh — install a built core plugin into the OE cores directory
 #
 # Usage:
-#   ./Scripts/install-core.sh <CoreName>
+#   ./Scripts/install-core.sh <CoreName> [--debug|--release]
 #
-# Example:
-#   ./Scripts/install-core.sh Dolphin
-#   ./Scripts/install-core.sh Flycast
+# Examples:
+#   ./Scripts/install-core.sh Dolphin                # default: install the Debug build
+#   ./Scripts/install-core.sh FCEU --release         # install the Release build (use when
+#                                                    # reproducing a Release-only bug)
 #
 # Why this script exists:
 #   - cp -Rf on an existing .oecoreplugin bundle silently skips files that
@@ -16,18 +17,90 @@
 #     cp will silently fail to replace it.
 #   This script quits OpenEmu first, then copies the binary and Info.plist
 #   individually with -f so the destination is always fully updated.
+#
+#   At the end the source and installed MD5 hashes are printed side by side
+#   so a stale install (e.g. wrong configuration, OpenEmu still holding the
+#   binary open, copy silently failed) jumps off the screen.
 
 set -euo pipefail
 
-CORE="${1:?Usage: $0 <CoreName> (e.g. Dolphin, Flycast)}"
+CORE=""
+CONFIG="Debug"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --debug)   CONFIG="Debug";   shift ;;
+    --release) CONFIG="Release"; shift ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0 ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2 ;;
+    *)
+      if [ -z "$CORE" ]; then
+        CORE="$1"
+      else
+        echo "error: unexpected positional argument: $1" >&2
+        exit 2
+      fi
+      shift ;;
+  esac
+done
+
+if [ -z "$CORE" ]; then
+  echo "Usage: $0 <CoreName> [--debug|--release]" >&2
+  exit 2
+fi
+
 DEST="$HOME/Library/Application Support/OpenEmu/Cores/${CORE}.oecoreplugin"
-DERIVED=$(ls -dt "$HOME/Library/Developer/Xcode/DerivedData/OpenEmu-metal-"*/Build/Products/Debug/"${CORE}.oecoreplugin" 2>/dev/null | head -1)
+
+# Look in two places, in this order, and pick the most recently built:
+#   1. ~/Builds/openemu/<branch>/  — worktree mode build path, used by verify.sh
+#                                    when run inside a git worktree
+#   2. ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/  — standard build path
+#
+# Picking the most recent is critical: if a stale build exists in DerivedData,
+# we must not silently install it instead of the worktree build the user just
+# made (or vice versa). This is the failure mode the FCEU grey-screen session
+# spent hours debugging — see issue #214.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+WORKTREE_BUILD=""
+if [ -f "$REPO_ROOT/.git" ]; then
+  BRANCH=$(cd "$REPO_ROOT" && git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|-|g')
+  if [ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ]; then
+    CANDIDATE="$HOME/Builds/openemu/$BRANCH/Build/Products/${CONFIG}/${CORE}.oecoreplugin"
+    [ -e "$CANDIDATE/Contents/MacOS/${CORE}" ] && WORKTREE_BUILD="$CANDIDATE"
+  fi
+fi
+
+DERIVED_BUILD=$(ls -dt "$HOME/Library/Developer/Xcode/DerivedData/OpenEmu-metal-"*/Build/Products/${CONFIG}/"${CORE}.oecoreplugin" 2>/dev/null | head -1 || true)
+
+# Choose whichever candidate has the more recently modified binary.
+DERIVED=""
+if [ -n "$WORKTREE_BUILD" ] && [ -n "$DERIVED_BUILD" ]; then
+  WT_MTIME=$(stat -f "%m" "$WORKTREE_BUILD/Contents/MacOS/${CORE}" 2>/dev/null || echo 0)
+  DD_MTIME=$(stat -f "%m" "$DERIVED_BUILD/Contents/MacOS/${CORE}" 2>/dev/null || echo 0)
+  if [ "$WT_MTIME" -ge "$DD_MTIME" ]; then
+    DERIVED="$WORKTREE_BUILD"
+  else
+    DERIVED="$DERIVED_BUILD"
+  fi
+elif [ -n "$WORKTREE_BUILD" ]; then
+  DERIVED="$WORKTREE_BUILD"
+elif [ -n "$DERIVED_BUILD" ]; then
+  DERIVED="$DERIVED_BUILD"
+fi
 
 if [ -z "$DERIVED" ]; then
-  echo "error: ${CORE}.oecoreplugin not found in DerivedData."
+  echo "error: ${CORE}.oecoreplugin not found in any known build location (${CONFIG})."
+  echo "       Looked in:"
+  echo "         ~/Builds/openemu/<branch>/Build/Products/${CONFIG}/"
+  echo "         ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/${CONFIG}/"
   echo "       Build the '${CORE}' scheme first:"
-  echo "       xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme ${CORE} \\"
-  echo "         -configuration Debug -destination 'platform=macOS,arch=arm64' build"
+  echo "       xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme \"OpenEmu + ${CORE}\" \\"
+  echo "         -configuration ${CONFIG} -destination 'platform=macOS,arch=arm64' build"
   exit 1
 fi
 
@@ -48,9 +121,27 @@ if pgrep -xq "OpenEmu"; then
   fi
 fi
 
-echo "Installing ${CORE}.oecoreplugin from DerivedData..."
+echo "Installing ${CORE}.oecoreplugin (${CONFIG}) from:"
+echo "  ${DERIVED}"
 cp -f "${DERIVED}/Contents/MacOS/${CORE}" "${DEST}/Contents/MacOS/${CORE}"
 cp -f "${DERIVED}/Contents/Info.plist"    "${DEST}/Contents/Info.plist"
 
-INSTALLED_DATE=$(stat -f "%Sm" -t "%b %d %H:%M" "${DEST}/Contents/MacOS/${CORE}")
-echo "Done. Binary timestamp: ${INSTALLED_DATE}"
+SRC_MD5=$(md5 -q "${DERIVED}/Contents/MacOS/${CORE}")
+DST_MD5=$(md5 -q "${DEST}/Contents/MacOS/${CORE}")
+SRC_DATE=$(stat -f "%Sm" -t "%b %d %H:%M:%S" "${DERIVED}/Contents/MacOS/${CORE}")
+DST_DATE=$(stat -f "%Sm" -t "%b %d %H:%M:%S" "${DEST}/Contents/MacOS/${CORE}")
+
+echo ""
+echo "Source     ${SRC_MD5}   built  ${SRC_DATE}"
+echo "Installed  ${DST_MD5}   active ${DST_DATE}"
+
+if [ "${SRC_MD5}" = "${DST_MD5}" ]; then
+  echo ""
+  echo "OK — installed binary matches source."
+else
+  echo ""
+  echo "WARNING — installed binary does NOT match source. The copy may have"
+  echo "          failed silently (OpenEmu still holding the binary open?)."
+  echo "          Quit OpenEmu fully and re-run."
+  exit 1
+fi

--- a/Scripts/verify-core-installed.sh
+++ b/Scripts/verify-core-installed.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# verify-core-installed.sh — sub-second preflight: does the installed core
+# plugin match the latest build? Run this before declaring a core test result.
+#
+# Usage:
+#   ./Scripts/verify-core-installed.sh <CoreName> [--debug|--release]
+#
+# Examples:
+#   ./Scripts/verify-core-installed.sh FCEU
+#   ./Scripts/verify-core-installed.sh FCEU --release
+#
+# Why this script exists:
+#   OpenEmu loads cores from ~/Library/Application Support/OpenEmu/Cores/,
+#   not from the build directory. Building a core does not affect what
+#   OpenEmu loads. This script catches the very common failure mode where
+#   you've built a core but forgotten (or silently failed) to install it,
+#   and are about to claim a test result against the stale installed copy.
+#
+# Exit codes:
+#   0  — installed plugin matches the latest build
+#   1  — installed plugin does NOT match the latest build (stale install)
+#   2  — bad usage (missing or unknown args)
+#   3  — no installed plugin found (run OpenEmu once to install, or copy manually)
+#   4  — no built artifact found (build the core scheme first)
+
+set -uo pipefail
+
+CORE=""
+CONFIG="Debug"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --debug)   CONFIG="Debug";   shift ;;
+    --release) CONFIG="Release"; shift ;;
+    -h|--help)
+      sed -n '2,28p' "$0"
+      exit 0 ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2 ;;
+    *)
+      if [ -z "$CORE" ]; then
+        CORE="$1"
+      else
+        echo "error: unexpected positional argument: $1" >&2
+        exit 2
+      fi
+      shift ;;
+  esac
+done
+
+if [ -z "$CORE" ]; then
+  echo "Usage: $0 <CoreName> [--debug|--release]" >&2
+  exit 2
+fi
+
+INSTALLED="$HOME/Library/Application Support/OpenEmu/Cores/${CORE}.oecoreplugin"
+
+# Look in both possible build locations and pick the most recent. Same logic
+# as install-core.sh — see comment there for rationale.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+WORKTREE_BUILD=""
+if [ -f "$REPO_ROOT/.git" ]; then
+  BRANCH=$(cd "$REPO_ROOT" && git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|-|g')
+  if [ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ]; then
+    CANDIDATE="$HOME/Builds/openemu/$BRANCH/Build/Products/${CONFIG}/${CORE}.oecoreplugin"
+    [ -e "$CANDIDATE/Contents/MacOS/${CORE}" ] && WORKTREE_BUILD="$CANDIDATE"
+  fi
+fi
+
+DERIVED_BUILD=$(ls -dt "$HOME/Library/Developer/Xcode/DerivedData/OpenEmu-metal-"*/Build/Products/${CONFIG}/"${CORE}.oecoreplugin" 2>/dev/null | head -1 || true)
+
+BUILT=""
+if [ -n "$WORKTREE_BUILD" ] && [ -n "$DERIVED_BUILD" ]; then
+  WT_MTIME=$(stat -f "%m" "$WORKTREE_BUILD/Contents/MacOS/${CORE}" 2>/dev/null || echo 0)
+  DD_MTIME=$(stat -f "%m" "$DERIVED_BUILD/Contents/MacOS/${CORE}" 2>/dev/null || echo 0)
+  if [ "$WT_MTIME" -ge "$DD_MTIME" ]; then
+    BUILT="$WORKTREE_BUILD"
+  else
+    BUILT="$DERIVED_BUILD"
+  fi
+elif [ -n "$WORKTREE_BUILD" ]; then
+  BUILT="$WORKTREE_BUILD"
+elif [ -n "$DERIVED_BUILD" ]; then
+  BUILT="$DERIVED_BUILD"
+fi
+
+if [ ! -e "${INSTALLED}/Contents/MacOS/${CORE}" ]; then
+  echo "FAIL — no installed plugin found for ${CORE}." >&2
+  echo "       Expected at: ${INSTALLED}" >&2
+  echo "       Launch OpenEmu once so it installs the plugin, or copy manually." >&2
+  exit 3
+fi
+
+if [ -z "${BUILT}" ] || [ ! -e "${BUILT}/Contents/MacOS/${CORE}" ]; then
+  echo "FAIL — no ${CONFIG} build of ${CORE} found in DerivedData." >&2
+  echo "       Build the core scheme first:" >&2
+  echo "       xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme \"OpenEmu + ${CORE}\" \\" >&2
+  echo "         -configuration ${CONFIG} -destination 'platform=macOS,arch=arm64' build" >&2
+  exit 4
+fi
+
+INSTALLED_BIN="${INSTALLED}/Contents/MacOS/${CORE}"
+BUILT_BIN="${BUILT}/Contents/MacOS/${CORE}"
+
+INSTALLED_MD5=$(md5 -q "${INSTALLED_BIN}")
+BUILT_MD5=$(md5 -q "${BUILT_BIN}")
+
+if [ "${INSTALLED_MD5}" = "${BUILT_MD5}" ]; then
+  INSTALLED_DATE=$(stat -f "%Sm" -t "%b %d %H:%M:%S" "${INSTALLED_BIN}")
+  echo "OK — installed ${CORE} (${CONFIG}) matches latest build."
+  echo "     md5: ${INSTALLED_MD5}   active ${INSTALLED_DATE}"
+  exit 0
+fi
+
+INSTALLED_DATE=$(stat -f "%Sm" -t "%b %d %H:%M:%S" "${INSTALLED_BIN}")
+BUILT_DATE=$(stat -f "%Sm" -t "%b %d %H:%M:%S" "${BUILT_BIN}")
+
+echo "FAIL — installed ${CORE} plugin does not match latest ${CONFIG} build." >&2
+echo "" >&2
+echo "Built:      ${BUILT_DATE}   md5: ${BUILT_MD5}" >&2
+echo "            ${BUILT_BIN}" >&2
+echo "" >&2
+echo "Installed:  ${INSTALLED_DATE}   md5: ${INSTALLED_MD5}" >&2
+echo "            ${INSTALLED_BIN}" >&2
+echo "" >&2
+echo "To fix: ./Scripts/install-core.sh ${CORE}$([ "${CONFIG}" = "Release" ] && echo " --release")" >&2
+exit 1

--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -6,6 +6,7 @@
 #   ./Scripts/verify.sh --launch               # above, plus 5s smoke launch with log + crash check
 #   ./Scripts/verify.sh --test                 # above, plus run OpenEmuTests unit test target
 #   ./Scripts/verify.sh --core <CoreName>      # build a core scheme + install + verify the installed plugin
+#   ./Scripts/verify.sh --core <CoreName> --release  # use Release configuration (for Release-only bugs)
 #   ./Scripts/verify.sh --core <CoreName> --launch
 #   ./Scripts/verify.sh --worktree             # build to ~/Builds/openemu/<branch>/ for stable permissions
 #
@@ -53,6 +54,7 @@ LAUNCH=0
 CORE=""
 RUN_TESTS=0
 WORKTREE=0
+CONFIG="Debug"
 FAILURES=0
 
 while [ $# -gt 0 ]; do
@@ -61,7 +63,9 @@ while [ $# -gt 0 ]; do
     --core) CORE="${2:-}"; shift 2 ;;
     --test) RUN_TESTS=1; shift ;;
     --worktree) WORKTREE=1; shift ;;
-    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    --debug) CONFIG="Debug"; shift ;;
+    --release) CONFIG="Release"; shift ;;
+    -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -109,7 +113,7 @@ fi
 
 BUILD_LOG=$(mktemp -t verify_build.XXXXXX)
 XCODEBUILD_ARGS=(-workspace "$WORKSPACE" -scheme "$SCHEME"
-                 -configuration Debug -destination 'platform=macOS,arch=arm64')
+                 -configuration "$CONFIG" -destination 'platform=macOS,arch=arm64')
 if [ "$WORKTREE" -eq 1 ]; then
   XCODEBUILD_ARGS+=(-derivedDataPath "$BUILD_DIR_OVERRIDE")
   info "worktree mode — building to $BUILD_DIR_OVERRIDE"
@@ -176,17 +180,17 @@ fi
 
 if [ -z "$CORE" ]; then
   if [ "$WORKTREE" -eq 1 ]; then
-    ARTIFACT="$ARTIFACT_BASE/Build/Products/Debug/OpenEmu.app"
+    ARTIFACT="$ARTIFACT_BASE/Build/Products/${CONFIG}/OpenEmu.app"
     [ -e "$ARTIFACT" ] || ARTIFACT=""
   else
-    ARTIFACT=$(find "$ARTIFACT_BASE" -maxdepth 5 -path '*OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app' -print -quit 2>/dev/null)
+    ARTIFACT=$(find "$ARTIFACT_BASE" -maxdepth 5 -path "*OpenEmu-metal-*/Build/Products/${CONFIG}/OpenEmu.app" -print -quit 2>/dev/null)
   fi
 else
   if [ "$WORKTREE" -eq 1 ]; then
-    ARTIFACT="$ARTIFACT_BASE/Build/Products/Debug/${CORE}.oecoreplugin"
+    ARTIFACT="$ARTIFACT_BASE/Build/Products/${CONFIG}/${CORE}.oecoreplugin"
     [ -e "$ARTIFACT" ] || ARTIFACT=""
   else
-    ARTIFACT=$(find "$ARTIFACT_BASE" -maxdepth 5 -path "*OpenEmu-metal-*/Build/Products/Debug/${CORE}.oecoreplugin" -print -quit 2>/dev/null)
+    ARTIFACT=$(find "$ARTIFACT_BASE" -maxdepth 5 -path "*OpenEmu-metal-*/Build/Products/${CONFIG}/${CORE}.oecoreplugin" -print -quit 2>/dev/null)
   fi
 fi
 
@@ -206,12 +210,13 @@ fi
 
 if [ -n "$CORE" ] && [ -n "${ARTIFACT:-}" ] && [ -e "$ARTIFACT" ]; then
   INSTALL_DEST="$INSTALLED_APP_DEFAULT/Cores/${CORE}.oecoreplugin"
+  CONFIG_FLAG="--$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')"
   if [ -x "./Scripts/install-core.sh" ]; then
-    info "installing core via Scripts/install-core.sh"
-    if ./Scripts/install-core.sh "$CORE" >/dev/null 2>&1; then
-      pass "install-core.sh $CORE"
+    info "installing core via Scripts/install-core.sh ($CONFIG)"
+    if ./Scripts/install-core.sh "$CORE" "$CONFIG_FLAG" >/dev/null 2>&1; then
+      pass "install-core.sh $CORE $CONFIG_FLAG"
     else
-      fail "install-core.sh $CORE"
+      fail "install-core.sh $CORE $CONFIG_FLAG"
     fi
   else
     info "Scripts/install-core.sh not executable — skipping install"
@@ -222,6 +227,18 @@ if [ -n "$CORE" ] && [ -n "${ARTIFACT:-}" ] && [ -e "$ARTIFACT" ]; then
       pass "codesign installed plugin"
     else
       fail "codesign installed plugin"
+    fi
+  fi
+
+  # Final preflight: confirm the installed plugin actually matches what we
+  # just built. This catches silent install failures (e.g. OpenEmu still
+  # holding the binary open) that the codesign check above would not.
+  if [ -x "./Scripts/verify-core-installed.sh" ]; then
+    if ./Scripts/verify-core-installed.sh "$CORE" "$CONFIG_FLAG" >/dev/null 2>&1; then
+      pass "verify-core-installed.sh $CORE $CONFIG_FLAG"
+    else
+      fail "verify-core-installed.sh $CORE $CONFIG_FLAG — installed plugin does not match build"
+      ./Scripts/verify-core-installed.sh "$CORE" "$CONFIG_FLAG" || true
     fi
   fi
 fi


### PR DESCRIPTION
## What does this PR do?

Adds tooling and documentation that makes it hard to repeat the most expensive failure mode in this repo: claiming a core test result against a stale installed plugin while the freshly-built binary sits unused in DerivedData (or the worktree build dir).

This bit hard during the FCEU grey-screen investigation (#214 / PR #317). OpenEmu loads cores from `~/Library/Application Support/OpenEmu/Cores/`, **not** from the build directory. Building a core does not affect what OpenEmu loads. Many "still grey" results in that session were actually testing a 6-hour-old installed plugin regardless of what had just been built. Hours were lost.

## What did you test?

End-to-end "stale install" simulation:

1. Build FCEU in Release in a worktree.
2. Manually corrupt the installed plugin so its MD5 differs from the build.
3. Run `./Scripts/verify-core-installed.sh FCEU --release` — confirms it FAILs loudly with hashes, timestamps, and the exact fix command (exit 1).
4. Run `./Scripts/install-core.sh FCEU --release` — confirms it picks the worktree build (newer) over a stale DerivedData build, prints source + installed MD5s side by side.
5. Re-run `verify-core-installed.sh` — confirms it passes (exit 0).
6. Run `./Scripts/verify.sh --core FCEU --release` end-to-end — passes all checks, including the new final preflight.

Also confirmed both new/changed scripts work under macOS's default `/bin/bash` (3.2.57).

## Which cores or systems are affected?

None directly — this is build/test tooling and documentation. But it improves the reliability of every future core change.

## Did you use AI tools?

Yes. Claude (via Cursor) wrote the scripts and the doc additions. I tested the end-to-end behavior locally before committing. The plan was drafted in a Plan-mode pass first, scoped to the changes you see here.

## Linked issues

Related to #214 (the FCEU investigation that motivated this).

---

## How to test locally

```bash
cd ~/Documents/Cursor/OpenEmu-fceu-grey-fix
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

# Sanity: --help works for all three scripts.
./Scripts/install-core.sh --help
./Scripts/verify-core-installed.sh --help
./Scripts/verify.sh --help

# Smoke test 1: --release flag is accepted and routes correctly.
./Scripts/install-core.sh FCEU --release
# Expect: source/installed MD5 lines, "OK — installed binary matches source."

# Smoke test 2: standalone preflight returns 0 immediately after install.
./Scripts/verify-core-installed.sh FCEU --release
# Expect: "OK — installed FCEU (Release) matches latest build."

# Smoke test 3: simulate a stale install. The preflight must fail loudly
# with concrete hashes, timestamps, and the fix command.
cp ~/Library/Application\ Support/OpenEmu/Cores/FCEU.oecoreplugin/Contents/MacOS/FCEU /tmp/FCEU.bak
echo "stale" >> ~/Library/Application\ Support/OpenEmu/Cores/FCEU.oecoreplugin/Contents/MacOS/FCEU
./Scripts/verify-core-installed.sh FCEU --release
# Expect: FAIL with two MD5 lines and "To fix:" command. Exit 1.

# Restore.
./Scripts/install-core.sh FCEU --release

# Smoke test 4: full verify.sh --core --release end-to-end.
./Scripts/verify.sh --core FCEU --release
# Expect: ALL PASS, including the new "verify-core-installed.sh ... --release" line.
```

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Tested on Apple Silicon (this repo's only target)
- [x] No build logs, binaries, or credentials committed
- [x] All scripts run under `/bin/bash` (macOS default 3.x)
- [x] No new files outside `Scripts/`, `.claude/`, `AGENTS.md`, and `.gitignore`

Made with [Cursor](https://cursor.com)