### PR TITLE
fix: add missing ScreenScraper system IDs for 16 systems

### DIFF
--- a/OpenEmu/ScreenScraperClient.swift
+++ b/OpenEmu/ScreenScraperClient.swift
@@ -67,32 +67,67 @@ final class ScreenScraperClient {
 
     // ScreenScraper numeric system IDs keyed by OpenEmu system identifier
     static let systemIDs: [String: Int] = [
+        // Nintendo
         "openemu.system.nes":           3,
+        "openemu.system.fds":         106,   // Famicom Disk System
         "openemu.system.snes":          4,
         "openemu.system.n64":          14,
+        "openemu.system.gc":           13,   // GameCube
+        "openemu.system.wii":          38,
         "openemu.system.gb":            9,   // Game Boy (also covers GBC — no separate GBC plugin)
         "openemu.system.gba":          12,
         "openemu.system.nds":          15,
-        "openemu.system.gg":           21,
+        "openemu.system.vb":           11,   // Virtual Boy
+        "openemu.system.pokemonmini": 211,
+
+        // Sony
+        "openemu.system.psx":          57,
+        "openemu.system.ps2":          58,
+        "openemu.system.psp":          61,
+
+        // Sega
+        "openemu.system.sg":            1,   // Mega Drive / Genesis
+        "openemu.system.sg1000":       32,   // Sega SG-1000
         "openemu.system.sms":           2,
-        "openemu.system.sg":            1,
+        "openemu.system.gg":           21,
         "openemu.system.scd":          20,
         "openemu.system.32x":          19,
-        "openemu.system.psx":          57,
         "openemu.system.saturn":       22,
         "openemu.system.dc":           23,
+
+        // Atari
         "openemu.system.2600":         26,
         "openemu.system.5200":         40,
         "openemu.system.7800":         41,
         "openemu.system.jaguar":       27,
-        "openemu.system.msx":         113,
+        "openemu.system.lynx":         28,
+        "openemu.system.atari8bit":    43,
+
+        // NEC
+        "openemu.system.pce":          31,   // PC Engine / TurboGrafx-16
+        "openemu.system.pcecd":       114,   // PC Engine CD-ROM
+        "openemu.system.pcfx":         72,
+
+        // SNK
+        "openemu.system.ngp":          82,   // Neo Geo Pocket / Color
+
+        // Bandai
+        "openemu.system.ws":           45,   // WonderSwan / WonderSwan Color
+
+        // Other home consoles
+        "openemu.system.3do":          29,
         "openemu.system.colecovision": 48,
         "openemu.system.intellivision": 115,
         "openemu.system.odyssey2":    104,
         "openemu.system.vectrex":     102,
-        "openemu.system.pokemonmini": 211,
-        "openemu.system.arcade":       75,
+        "openemu.system.sv":           24,   // Watara Supervision
+
+        // Computer / MSX
+        "openemu.system.msx":         113,
         "openemu.system.c64":          64,
+
+        // Arcade
+        "openemu.system.arcade":       75,
     ]
 
     // Preferred region tags in priority order, per OELocalizationHelper region


### PR DESCRIPTION
## What does this PR do?

GameCube cover art never completed because `openemu.system.gc` was absent from the `systemIDs` table in `ScreenScraperClient`. When the system identifier isn't in the table, `fetchGameInfo` returns `.success(nil)` immediately without making any network request — so the UI appears to complete but no art is applied and no error is shown. The same silent failure affected 15 other systems that were also never added to the table.

Added 16 missing system IDs: GameCube, Wii, PS2, PSP, Famicom Disk System, Virtual Boy, SG-1000, Atari Lynx, Atari 8-bit, PC Engine, PC Engine CD, PC-FX, Neo Geo Pocket, WonderSwan, 3DO, and Watara Supervision. Also reorganised the table into manufacturer groups so missing entries are obvious at a glance.

## What did you test?

Build confirmed passing. Cover art lookups require a live ScreenScraper account and ROMs to verify end-to-end — functional testing should confirm GameCube box art now resolves.

## Which cores or systems are affected?

Cover art / metadata lookup for all 16 newly-added systems. No emulation code changed.

## Did you use AI tools?

Used Claude to identify the root cause and draft the fix, reviewed the system ID mappings myself.

## Linked issues

Fixes #341

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 342 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header