### PR TITLE
fix: force content view redraw on window resize to clear ghost layers

### DIFF
--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -455,6 +455,10 @@ extension MainWindowController: NSWindowDelegate {
         }
     }
     
+    func windowDidResize(_ notification: Notification) {
+        window?.contentView?.needsDisplay = true
+    }
+
     func windowDidExitFullScreen(_ notification: Notification) {
         if shouldUndockGameWindowOnFullScreenExit {
             shouldUndockGameWindowOnFullScreenExit = false


### PR DESCRIPTION
## What does this PR do?

Adds a `windowDidResize` delegate handler to `MainWindowController` that marks the content view dirty after every frame change. On macOS Tahoe + M4, layer-backed views that have `wantsLayer = true` but no explicit `layerContentsRedrawPolicy` leave ghost/stale content visible after the window frame changes via zoom (Option+click green button or drag-to-fill). Flagging `needsDisplay` forces the compositor to re-composite all layers.

## What did you test?

Built and launched. Maximized the library window via Option+click on the green button and by dragging to fill the screen. No ghost/stale content visible. Also tested drag-resize — no performance impact.

## Which cores or systems are affected?

General app change — main window only.

## Did you use AI tools?

Yes — used Claude to draft the fix, reviewed and tested it.

## Linked issues

Related to #352

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

To test: maximize the library window (Option+click green button, or drag to fill). Confirm no ghost/stale content remains. Also test drag-resize to confirm no performance change.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header