### PR TITLE
chore: Cursor hook that reminds agents to install + verify after core edits

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "command": ".cursor/hooks/post-edit-core.sh",
+        "matcher": "Write|Edit|StrReplace|EditNotebook"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/post-edit-core.sh
+++ b/.cursor/hooks/post-edit-core.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#
+# post-edit-core.sh — Cursor postToolUse hook for Write/Edit tool calls.
+#
+# When the agent edits a file inside a core plugin directory, surface a
+# reminder that any in-game test result must be preceded by install-core.sh
+# and verify-core-installed.sh, or it is invalid.
+#
+# Why this hook exists:
+#   The single most expensive failure mode in this repo is claiming a core
+#   test result against a stale installed plugin while the freshly-built
+#   binary sits unused in DerivedData. The protocol to prevent this is
+#   already documented in AGENTS.md and CLAUDE.md, and the tooling already
+#   exists in Scripts/. But agents (including the one that wrote this hook)
+#   have demonstrably ignored that protocol. This hook is the mechanical
+#   enforcement layer: every edit to a core file produces a fresh reminder
+#   in the agent's tool output, which the agent has to acknowledge.
+#
+# This hook does not block edits. It only surfaces context.
+#
+# Input (stdin, JSON):
+#   {
+#     "tool_name": "Write" | "Edit" | "StrReplace" | ...,
+#     "tool_input": { "path": "..." | "filePath": "...", ... },
+#     ...
+#   }
+#
+# Output (stdout, JSON):
+#   { "additional_context": "..." }
+#
+# Exit code 0 always (fail-open by design — never break the agent's flow).
+
+set -uo pipefail
+
+# Always exit 0 — failures here must not break the agent.
+trap 'exit 0' ERR
+
+input=$(cat)
+
+# Try to extract the edited file path from common shapes. Different Cursor
+# tools use different key names (path / filePath / target_notebook).
+# Use a single jq invocation that tries each in order.
+if ! command -v jq >/dev/null 2>&1; then
+  # No jq available — silently no-op. The hook is informational only.
+  echo '{}'
+  exit 0
+fi
+
+path=$(echo "$input" | jq -r '
+  .tool_input.path //
+  .tool_input.filePath //
+  .tool_input.file_path //
+  .tool_input.target_notebook //
+  empty
+')
+
+if [ -z "$path" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Determine the repo root from this script's location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Normalise: if the edited path is absolute and inside the repo, strip the
+# repo prefix. Otherwise treat it as already-relative.
+case "$path" in
+  "$REPO_ROOT"/*) rel_path="${path#$REPO_ROOT/}" ;;
+  /*)             # absolute but outside repo — not interesting
+                  echo '{}'; exit 0 ;;
+  *)              rel_path="$path" ;;
+esac
+
+# The first path component is the core directory candidate.
+core="${rel_path%%/*}"
+
+# Skip non-core paths quickly. Core directories are top-level and contain
+# an `Info.plist` plus a `*.xcodeproj` (or are referenced by the workspace).
+# Use a simple filesystem check rather than maintaining a hardcoded list.
+if [ -z "$core" ] || [ ! -d "$REPO_ROOT/$core" ]; then
+  echo '{}'
+  exit 0
+fi
+if [ ! -f "$REPO_ROOT/$core/Info.plist" ]; then
+  # Not a core directory.
+  echo '{}'
+  exit 0
+fi
+# Filter further: only fire for source-file edits (skip docs, READMEs, etc.).
+case "$rel_path" in
+  *.m|*.mm|*.h|*.hpp|*.c|*.cpp|*.swift|*.metal|*.plist) ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+# Build the reminder. If a verify script is available, also run it and
+# include its current verdict so the agent knows whether the installed
+# plugin already matches a recent build.
+verify_status=""
+if [ -x "$REPO_ROOT/Scripts/verify-core-installed.sh" ]; then
+  for cfg in --debug --release; do
+    out=$("$REPO_ROOT/Scripts/verify-core-installed.sh" "$core" "$cfg" 2>&1) && code=0 || code=$?
+    case "$code" in
+      0) verify_status="${verify_status}  [${cfg#--}] OK ($(echo "$out" | head -1))"$'\n' ;;
+      1) verify_status="${verify_status}  [${cfg#--}] STALE — installed plugin does NOT match latest build. Run: ./Scripts/install-core.sh ${core} ${cfg}"$'\n' ;;
+      3) verify_status="${verify_status}  [${cfg#--}] no installed plugin yet (first run will install it)"$'\n' ;;
+      4) verify_status="${verify_status}  [${cfg#--}] no ${cfg#--} build of ${core} exists yet"$'\n' ;;
+      *) verify_status="${verify_status}  [${cfg#--}] verify script returned exit ${code}"$'\n' ;;
+    esac
+  done
+fi
+
+reminder=$(cat <<EOF
+You just edited a file in the **${core}** core plugin directory (${rel_path}).
+
+Before you (or the user) report any in-game test result for ${core}:
+
+  1. Build:   xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + ${core}" -configuration <Debug|Release> -destination 'platform=macOS,arch=arm64' build
+              or:    ./Scripts/verify.sh --core ${core}            (Debug)
+                     ./Scripts/verify.sh --core ${core} --release  (Release)
+
+  2. Install: ./Scripts/install-core.sh ${core} [--debug|--release]
+              (verify.sh --core does this automatically)
+
+  3. Preflight: ./Scripts/verify-core-installed.sh ${core} [--debug|--release]
+                Confirm it prints "OK" before claiming any test result.
+
+OpenEmu loads cores from ~/Library/Application Support/OpenEmu/Cores/, NOT
+from the build directory. Skipping step 2 means OpenEmu will load the
+previously installed plugin regardless of what you just built. This is the
+exact failure mode that wasted hours during the FCEU grey-screen
+investigation (#214).
+
+Current preflight status:
+${verify_status:-  (Scripts/verify-core-installed.sh not present yet; cannot check.)}
+EOF
+)
+
+# Emit the reminder as additional_context for postToolUse.
+jq -n --arg ctx "$reminder" '{additional_context: $ctx}'
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,12 @@ test_dlopen
 # Claude Code local config
 .claude/settings.json
 
-# Cursor IDE config
-.cursor/
+# Cursor IDE config — local user settings stay out of git, but project hooks
+# are checked in so every contributor (and AI session) gets the same automated
+# guardrails.
+.cursor/*
+!.cursor/hooks.json
+!.cursor/hooks/
 
 # Agent artifacts — plans, scratchpads, notes (kept out of PR diffs by convention)
 tmp/agent/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,8 @@ The main app is **BSD 2-Clause**. Emulator cores are mostly **GPL v2**. Key rule
 > 3. Run `./Scripts/verify-core-installed.sh <CoreName>` and confirm `OK`. If it prints `FAIL`, the installed plugin doesn't match the build and your test result is invalid.
 >
 > The most common silent failure is testing against a stale installed plugin from a previous session. The preflight script catches this in under a second; run it before reporting any "still broken" or "now working" result.
+>
+> Cursor users: a project-level hook at `.cursor/hooks/post-edit-core.sh` automatically reminds the agent of these steps after every edit to a core source file, and surfaces the live preflight status. Do not work around the hook — if it tells you the install is stale, fix it before claiming a result.
 
 Before merging any PR, check it out locally, build, and verify the behaviors described in the PR's test plan.
 


### PR DESCRIPTION
## What does this PR do?

Adds a project-level Cursor hook that fires on `Write`/`Edit`/`StrReplace` tool calls and, if the edited file is a source file inside a top-level core directory, surfaces a reminder of the core install + preflight protocol along with the **live** preflight status for both Debug and Release builds.

The hook does not block edits — it only injects context. The point is to make ignoring the protocol *visible* in the agent's tool output, not to hard-block. Hard-blocking would prevent the agent from rebuilding to fix a stale state.

This is the mechanical-enforcement layer that complements #321. The protocol was already documented when the FCEU grey-screen session ignored it; this hook ensures the reminder now lands inside the agent's tool output every time it edits a core source file.

> **Stacked on #321.** This branch is based on `chore/core-install-verification`. Merge #321 first, then this. The hook depends on `Scripts/verify-core-installed.sh` which lands in #321.

## What did you test?

```bash
# 1. FCEU edit — produces full reminder + live preflight status.
echo '{"tool_name":"Write","tool_input":{"path":"FCEU/FCEUGameCore.mm"}}' \
  | .cursor/hooks/post-edit-core.sh

# 2. Non-core file (OpenEmuKit) — silent.
echo '{"tool_name":"Write","tool_input":{"path":"OpenEmuKit/Source/MTLGameRenderer.swift"}}' \
  | .cursor/hooks/post-edit-core.sh
# Expect: {}

# 3. Doc file in core dir — silent (filtered by source extension).
echo '{"tool_name":"Write","tool_input":{"path":"FCEU/README.md"}}' \
  | .cursor/hooks/post-edit-core.sh
# Expect: {}

# 4. Malformed input — silent.
echo '{}' | .cursor/hooks/post-edit-core.sh
# Expect: {}

# 5. bash 3.x compatibility.
/bin/bash .cursor/hooks/post-edit-core.sh < /dev/null
```

All five scenarios work as designed.

## Which cores or systems are affected?

None directly — this is editor tooling. But it improves the reliability of every future core change for anyone using Cursor.

## Did you use AI tools?

Yes. Claude (via Cursor) wrote the hook and the gitignore carve-out. The implementation was driven by the `create-hook` skill in the workspace. Tested locally with simulated tool inputs before committing.

## Linked issues

Related to #214 (the FCEU investigation).

---

## How to test locally

```bash
cd ~/Documents/Cursor/OpenEmu-fceu-grey-fix
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

# Confirm the hook is registered for Cursor users.
cat .cursor/hooks.json
ls -la .cursor/hooks/post-edit-core.sh

# Simulate the hook with a core edit and confirm a useful reminder.
echo '{"tool_name":"Write","tool_input":{"path":"FCEU/FCEUGameCore.mm"}}' \
  | ./.cursor/hooks/post-edit-core.sh

# Simulate with a non-core edit and confirm no output.
echo '{"tool_name":"Write","tool_input":{"path":"OpenEmuKit/Source/MTLGameRenderer.swift"}}' \
  | ./.cursor/hooks/post-edit-core.sh
# Expect: {}

# Inside Cursor itself: edit any source file inside a core directory
# (e.g. FCEU/FCEUGameCore.mm). Open the Hooks output channel — you
# should see the postToolUse hook fire and additional_context appear
# in the next agent turn.
```

---

## Implementation notes

- **No hardcoded core list.** The hook detects core directories by checking for an `Info.plist` at the top level of the edited file's first path component. New cores added to the project work automatically.
- **Source-file filter.** Only fires for `.m`, `.mm`, `.h`, `.hpp`, `.c`, `.cpp`, `.swift`, `.metal`, `.plist`. Edits to docs, READMEs, etc. are silent.
- **Fail-open.** Any error in the hook returns `{}` (no context injected) and exit 0. The hook never breaks the agent's flow.
- **Live preflight.** When `Scripts/verify-core-installed.sh` is present and the core has a build, the hook runs the preflight for both Debug and Release and includes the result in the reminder. So the agent sees, for example: `[release] STALE — installed plugin does NOT match latest build` exactly when that's the case.
- **Gitignore policy change.** The repo previously ignored `.cursor/` entirely. This PR carves out `.cursor/hooks.json` and `.cursor/hooks/` so the hook is checked in for every contributor, while local user settings (`.cursor/settings.json`, etc.) stay ignored.

## PR checklist

- [x] Branched from `chore/core-install-verification` (which was branched from `main`)
- [x] Tested on Apple Silicon
- [x] Hook script is executable and runs under `/bin/bash` (macOS default 3.x)
- [x] No build logs, binaries, or credentials committed
- [x] No new files outside `.cursor/`, `.gitignore`, and `AGENTS.md`

Made with [Cursor](https://cursor.com)