### PR TITLE
fix: cache Keychain tokens in memory to prevent main-thread hang

### DIFF
--- a/OpenEmu/OESaveSyncManager.swift
+++ b/OpenEmu/OESaveSyncManager.swift
@@ -87,29 +87,34 @@ final class OESaveSyncManager: NSObject {
     @objc var isSignedIn: Bool { accessToken != nil }
     
     // MARK: - OAuth Tokens
-    
+
     private var accessToken: String?
+    // In-memory cache for Keychain-backed tokens. Pre-loaded off the main thread in
+    // startMonitoring() so SecItemCopyMatching is never called on the main thread during
+    // timer-driven or FSEvent-driven sync checks (which run on the main actor in Swift 5.x).
+    private var _refreshToken: String?
     private var refreshToken: String? {
-        get { keychainRead(account: "refreshToken") }
-        set { keychainWrite(value: newValue, account: "refreshToken") }
+        get { _refreshToken }
+        set { _refreshToken = newValue; keychainWrite(value: newValue, account: "refreshToken") }
     }
     private var tokenExpiryDate: Date?
-    
+
     // MARK: - FSEventStream
-    
+
     private var eventStream: FSEventStreamRef?
     private var monitoredURLs: [URL] = []
-    
+
     // MARK: - OAuth Listener
-    
+
     private var oauthListener: NWListener?
-    
+
     // MARK: - Save Folder
 
     /// Cached Drive folder ID for "OpenEmu Saves". Persisted in keychain across sessions.
+    private var _saveFolderID: String?
     private var saveFolderID: String? {
-        get { keychainRead(account: "saveFolderID") }
-        set { keychainWrite(value: newValue, account: "saveFolderID") }
+        get { _saveFolderID }
+        set { _saveFolderID = newValue; keychainWrite(value: newValue, account: "saveFolderID") }
     }
 
     // MARK: - Background Sync
@@ -171,7 +176,19 @@ final class OESaveSyncManager: NSObject {
         monitoredURLs = urls
         startFSEventStream(for: urls)
         os_log(.info, log: log, "Save Sync Manager started monitoring %d directories.", urls.count)
-        
+
+        // Pre-load persisted tokens from Keychain on a background thread so the main thread
+        // is never blocked by SecItemCopyMatching when the sync timer or FSEvent fires.
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self = self else { return }
+            let token    = self.keychainRead(account: "refreshToken")
+            let folderID = self.keychainRead(account: "saveFolderID")
+            await MainActor.run {
+                self._refreshToken  = token
+                self._saveFolderID  = folderID
+            }
+        }
+
         startBackgroundTimer()
     }
     


### PR DESCRIPTION
## What does this PR do?

`refreshToken` and `saveFolderID` were computed properties that called `SecItemCopyMatching` on every read. `Task {}` blocks created from Timer and FSEvent callbacks inherit the main actor context in Swift 5.x, so these Keychain reads were landing on the main thread and blocking for 2000ms+ on macOS 26. Sentry recorded ~20 escalating hang events from this path.

The fix caches both values in private stored properties (`_refreshToken`, `_saveFolderID`). `startMonitoring()` pre-loads them from Keychain on a detached background task before the sync timer starts. All subsequent reads are in-memory; writes still persist to Keychain. `signOut()` clears both cache and Keychain correctly via the existing setters.

## What did you test?

- Verified build succeeds cleanly (no new warnings or errors in `OESaveSyncManager.swift`)
- Code path review: sign-in, sign-out, token refresh, `ensureValidAccessToken`, `saveFolderID` caching in `ensureSaveFolder` all trace correctly through the new stored vars
- Pre-load race window is negligible: background timer fires after 300s, FSEvent coalesce latency is 2s — the detached task completes in milliseconds

## Which cores or systems are affected?

General app change — affects all users with Google Drive sync enabled, regardless of core or system.

## Did you use AI tools?

Used Claude to identify the root cause from Sentry stack traces, draft the fix, and verify the sign-in/sign-out/token-refresh paths were all correct. Reviewed and confirmed the change.

## Linked issues

Fixes #328

---

## How to test locally

Replace `NUMBER` with this PR's number, then paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

To reproduce the original hang: on macOS 26, launch with Google Drive sync enabled and watch for `SecItemCopyMatching` blocks in Instruments → Time Profiler on the main thread. With this fix, the Keychain call should only appear on a background thread during `startMonitoring()`.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header