### PR TITLE
fix: harden cheats database load against missing bundle resource

### DIFF
--- a/OpenEmu/Cheats.swift
+++ b/OpenEmu/Cheats.swift
@@ -62,15 +62,20 @@ final class Cheats: NSObject {
     }
     
     private func findCheats() {
-        
+
         // TODO: Read cheats database from server instead of bundling with the app for easy updating.
-        let cheatsDatabaseURL = Bundle.main.url(forResource: "cheats-database", withExtension: "xml")!
-        
-        let xml = try! Data(contentsOf: cheatsDatabaseURL)
-        
+        guard let cheatsDatabaseURL = Bundle.main.url(forResource: "cheats-database", withExtension: "xml") else {
+            NSLog("[Cheats] cheats-database.xml not found in app bundle — no cheats available.")
+            return
+        }
+
+        guard let xml = try? Data(contentsOf: cheatsDatabaseURL) else {
+            NSLog("[Cheats] Failed to read cheats-database.xml at %@", cheatsDatabaseURL.path)
+            return
+        }
+
         let parser = XMLParser(data: xml)
         parser.delegate = self
-        
         parser.parse()
     }
 }


### PR DESCRIPTION
## What does this PR do?

`findCheats()` in `Cheats.swift` used two force-unwraps: one on `Bundle.main.url(forResource:)` and one on `try! Data(contentsOf:)`. When `cheats-database.xml` was absent from the installed app bundle, the forced read threw a fatal error and crashed the app. Sentry recorded this for users opening cheats on PSX games (Mednafen, Breath of Fire III).

Both force-unwraps are replaced with guarded paths that log a message and return early. `allCheats` stays empty, the cheats panel shows nothing, and the app continues normally.

## What did you test?

- Build passes cleanly with no new warnings
- Code path review: both early-return paths leave `allCheats` as `[]`, which the cheats UI already handles gracefully (empty list)
- `cheats-database.xml` is confirmed present in `OpenEmu/Other Assets/` and referenced in the Copy Bundle Resources build phase — the guard is a safety net for any future packaging regression

## Which cores or systems are affected?

General app change — affects the cheats lookup path for all cores and systems.

## Did you use AI tools?

Used Claude to identify the crash site from Sentry, verify the bundle reference in the project file, and draft the hardened guard. Reviewed and confirmed.

## Linked issues

Fixes #331

---

## How to test locally

Replace `NUMBER` with this PR's number, then paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

To verify the fix manually: temporarily rename `cheats-database.xml` out of the bundle after building, launch the app, open any game's cheats panel — it should show an empty list and log a message rather than crashing.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header