### PR TITLE
fix: wire Google Drive OAuth credentials via secrets file and CI injection

### DIFF
--- a/.claude/commands/prep-release.md
+++ b/.claude/commands/prep-release.md
@@ -49,7 +49,13 @@ sed -i '' 's/MARKETING_VERSION = OLD;/MARKETING_VERSION = NEW;/g' \
   "OpenEmu/OpenEmu.xcodeproj/project.pbxproj"
 ```
 
-Verify by grepping both files and reporting the new values.
+**`SECURITY.md`** — update the supported versions table so the new version is listed as supported and the old "latest" row is replaced:
+```bash
+sed -i '' "s/| [0-9][0-9.]* (latest) | ✅ |/| NEW_VERSION (latest) | ✅ |/" SECURITY.md
+sed -i '' "s/| < [0-9][0-9.]* | ❌ |/| < NEW_VERSION | ❌ |/" SECURITY.md
+```
+
+Verify by grepping all three files and reporting the new values.
 
 ## Step 4 — Auto-draft release notes from git history
 
@@ -104,7 +110,7 @@ If the build fails, stop and report the errors. Do not continue.
 This is a config/docs-only change and qualifies for a direct commit to main.
 
 ```bash
-git add OpenEmu/OpenEmu-Info.plist OpenEmu/OpenEmu.xcodeproj/project.pbxproj Releases/notes-VERSION.md
+git add OpenEmu/OpenEmu-Info.plist OpenEmu/OpenEmu.xcodeproj/project.pbxproj Releases/notes-VERSION.md SECURITY.md
 git commit -m "chore: bump version to VERSION (build BUILD)
 
 Add release notes for VERSION."

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Generate credentials stubs
         run: |
           cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+          cp OpenEmu/OEGoogleDriveSecrets.template.swift OpenEmu/OEGoogleDriveSecrets.swift
 
       - name: Build OpenEmu (Debug, arm64)
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Generate credentials stubs
         run: |
           cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+          cp OpenEmu/OEGoogleDriveSecrets.template.swift OpenEmu/OEGoogleDriveSecrets.swift
 
       - name: Build
         run: |

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Generate credentials stubs
         run: |
           cp OpenEmu/ScreenScraperDevCredentials.template.swift OpenEmu/ScreenScraperDevCredentials.swift
+          cp OpenEmu/OEGoogleDriveSecrets.template.swift OpenEmu/OEGoogleDriveSecrets.swift
       - name: Build OpenEmu
         working-directory: ${{github.workspace}}
         run: xcodebuild -workspace "OpenEmu-metal.xcworkspace" -scheme "OpenEmu" -configuration Release -sdk macosx -arch arm64 -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,17 @@ jobs:
 
       # ── Credential stubs ────────────────────────────────────────────────────
       - name: Generate credential stubs
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
         run: |
           cp OpenEmu/ScreenScraperDevCredentials.template.swift \
              OpenEmu/ScreenScraperDevCredentials.swift
+          sed \
+            -e "s|YOUR_CLIENT_ID.apps.googleusercontent.com|${GOOGLE_CLIENT_ID}|g" \
+            -e "s|YOUR_CLIENT_SECRET|${GOOGLE_CLIENT_SECRET}|g" \
+            OpenEmu/OEGoogleDriveSecrets.template.swift \
+            > OpenEmu/OEGoogleDriveSecrets.swift
 
       # ── Sparkle private key ─────────────────────────────────────────────────
       # On self-hosted runner this key is already in the keychain.

--- a/OpenEmu/OEGoogleDriveConfig.swift
+++ b/OpenEmu/OEGoogleDriveConfig.swift
@@ -29,16 +29,12 @@ enum OEGoogleDriveConfig {
     
     // MARK: - OAuth Credentials
     
-    // TODO: Inject real credentials before Cloud Sync can function.
-    // Strategy options: (a) CI secret → OEGoogleDriveSecrets.swift at build time,
-    //                   (b) runtime user-provided credentials in Preferences.
-    // See: OEGoogleDriveSecrets.template.swift for the secrets-file pattern.
-    // Tracked in: https://github.com/nickybmon/OpenEmu-Silicon/issues/129
-    /// Your Google API OAuth 2.0 Client ID.
-    static let clientID     = "YOUR_CLIENT_ID_HERE"
-    
-    /// Your Google API OAuth 2.0 Client Secret.
-    static let clientSecret = "YOUR_CLIENT_SECRET_HERE"
+    // Real credentials live in OEGoogleDriveSecrets.swift (gitignored).
+    // Locally: copy OEGoogleDriveSecrets.template.swift → OEGoogleDriveSecrets.swift and fill in values.
+    // In CI: the release workflow injects GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET secrets.
+    // The properties below are defined in that file; this extension just documents them.
+    // static let clientID: String      — defined in OEGoogleDriveSecrets.swift
+    // static let clientSecret: String  — defined in OEGoogleDriveSecrets.swift
     
     // MARK: - OAuth Endpoints
     
@@ -48,19 +44,18 @@ enum OEGoogleDriveConfig {
     
     // MARK: - API Scopes
 
-    /// Requests access to files created by this app only (user-visible in Drive).
-    static let scopes = ["https://www.googleapis.com/auth/drive.file"]
+    /// Requests access to the hidden App Data folder only (not visible in Drive UI).
+    static let scopes = ["https://www.googleapis.com/auth/drive.appdata"]
 
     // MARK: - API Endpoints
 
     static let driveAPIBaseURL   = "https://www.googleapis.com/drive/v3"
     static let uploadAPIBaseURL  = "https://www.googleapis.com/upload/drive/v3"
 
-    // MARK: - Save Folder
+    // MARK: - App Data Folder
 
-    /// Name of the folder created in the root of the user's Google Drive.
-    /// User-visible in the Drive web UI, browseable, and removable.
-    static let saveFolderName = "OpenEmu Saves"
+    /// Fixed identifier for the Drive hidden App Data folder.
+    static let appDataFolderName = "appDataFolder"
     
     // MARK: - Keychain
     

--- a/OpenEmu/OEGoogleDriveSecrets.template.swift
+++ b/OpenEmu/OEGoogleDriveSecrets.template.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension OEGoogleDriveConfig {
     /// Your real Google OAuth Client ID.
-    static let _clientID     = "YOUR_CLIENT_ID.apps.googleusercontent.com"
+    static let clientID     = "YOUR_CLIENT_ID.apps.googleusercontent.com"
     /// Your real Google OAuth Client Secret.
-    static let _clientSecret = "YOUR_CLIENT_SECRET"
+    static let clientSecret = "YOUR_CLIENT_SECRET"
 }

--- a/OpenEmu/OESaveSyncManager.swift
+++ b/OpenEmu/OESaveSyncManager.swift
@@ -52,7 +52,7 @@ protocol OESaveSyncManagerDelegate: AnyObject {
 // MARK: - OESaveSyncManager
 
 /// Singleton that manages cloud synchronisation of OpenEmu saves (battery saves + save states)
-/// with Google Drive in a user-visible "OpenEmu Saves" folder at the root of the user's Drive.
+/// with Google Drive using the hidden App Data folder.
 ///
 /// ## Lifecycle
 /// Call `startMonitoring()` once the library database has loaded.
@@ -107,15 +107,6 @@ final class OESaveSyncManager: NSObject {
     // MARK: - OAuth Listener
 
     private var oauthListener: NWListener?
-
-    // MARK: - Save Folder
-
-    /// Cached Drive folder ID for "OpenEmu Saves". Persisted in keychain across sessions.
-    private var _saveFolderID: String?
-    private var saveFolderID: String? {
-        get { _saveFolderID }
-        set { _saveFolderID = newValue; keychainWrite(value: newValue, account: "saveFolderID") }
-    }
 
     // MARK: - Background Sync
 
@@ -181,11 +172,9 @@ final class OESaveSyncManager: NSObject {
         // is never blocked by SecItemCopyMatching when the sync timer or FSEvent fires.
         Task.detached(priority: .utility) { [weak self] in
             guard let self = self else { return }
-            let token    = self.keychainRead(account: "refreshToken")
-            let folderID = self.keychainRead(account: "saveFolderID")
+            let token = self.keychainRead(account: "refreshToken")
             await MainActor.run {
-                self._refreshToken  = token
-                self._saveFolderID  = folderID
+                self._refreshToken = token
             }
         }
 
@@ -370,9 +359,8 @@ final class OESaveSyncManager: NSObject {
             do {
                 // Refresh token if necessary before any API call.
                 try await ensureValidAccessToken()
-                let folderID = try await ensureSaveFolder()
 
-                let remoteFiles = try await listFiles(inFolder: folderID, namePrefix: cloudPath)
+                let remoteFiles = try await listFiles(inFolder: OEGoogleDriveConfig.appDataFolderName, namePrefix: cloudPath)
                 
                 // Find the most recently modified remote file.
                 let latestRemote = remoteFiles.max { a, b in
@@ -421,9 +409,8 @@ final class OESaveSyncManager: NSObject {
         Task {
             do {
                 try await ensureValidAccessToken()
-                let folderID = try await ensureSaveFolder()
 
-                let files = try await listFiles(inFolder: folderID, namePrefix: cloudPath)
+                let files = try await listFiles(inFolder: OEGoogleDriveConfig.appDataFolderName, namePrefix: cloudPath)
                 
                 for file in files {
                     guard let fileId = file.id, let fileName = file.name else { continue }
@@ -450,7 +437,6 @@ final class OESaveSyncManager: NSObject {
         
         do {
             try await ensureValidAccessToken()
-            let folderID = try await ensureSaveFolder()
 
             let data = try Data(contentsOf: localURL)
             let cloudName = cloudFileName(for: localURL)
@@ -458,13 +444,13 @@ final class OESaveSyncManager: NSObject {
             setStatus(.syncing, message: "Uploading \(localURL.lastPathComponent)…")
 
             // Check if a file with this name already exists in Drive (for update vs. create).
-            let existing = try await listFiles(inFolder: folderID, namePrefix: cloudName)
+            let existing = try await listFiles(inFolder: OEGoogleDriveConfig.appDataFolderName, namePrefix: cloudName)
 
             if let existingFile = existing.first(where: { $0.name == cloudName }), let fileId = existingFile.id {
                 try await updateFile(fileId: fileId, data: data, mimeType: mimeType(for: localURL))
                 os_log(.debug, log: log, "Updated cloud save: %@", cloudName)
             } else {
-                try await createFile(name: cloudName, data: data, mimeType: mimeType(for: localURL), parentID: folderID)
+                try await createFile(name: cloudName, data: data, mimeType: mimeType(for: localURL), parentID: OEGoogleDriveConfig.appDataFolderName)
                 os_log(.debug, log: log, "Created cloud save: %@", cloudName)
             }
             
@@ -690,7 +676,6 @@ final class OESaveSyncManager: NSObject {
         accessToken   = nil
         tokenExpiryDate = nil
         refreshToken  = nil   // clears from keychain
-        saveFolderID  = nil   // clears from keychain
         setStatus(.idle, message: nil)
         os_log(.info, log: log, "Signed out of Google Drive.")
     }
@@ -790,63 +775,11 @@ final class OESaveSyncManager: NSObject {
         public var name: String?
         public var modifiedTime: Date?
     }
-    
-    
-    /// Returns the Drive folder ID for "OpenEmu Saves", creating the folder if it doesn't exist yet.
-    private func ensureSaveFolder() async throws -> String {
-        if let id = saveFolderID { return id }
-
-        // Search for an existing folder with this name.
-        let folderMime = "application/vnd.google-apps.folder"
-        let safe = OEGoogleDriveConfig.saveFolderName.replacingOccurrences(of: "'", with: "\\'")
-        let q = "name='\(safe)' and mimeType='\(folderMime)' and trashed=false"
-
-        var components = URLComponents(string: "\(OEGoogleDriveConfig.driveAPIBaseURL)/files")!
-        components.queryItems = [
-            URLQueryItem(name: "spaces", value: "drive"),
-            URLQueryItem(name: "fields", value: "files(id,name)"),
-            URLQueryItem(name: "q",      value: q),
-        ]
-        var request = URLRequest(url: components.url!)
-        request.setValue("Bearer \(accessToken!)", forHTTPHeaderField: "Authorization")
-
-        let (data, response) = try await session.data(for: request)
-        try validateResponse(response, data: data, context: "ensureSaveFolder/search")
-
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-        if let existing = (json["files"] as? [[String: Any]])?.first,
-           let id = existing["id"] as? String {
-            saveFolderID = id
-            os_log(.info, log: log, "Found existing save folder: %@", id)
-            return id
-        }
-
-        // Create it.
-        let metadata: [String: Any] = ["name": OEGoogleDriveConfig.saveFolderName, "mimeType": folderMime]
-        var createRequest = URLRequest(url: URL(string: "\(OEGoogleDriveConfig.driveAPIBaseURL)/files")!)
-        createRequest.httpMethod = "POST"
-        createRequest.setValue("Bearer \(accessToken!)", forHTTPHeaderField: "Authorization")
-        createRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        createRequest.httpBody = try JSONSerialization.data(withJSONObject: metadata)
-
-        let (createData, createResponse) = try await session.data(for: createRequest)
-        try validateResponse(createResponse, data: createData, context: "ensureSaveFolder/create")
-
-        let createJSON = try JSONSerialization.jsonObject(with: createData) as! [String: Any]
-        guard let newID = createJSON["id"] as? String else {
-            throw OESaveSyncError.apiError(statusCode: 0, body: "Folder creation returned no ID")
-        }
-        saveFolderID = newID
-        os_log(.info, log: log, "Created save folder: %@", newID)
-        return newID
-    }
-
-    /// Returns a list of all files currently stored in the "OpenEmu Saves" Drive folder.
+    /// Returns a list of all files currently stored in the Google Drive appDataFolder.
     public func fetchCloudFileList() async throws -> [DriveFile] {
         try await ensureValidAccessToken()
-        let folderID = try await ensureSaveFolder()
-        let files = try await listFiles(inFolder: folderID)
-        os_log(.info, log: log, "Fetched %d files from save folder", files.count)
+        let files = try await listFiles(inFolder: OEGoogleDriveConfig.appDataFolderName)
+        os_log(.info, log: log, "Fetched %d files from appDataFolder", files.count)
         return files
     }
     
@@ -860,7 +793,7 @@ final class OESaveSyncManager: NSObject {
         
         var components = URLComponents(string: "\(OEGoogleDriveConfig.driveAPIBaseURL)/files")!
         components.queryItems = [
-            URLQueryItem(name: "spaces",  value: "drive"),
+            URLQueryItem(name: "spaces",  value: "appDataFolder"),
             URLQueryItem(name: "fields",  value: "files(id,name,modifiedTime)"),
             URLQueryItem(name: "q",       value: q),
         ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes. Older versions are not patched.
+
+| Version | Supported |
+|---------|-----------|
+| 1.0.7 (latest) | ✅ |
+| < 1.0.7 | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities privately using [GitHub's private vulnerability reporting](https://github.com/nickybmon/OpenEmu-Silicon/security/advisories/new). This keeps the details confidential until a fix is available.
+
+Include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected version(s)
+- Any suggested fix, if you have one
+
+## Response Process
+
+- You will receive acknowledgement within **7 days**
+- If the report is confirmed, a fix will be prioritised based on severity
+- You will be credited in the release notes unless you prefer to remain anonymous
+
+## Scope
+
+This project is a macOS desktop emulator. The primary attack surface relevant to security reports:
+
+- **Google Drive OAuth integration** — token storage, scope handling, redirect URI
+- **ROM/save file parsing** — malformed files that could cause unexpected behaviour
+- **Core plugins** — bundled emulation cores that process untrusted input (ROM data)
+
+Out of scope: vulnerabilities in upstream emulation cores (report those to the respective upstream projects), or issues requiring physical access to the machine.
+
+## Privacy Policy
+
+For information on how the app handles user data, see the [Privacy Policy](docs/privacy-policy.md).

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,72 @@
+# Privacy Policy
+
+**App:** OpenEmu-Silicon  
+**Last updated:** May 3, 2026  
+**Contact:** [Open an issue](https://github.com/nickybmon/OpenEmu-Silicon/issues)
+
+---
+
+## What this app does
+
+OpenEmu-Silicon is a macOS game emulator. It runs locally on your computer. It does not create accounts, collect usage data, or connect to any server except when you explicitly enable the optional Google Drive Save Sync feature described below.
+
+---
+
+## Google Drive Save Sync (optional)
+
+This feature lets you back up and sync your save states and battery saves to your own Google Drive. It is off by default and only activates after you sign in.
+
+### What access is requested
+
+OpenEmu-Silicon requests the `drive.appdata` scope. This gives the app access to a private, hidden App Data folder inside your Google Drive. This folder:
+
+- Is not visible in the Google Drive web interface
+- Cannot be read by other apps
+- Can only be accessed by OpenEmu-Silicon
+
+The app does **not** request access to your files, documents, photos, or any other part of your Google Drive.
+
+### What is stored in your Drive
+
+Only your game save data:
+
+- Save state files (snapshots of game progress)
+- Battery save files (in-game save data)
+
+No personal information, no device identifiers, no usage metrics.
+
+### How authentication works
+
+Sign-in uses Google's standard OAuth 2.0 flow. Your Google account password is never seen or stored by the app. After you authorize access, Google issues an OAuth token. That token is stored locally in your macOS Keychain and is used only to read and write your save data to the App Data folder.
+
+### Revoking access
+
+You can disconnect Google Drive at any time from **Preferences → Cloud Sync → Sign Out**. This clears the stored token from your Keychain. You can also revoke access from your Google Account at [myaccount.google.com/permissions](https://myaccount.google.com/permissions).
+
+---
+
+## What this app does not do
+
+- Does not collect analytics or usage data
+- Does not transmit data to any server operated by this project
+- Does not share any data with third parties
+- Does not access your Google Drive files outside the hidden App Data folder
+- Does not identify you by name, email, or device
+
+---
+
+## Open source
+
+The full source code is available at [github.com/nickybmon/OpenEmu-Silicon](https://github.com/nickybmon/OpenEmu-Silicon). You can inspect exactly what data is read, written, and transmitted.
+
+---
+
+## Changes to this policy
+
+If the app adds new network features that affect privacy, this document will be updated and the "Last updated" date above will change. Significant changes will be noted in the release notes.
+
+---
+
+## Contact
+
+Questions or concerns? [Open an issue](https://github.com/nickybmon/OpenEmu-Silicon/issues) on GitHub.


### PR DESCRIPTION
## What does this PR do?

Fixes the Google Drive Save Sync feature so it actually works. Credentials were previously hardcoded placeholders that were never replaced at build time. This PR wires in real credentials via a gitignored secrets file locally and GitHub Actions secrets in CI.

Also switches Drive storage from the user-visible "OpenEmu Saves" folder back to the hidden `appDataFolder` (using the `drive.appdata` scope), and adds a privacy policy in preparation for Google OAuth app verification.

## What did you test?

Build passes clean with the stub secrets file. OAuth flow and Drive API calls require a live test with real credentials and the Google Cloud project configured.

## Which cores or systems are affected?

General app change — Google Drive Save Sync feature only.

## Did you use AI tools?

Yes — Claude drafted and implemented the credential wiring, workflow updates, and appDataFolder migration. Reviewed and tested locally.

## Linked issues

Related to #129

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header