### PR TITLE
chore: bump cores to cores-v1.3.0 — RA Phase 2 + bug fixes

### DIFF
--- a/Appcasts/fceu.xml
+++ b/Appcasts/fceu.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>FCEU</title>
         <item>
+      <title>FCEU 2.6.8</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.0/FCEU.oecoreplugin.zip"
+        sparkle:version="2.6.8"
+        sparkle:shortVersionString="2.6.8"
+        length="549247"
+        type="application/octet-stream" />
+    </item>
+        <item>
       <title>FCEU 2.6.7</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/flycast.xml
+++ b/Appcasts/flycast.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>Flycast</title>
     <item>
+      <title>Flycast 2.4.1</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.0/Flycast.oecoreplugin.zip"
+        sparkle:version="2.4.1"
+        sparkle:shortVersionString="2.4.1"
+        length="3094032"
+        type="application/octet-stream" />
+    </item>
+    <item>
       <title>Flycast 2.4</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mednafen.xml
+++ b/Appcasts/mednafen.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>Mednafen</title>
         <item>
+      <title>Mednafen 1.26.3</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.0/Mednafen.oecoreplugin.zip"
+        sparkle:version="1.26.3"
+        sparkle:shortVersionString="1.26.3"
+        length="2915033"
+        type="application/octet-stream" />
+    </item>
+        <item>
       <title>Mednafen 1.26.2</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mupen64plus.xml
+++ b/Appcasts/mupen64plus.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>Mupen64Plus</title>
         <item>
+      <title>Mupen64Plus 2.5.12</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.0/Mupen64Plus.oecoreplugin.zip"
+        sparkle:version="2.5.12"
+        sparkle:shortVersionString="2.5.12"
+        length="1218351"
+        type="application/octet-stream" />
+    </item>
+        <item>
       <title>Mupen64Plus 2.5.11</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/FCEU/Info.plist
+++ b/FCEU/Info.plist
@@ -16,8 +16,10 @@
 	<string>BNDL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.6.8</string>
 	<key>CFBundleVersion</key>
-	<string>2.6.6</string>
+	<string>2.6.8</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Flycast/OpenEmu/Info.plist
+++ b/Flycast/OpenEmu/Info.plist
@@ -18,8 +18,10 @@
 	<string>BNDL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.4</string>
+	<string>2.4.1</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Mednafen/Info.plist
+++ b/Mednafen/Info.plist
@@ -18,8 +18,10 @@
 	<string>BNDL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.26.3</string>
 	<key>CFBundleVersion</key>
-	<string>1.26.1</string>
+	<string>1.26.3</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Mupen64Plus/Info.plist
+++ b/Mupen64Plus/Info.plist
@@ -18,8 +18,10 @@
 	<string>BNDL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.5.12</string>
 	<key>CFBundleVersion</key>
-	<string>2.5.10</string>
+	<string>2.5.12</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>


### PR DESCRIPTION
## What does this PR do?

Bumps four cores to `cores-v1.3.0` and updates their appcast entries. All four have meaningful code changes merged to main since the last cores release (`cores-v1.2.0`).

| Core | Old | New | Changes |
|------|-----|-----|---------|
| Mednafen | 1.26.2 | 1.26.3 | RetroAchievements for PSX/PCE/Lynx/NGP; multi-disc PSX auto-m3u; scratchpad fix; logging |
| Mupen64Plus | 2.5.11 | 2.5.12 | RetroAchievements for N64; corrected memory reads; deferred address validation |
| Flycast | 2.4 | 2.4.1 | Fix 27fps slowdown (JIT re-enabled + frame timeout restored); fix black screen on second launch |
| FCEU | 2.6.7 | 2.6.8 | Fix rendering in Release/notarised builds (pixels now written on executeFrame path) |

## What did you test?

Cores built from source in Release config, signed with Developer ID, verified version in built plugin Info.plist, uploaded to `cores-v1.3.0` prerelease.

## Which cores or systems are affected?

Mednafen (PSX, PCE, Lynx, NGP, Saturn, VB, WS), Mupen64Plus (N64), Flycast (Dreamcast), FCEU (NES).

## Did you use AI tools?

Yes — Claude Sonnet 4.6 handled the version bumps, builds, signing, zip, appcast edits, and upload. Nick reviewed and approved each step.

## Linked issues

Related to #258

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

**QA checklist for this PR:**
- [ ] Open Preferences → Cores, confirm each updated core shows the new version offered
- [ ] Accept the update for each core, confirm it installs without error
- [ ] Load a PSX game, earn or trigger an achievement — confirm RA banner appears (Mednafen)
- [ ] Load an N64 game — confirm RA banner appears (Mupen64Plus)
- [ ] Load a Dreamcast game — confirm it runs at full speed, no 27fps slowdown (Flycast)
- [ ] Load a NES game from a Release build — confirm it renders (FCEU)

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: Release config, all four cores
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files