### PR TITLE
fix(flycast): fix 27fps video slowdown by re-enabling JIT and restoring dynamic frame timeout

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -33,10 +33,16 @@ Run the full git shipping loop for the current branch.
 
    Then the template's `## How to test locally` section follows automatically — that's already in `.github/PULL_REQUEST_TEMPLATE.md` and `gh pr create --body` will inherit it if you pass `--body-file` or pipe through. If you're constructing the body inline with `--body "..."`, copy the test block verbatim from the template.
 
-   Then push and open the PR in the same step:
+   Push and open the PR, then immediately edit the body to replace `NUMBER` with the real PR number:
+   ```bash
+   # Step 1 — create the PR (NUMBER is a placeholder at this point)
+   PR_URL=$(gh pr create --repo nickybmon/OpenEmu-Silicon --base main --title "<type>: description" --body "...")
+   # Step 2 — extract the number and patch the body
+   PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+   gh pr edit "$PR_NUM" --repo nickybmon/OpenEmu-Silicon --body "$(gh pr view "$PR_NUM" --repo nickybmon/OpenEmu-Silicon --json body -q .body | sed "s/NUMBER/$PR_NUM/g")"
    ```
-   gh pr create --repo nickybmon/OpenEmu-Silicon --base main --title "<type>: description" --body "..."
-   ```
+
+   Always do both steps. The reviewer should never see `NUMBER` in the test block — it must be the real PR number before you report the PR as open.
 
    - If this PR fixes a tracked issue, the PR body **must** include `Fixes #N` (not just the commit). GitHub only auto-closes an issue when the keyword appears in the PR body.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Fixes #
 
 ## How to test locally
 
-Replace `NUMBER` with this PR's number, then paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.
+The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.
 
 ```bash
 cd ~/Documents/Cursor/Open\ Emu

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -69,11 +69,11 @@ public:
     bool init() override {
         mach_timebase_info(&_tb);
         _nextPushTime = 0;
-        // Allow SH4 to run up to one NTSC frame (~16.7ms) ahead of real time
-        // before sleeping. This matches the original ring-buffer one-frame
-        // lookahead, and crucially lets VBlank fire during the free-run window
-        // so the render thread gets frames at full rate (#202).
-        _frameAheadTicks = (uint64_t)NSEC_PER_SEC / 60 * _tb.denom / _tb.numer;
+        // Allow SH4 to run up to two NTSC frames (~33.4ms) ahead of real time
+        // before sleeping. Two frames gives SH4 enough runway to complete a full
+        // PVR render cycle and signal the render thread before the 60ms timeout
+        // fires, fixing video slowdown and maple-bus polling gaps (#202).
+        _frameAheadTicks = (uint64_t)NSEC_PER_SEC / 60 * 2 * _tb.denom / _tb.numer;
         return true;
     }
 
@@ -97,8 +97,9 @@ public:
             uint64_t now = mach_absolute_time();
 
             // Reset after pauses, save-state loads, or the very first push.
-            // 40ms slack = two PAL frames; anything larger means we fell behind.
-            uint64_t maxSlipTicks = (uint64_t)(40 * NSEC_PER_MSEC) * _tb.denom / _tb.numer;
+            // 60ms slack = three PAL frames; matches the wider 2-frame lookahead
+            // window so a brief CPU hiccup doesn't trigger a spurious clock reset.
+            uint64_t maxSlipTicks = (uint64_t)(60 * NSEC_PER_MSEC) * _tb.denom / _tb.numer;
             if (_nextPushTime == 0 || now > _nextPushTime + maxSlipTicks)
                 _nextPushTime = now;
 
@@ -183,7 +184,9 @@ __weak FlycastGameCore *_current;
 
     config::RendererType = RenderType::OpenGL;
     config::AudioBackend.set("openemu");
-    config::DynarecEnabled.override(false); // interpreter — JIT has stability issues on ARM64 macOS
+    // JIT was previously disabled due to a race under non-threaded rendering (#46cdc996).
+    // Threaded rendering is always active in this build so that race does not apply.
+    config::DynarecEnabled.override(true);
 
     if (!addrspace::reserve()) {
         NSLog(@"[Flycast] Failed to reserve Dreamcast address space");
@@ -245,7 +248,7 @@ __weak FlycastGameCore *_current;
             theGLContext.init();
             emu.loadGame(_romPath.fileSystemRepresentation);
             // loadGame calls reset()+load() which clears all settings — re-apply after it returns.
-            config::DynarecEnabled.override(false); // keep interpreter; JIT unstable on ARM64 macOS
+            config::DynarecEnabled.override(true);  // JIT race was non-threaded-rendering only; threaded is always active
             config::AudioBackend.set("openemu");    // reset() clears this to "auto"; restore before InitAudio()
             // loadGameSpecificSettings() runs load(true) which can flip UseReios=false from a per-game
             // config. Without HLE BIOS the VBL-driven GD-ROM server is inert and games freeze on a

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -48,6 +48,7 @@
 #include "wsi/osx.h"
 
 #include <OpenGL/gl3.h>
+#include <mach/mach_time.h>
 #include <sys/stat.h>
 
 #define SAMPLERATE 44100
@@ -58,33 +59,51 @@
 // Custom AudioBackend that writes samples to OpenEmu's ring buffer
 class OpenEmuAudioBackend : public AudioBackend
 {
+    mach_timebase_info_data_t _tb;
+    uint64_t _nextPushTime = 0;
+
 public:
     OpenEmuAudioBackend() : AudioBackend("openemu", "OpenEmu") {}
 
-    bool init() override { return true; }
+    bool init() override {
+        mach_timebase_info(&_tb);
+        _nextPushTime = 0;
+        return true;
+    }
 
     u32 push(const void *data, u32 frames, bool wait) override
     {
         if (!_current) return frames;
 
-        OERingBuffer *buf = [_current audioBufferAtIndex:0];
-        NSUInteger byteCount = frames * 4; // stereo s16 = 4 bytes per frame
-
         if (wait) {
-            // Block until there's room in the ring buffer. This is the primary
-            // real-time throttle: config::LimitFPS is constexpr true, so push()
-            // is always called with wait=true. Spinning here paces the SH4 thread
-            // to OE's audio consumption rate, fixing games running too fast (#202).
-            // 200 × 100µs = 20ms max (one PAL frame), preventing infinite spin if
-            // the emulator stops while the SH4 thread is mid-flight.
-            for (int i = 0; i < 200 && _current && [buf freeBytes] < byteCount; i++)
-                usleep(100);
+            // Wall-clock throttle: pace the SH4 thread to real time using
+            // mach_absolute_time rather than ring-buffer drain rate. The
+            // previous ring-buffer approach (#203) ran ~8.8% fast on 48 kHz
+            // hosts because CoreAudio drained the buffer faster than the
+            // 44100 Hz math assumed (#202).
+            uint64_t now = mach_absolute_time();
+
+            // Reset after pauses, save-state loads, or the very first push.
+            // 20ms slack = one PAL frame; anything larger means we fell behind.
+            uint64_t maxSlipTicks = (uint64_t)(20 * NSEC_PER_MSEC) * _tb.denom / _tb.numer;
+            if (_nextPushTime == 0 || now > _nextPushTime + maxSlipTicks)
+                _nextPushTime = now;
+
+            if (now < _nextPushTime) {
+                uint64_t sleepNanos = (_nextPushTime - now) * _tb.numer / _tb.denom;
+                usleep((useconds_t)(sleepNanos / 1000));
+            }
+
+            uint64_t batchNanos = (uint64_t)frames * NSEC_PER_SEC / SAMPLERATE;
+            _nextPushTime += batchNanos * _tb.denom / _tb.numer;
         }
-        [buf write:(const uint8_t *)data maxLength:byteCount];
+
+        OERingBuffer *buf = [_current audioBufferAtIndex:0];
+        [buf write:(const uint8_t *)data maxLength:(NSUInteger)(frames * 4)];
         return frames;
     }
 
-    void term() override {}
+    void term() override { _nextPushTime = 0; }
 };
 
 static OpenEmuAudioBackend openEmuAudioBackend;

--- a/Flycast/OpenEmu/FlycastGameCore.mm
+++ b/Flycast/OpenEmu/FlycastGameCore.mm
@@ -61,6 +61,7 @@ class OpenEmuAudioBackend : public AudioBackend
 {
     mach_timebase_info_data_t _tb;
     uint64_t _nextPushTime = 0;
+    uint64_t _frameAheadTicks = 0; // one NTSC frame of lookahead in mach ticks
 
 public:
     OpenEmuAudioBackend() : AudioBackend("openemu", "OpenEmu") {}
@@ -68,6 +69,11 @@ public:
     bool init() override {
         mach_timebase_info(&_tb);
         _nextPushTime = 0;
+        // Allow SH4 to run up to one NTSC frame (~16.7ms) ahead of real time
+        // before sleeping. This matches the original ring-buffer one-frame
+        // lookahead, and crucially lets VBlank fire during the free-run window
+        // so the render thread gets frames at full rate (#202).
+        _frameAheadTicks = (uint64_t)NSEC_PER_SEC / 60 * _tb.denom / _tb.numer;
         return true;
     }
 
@@ -81,21 +87,29 @@ public:
             // previous ring-buffer approach (#203) ran ~8.8% fast on 48 kHz
             // hosts because CoreAudio drained the buffer faster than the
             // 44100 Hz math assumed (#202).
+            //
+            // Advance the deadline first, then sleep only if SH4 is more than
+            // one NTSC frame ahead of real time. This gives VBlank a full
+            // ~16.7ms window to fire before we block the SH4 thread.
+            uint64_t batchNanos = (uint64_t)frames * NSEC_PER_SEC / SAMPLERATE;
+            uint64_t batchTicks = batchNanos * _tb.denom / _tb.numer;
+
             uint64_t now = mach_absolute_time();
 
             // Reset after pauses, save-state loads, or the very first push.
-            // 20ms slack = one PAL frame; anything larger means we fell behind.
-            uint64_t maxSlipTicks = (uint64_t)(20 * NSEC_PER_MSEC) * _tb.denom / _tb.numer;
+            // 40ms slack = two PAL frames; anything larger means we fell behind.
+            uint64_t maxSlipTicks = (uint64_t)(40 * NSEC_PER_MSEC) * _tb.denom / _tb.numer;
             if (_nextPushTime == 0 || now > _nextPushTime + maxSlipTicks)
                 _nextPushTime = now;
 
-            if (now < _nextPushTime) {
-                uint64_t sleepNanos = (_nextPushTime - now) * _tb.numer / _tb.denom;
+            _nextPushTime += batchTicks;
+
+            // Only sleep when SH4 is more than one NTSC frame ahead.
+            if (_nextPushTime > now + _frameAheadTicks) {
+                uint64_t sleepTicks = _nextPushTime - (now + _frameAheadTicks);
+                uint64_t sleepNanos = sleepTicks * _tb.numer / _tb.denom;
                 usleep((useconds_t)(sleepNanos / 1000));
             }
-
-            uint64_t batchNanos = (uint64_t)frames * NSEC_PER_SEC / SAMPLERATE;
-            _nextPushTime += batchNanos * _tb.denom / _tb.numer;
         }
 
         OERingBuffer *buf = [_current audioBufferAtIndex:0];

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,7 +1077,10 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	return rend_single_frame(true); // use default timeout (20ms NTSC / 23ms PAL)
+	// OE's audio throttle allows SH4 to run up to one NTSC frame (~16.7ms) ahead
+	// of real time. 35ms gives comfortable margin above PAL's 20ms VBlank period
+	// without stalling the render thread on slow frames.
+	return rend_single_frame(true, 35);
 }
 
 void Emulator::vblank()

--- a/Flycast/flycast/core/emulator.cpp
+++ b/Flycast/flycast/core/emulator.cpp
@@ -1077,10 +1077,16 @@ bool Emulator::render()
 		return false;
 	if (state != Running)
 		return false;
-	// OE's audio throttle allows SH4 to run up to one NTSC frame (~16.7ms) ahead
-	// of real time. 35ms gives comfortable margin above PAL's 20ms VBlank period
-	// without stalling the render thread on slow frames.
-	return rend_single_frame(true, 35);
+	// Interpreter runs at ~10-20% real speed on ARM64; a Dreamcast frame takes
+	// ~160ms of wall time. Use 500ms timeout for interpreter so rend_single_frame
+	// doesn't time out mid-frame. JIT runs at full speed so -1 (infinite wait) is
+	// correct there — the render thread will be woken promptly by the SH4 thread.
+#if FEAT_SHREC != DYNAREC_NONE
+	const int frameTimeout = config::DynarecEnabled ? -1 : 500;
+#else
+	const int frameTimeout = 500;
+#endif
+	return rend_single_frame(true, frameTimeout);
 }
 
 void Emulator::vblank()


### PR DESCRIPTION
## What does this PR do?

Fixes Flycast video running at ~27fps instead of 60fps on games like Jet Set Radio. Two root causes addressed:

1. **Wrong frame timeout**: A previous commit replaced the dynamic `rend_single_frame` timeout (500ms for interpreter, -1 for JIT) with a flat 60ms. The Dreamcast SH4 interpreter runs at ~10-20% real speed on ARM64, meaning frames take ~160ms of wall time — so the render thread was timing out and dropping frames constantly.

2. **JIT disabled unnecessarily**: JIT was disabled in commit `46cdc996` due to a race condition under *non-threaded* rendering mode. This build always uses threaded rendering, so that race cannot occur. Re-enabling JIT brings SH4 to full speed.

## What did you test?

- Jet Set Radio: confirmed 60fps gameplay after warm boot
- Audio throttle (48 kHz fix from earlier commits in this branch): still correct, no overspeed regression

## Which cores or systems are affected?

Flycast (Dreamcast)

## Did you use AI tools?

Yes — used Claude to investigate root cause (tracing git history back to commits `11d0d261` and `46cdc996`) and draft the fix. Reviewed and tested.

## Linked issues

Fixes #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 336 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/Flycast.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/Flycast.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/Flycast.oecoreplugin
```

Test: launch Jet Set Radio, confirm it runs at full 60fps after warm boot.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header