### PR TITLE
fix: call requestAccess() when Input Monitoring is already granted at launch

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -520,7 +520,12 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
                 }
 
             default:
-                break
+                // Permission already granted. Call requestAccess() anyway — it is idempotent
+                // (returns true, no dialog) but ensures HID event delivery is active for this
+                // binary. IOHIDCheckAccess returning .granted does not activate delivery; that
+                // requires IOHIDRequestAccess to be called. Same reason the DEBUG path always
+                // calls it unconditionally.
+                _ = dm.requestAccess()
             }
             #endif
             // Re-enumerate keyboards in case permission was granted after init.


### PR DESCRIPTION
## What does this PR do?

When Input Monitoring is already granted before the app launches, the release-build switch hit `default: break` and never called `requestAccess()`. `IOHIDCheckAccess` only queries TCC — it does not activate HID event delivery. `IOHIDRequestAccess` must be called to register the binary with the HID framework, even when permission was pre-granted. Without it, keyboards matched via IOKit but all keystrokes were silently dropped, making Preferences → Controls unable to detect any keyboard input.

## What did you test?

Verified the fix compiles clean. Functional test requires a machine where Input Monitoring is already granted before launch and keyboard remapping is attempted in Preferences → Controls.

## Which cores or systems are affected?

General app change — all systems, affects keyboard input binding and in-game keyboard use.

## Did you use AI tools?

Used Claude to investigate the root cause and draft the fix, reviewed the code path myself.

## Linked issues

Fixes #316

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 340 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header