### PR TITLE
fix: remove stale DB entry and allow re-import of deleted ROM files

### DIFF
--- a/OpenEmu/ImportOperation.swift
+++ b/OpenEmu/ImportOperation.swift
@@ -733,14 +733,15 @@ final class ImportOperation: Operation, NSCopying, @unchecked Sendable {
             
             let isReachable = (try? romURL?.checkResourceIsReachable()) ?? false
             if !isReachable {
-                DLog("rom file not available")
-                error = NSError(domain: OEImportErrorDomainFatal, code: OEImportErrorCode.alreadyInDatabaseFileUnreachable.rawValue)
-            }
-            else {
+                DLog("rom file not available — removing stale entry and re-importing")
+                context.delete(rom)
+                try? context.save()
+                self.rom = nil
+                // fall through: let import proceed normally
+            } else {
                 error = NSError(domain: OEImportErrorDomainFatal, code: OEImportErrorCode.alreadyInDatabase.rawValue)
+                exit(with: .errorFatal, error: error)
             }
-            
-            exit(with: .errorFatal, error: error)
         }
     }
     


### PR DESCRIPTION
## What does this PR do?

When a ROM file was deleted from disk but its database entry remained, trying to re-import the same file showed "already in library" and blocked import. This fix detects the unreachable case, deletes the orphaned `OEDBRom` Core Data record, and lets the import proceed normally.

## What did you test?

1. Imported a ROM.
2. Deleted the game from the library and the file from disk.
3. Re-imported the same file — import succeeded, game appeared in library.

## Which cores or systems are affected?

General app change — ROM importer only.

## Did you use AI tools?

Yes — used Claude to draft the fix, reviewed and tested it.

## Linked issues

Fixes #344

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

To reproduce: import any ROM, delete it from the library and from disk, then re-import the same file. Before this fix: "already in library." After: imports successfully.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header