### PR TITLE
fix: always request HID access in debug builds to fix missing controller input

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -488,6 +488,16 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
         _ = OEBindingsController.self
         let dm = OEDeviceManager.shared
         if #available(macOS 10.15, *) {
+            #if DEBUG
+            // In debug builds, always call requestAccess() regardless of what
+            // IOHIDCheckAccess reports. IOHIDCheckAccess may return .granted based
+            // on the production app's TCC bundle-ID entry, causing the switch below
+            // to hit default:break — but macOS HID event delivery is gated on the
+            // specific binary being registered, so the debug binary never receives
+            // events. IOHIDRequestAccess is idempotent when permission is already
+            // granted (returns true, no dialog), so this is safe to call every launch.
+            dm.requestAccess()
+            #else
             switch dm.accessType {
             case .unknown:
                 // TCC may return "unknown" on subsequent launches when the app lacks a
@@ -512,6 +522,7 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
             default:
                 break
             }
+            #endif
             // Re-enumerate keyboards in case permission was granted after init.
             dm.rescanKeyboardDevices()
         }

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -8641,7 +8641,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0.6;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.$(PRODUCT_NAME:identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.OpenEmu.debug";
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_OBJC_BRIDGING_HEADER = "OpenEmu-Bridging-Header.h";


### PR DESCRIPTION
## What does this PR do?

Fixes debug builds of OpenEmu not receiving controller input even after Input Monitoring permission is granted.

`IOHIDCheckAccess` may return `.granted` based on the **production app's** TCC bundle-ID entry. This causes the permission switch to hit `default: break` — but macOS HID event delivery is gated per-binary, so the debug build never actually receives controller events despite TCC reporting permission as granted.

Two changes working together:

1. **`AppDelegate.swift`** — in `#if DEBUG`, always call `dm.requestAccess()` regardless of what `IOHIDCheckAccess` reports. `IOHIDRequestAccess` is idempotent when permission is already granted (returns `true`, no dialog), so this is safe on every launch.

2. **`OpenEmu.xcodeproj`** — give the debug build a stable bundle ID (`org.openemu.OpenEmu.debug`) so TCC permissions persist across rebuilds, rather than being revoked each time a new binary is signed ad-hoc.

## What did you test?

- Build passes, static analyzer clean
- All existing warnings are pre-existing (rcheevos vendor code, deprecated IKImageBrowserView)

## Which cores or systems are affected?

Main app only — debug builds. No production behaviour change.

## Did you use AI tools?

Yes — used Claude to identify the root cause and draft the fix. Reviewed the logic myself.

## Linked issues

Fixes #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

Test: plug in a controller, launch the debug build, confirm controller input is received without having to re-grant Input Monitoring in System Settings.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header