### PR TITLE
fix: add Cancel button to GameScanner resolve-issues sheet

### DIFF
--- a/OpenEmu/GameScanner.xib
+++ b/OpenEmu/GameScanner.xib
@@ -97,6 +97,22 @@
                         <action selector="resolveIssues:" target="-2" id="142"/>
                     </connections>
                 </button>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CNc-el-cBT">
+                    <rect key="frame" x="345" y="14" width="75" height="32"/>
+                    <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="CNc-el-cBC">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                        <string key="keyEquivalent" base64-UTF8="YES">
+                            Gw==
+                        </string>
+                    </buttonCell>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="localizeTitle" value="YES"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="cancelOperation:" target="-2" id="CNc-el-cBA"/>
+                    </connections>
+                </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="130">
                     <rect key="frame" x="97" y="17" width="174" height="25"/>
                     <constraints>
@@ -135,6 +151,8 @@
                 <constraint firstItem="64" firstAttribute="top" secondItem="nfP-Bk-Jmp" secondAttribute="bottom" constant="8" id="rXw-AQ-4LR"/>
                 <constraint firstItem="130" firstAttribute="firstBaseline" secondItem="juM-7u-mF2" secondAttribute="firstBaseline" id="vyZ-74-yDt"/>
                 <constraint firstItem="138" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="130" secondAttribute="trailing" constant="8" symbolic="YES" id="wXa-tM-iTy"/>
+                <constraint firstItem="138" firstAttribute="leading" secondItem="CNc-el-cBT" secondAttribute="trailing" constant="8" id="CNc-el-cBL"/>
+                <constraint firstItem="CNc-el-cBT" firstAttribute="baseline" secondItem="138" secondAttribute="baseline" id="CNc-el-cBB"/>
             </constraints>
             <point key="canvasLocation" x="373.5" y="165"/>
         </customView>

--- a/OpenEmu/GameScannerViewController.swift
+++ b/OpenEmu/GameScannerViewController.swift
@@ -350,7 +350,11 @@ final class GameScannerViewController: NSViewController {
         
         dismiss(self)
     }
-    
+
+    @IBAction override func cancelOperation(_ sender: Any?) {
+        dismiss(self)
+    }
+
     @IBAction func buttonAction(_ sender: Any?) {
         
         if NSEvent.modifierFlags.contains(.option) || importer.status == .stopped && !itemsRequiringAttention.isEmpty {


### PR DESCRIPTION
## What does this PR do?

Adds a Cancel button to the GameScanner resolve-issues sheet. Previously the sheet had no way to dismiss without selecting a row and clicking Apply — clicking elsewhere or pressing Escape did nothing.

## What did you test?

Built and launched. Confirmed the sheet can be triggered via "Resolve Issues". Cancel button is visible and enabled without needing to select a row. Pressing Escape also dismisses the sheet. Apply still works as before.

## Which cores or systems are affected?

General app change — ROM importer workflow only.

## Did you use AI tools?

Yes — used Claude to draft the fix, reviewed and tested it.

## Linked issues

Fixes #308

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

To test: import a game that triggers the resolve-issues sheet. Verify Cancel button is visible and enabled without selecting a row, Escape also dismisses, and Apply still works.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header