### PR TITLE
feat: migrate core update channel to nickybmon-owned appcasts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,27 @@ Bump rules:
 
 ---
 
+## Core update channel
+
+Every shipped core plugin embeds a `SUFeedURL` in its `Info.plist`. Sparkle reads it from the **installed** plugin bundle, so it controls updates for users who already have the core.
+
+The canonical pattern, used by all cores nickybmon ships, is:
+
+```
+https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<core>.xml
+```
+
+`<core>` is the lowercased core name (e.g. `dolphin`, `mednafen`, `bluemsx`). The matching file must exist under `Appcasts/` in this repo — that is the file Sparkle fetches.
+
+Rules:
+
+- Never re-introduce `OpenEmu-Update`, `raw.github.com/OpenEmu`, or `appcast.openemu.org` URLs into a core `Info.plist`. That update channel is upstream-owned and dormant; updates published here will not reach users.
+- When adding a new core, add its appcast file to `Appcasts/<core>.xml` *and* set the `Info.plist` `SUFeedURL` to the canonical URL above in the same commit.
+- `Scripts/check-core-feed-urls.sh` enforces both rules and is wired into `Scripts/verify.sh --core` as a precondition.
+- Core appcast entries should be EdDSA-signed when newly published. `Scripts/update_core_appcast.py --sign-zip <path-to-zip>` runs Sparkle's `sign_update` against the local zip and embeds `sparkle:edSignature` on the new `<enclosure>`. The host app's existing Sparkle keypair is reused — do not generate a new one.
+
+---
+
 ## License Rules
 
 The main app is **BSD 2-Clause**. Emulator cores are mostly **GPL v2**. Key rules:

--- a/Atari800/Atari800Core/Atari800-Info.plist
+++ b/Atari800/Atari800Core/Atari800-Info.plist
@@ -93,6 +93,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/atari800_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/atari800.xml</string>
 </dict>
 </plist>

--- a/BSNES/Info.plist
+++ b/BSNES/Info.plist
@@ -92,6 +92,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/bsnes_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/bsnes.xml</string>
 </dict>
 </plist>

--- a/Bliss/Info.plist
+++ b/Bliss/Info.plist
@@ -94,6 +94,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/bliss_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/bliss.xml</string>
 </dict>
 </plist>

--- a/CrabEmu/Info.plist
+++ b/CrabEmu/Info.plist
@@ -95,6 +95,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/crabemu_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/crabemu.xml</string>
 </dict>
 </plist>

--- a/DeSmuME/src/cocoa/openemu/Info (OpenEmu Plug-in).plist
+++ b/DeSmuME/src/cocoa/openemu/Info (OpenEmu Plug-in).plist
@@ -49,6 +49,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/desmume_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/desmume.xml</string>
 </dict>
 </plist>

--- a/FCEU/Info.plist
+++ b/FCEU/Info.plist
@@ -51,6 +51,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/fceu_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/fceu.xml</string>
 </dict>
 </plist>

--- a/Gambatte/Info.plist
+++ b/Gambatte/Info.plist
@@ -49,6 +49,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/gambatte_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/gambatte.xml</string>
 </dict>
 </plist>

--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -134,6 +134,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/genesisplus_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/genesisplus.xml</string>
 </dict>
 </plist>

--- a/JollyCV/Info.plist
+++ b/JollyCV/Info.plist
@@ -45,6 +45,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/jollycv_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/jollycv.xml</string>
 </dict>
 </plist>

--- a/Mednafen/Info.plist
+++ b/Mednafen/Info.plist
@@ -224,6 +224,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/mednafen_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/mednafen.xml</string>
 </dict>
 </plist>

--- a/Mupen64Plus/Info.plist
+++ b/Mupen64Plus/Info.plist
@@ -47,6 +47,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/mupen64plus_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/mupen64plus.xml</string>
 </dict>
 </plist>

--- a/Nestopia/Info.plist
+++ b/Nestopia/Info.plist
@@ -80,6 +80,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/nestopia_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/nestopia.xml</string>
 </dict>
 </plist>

--- a/O2EM/Info.plist
+++ b/O2EM/Info.plist
@@ -54,6 +54,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/o2em_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/o2em.xml</string>
 </dict>
 </plist>

--- a/PPSSPP/PPSSPP-Core/Info.plist
+++ b/PPSSPP/PPSSPP-Core/Info.plist
@@ -35,6 +35,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/ppsspp_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/ppsspp.xml</string>
 </dict>
 </plist>

--- a/PokeMini/PokeMini/PokeMini-Info.plist
+++ b/PokeMini/PokeMini/PokeMini-Info.plist
@@ -60,6 +60,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/pokemini_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/pokemini.xml</string>
 </dict>
 </plist>

--- a/Potator-Core/Potator/Info.plist
+++ b/Potator-Core/Potator/Info.plist
@@ -33,6 +33,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/potator_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/potator.xml</string>
 </dict>
 </plist>

--- a/ProSystem/Info.plist
+++ b/ProSystem/Info.plist
@@ -45,6 +45,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/prosystem_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/prosystem.xml</string>
 </dict>
 </plist>

--- a/SNES9x/Info.plist
+++ b/SNES9x/Info.plist
@@ -78,6 +78,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/snes9x_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/snes9x.xml</string>
 </dict>
 </plist>

--- a/Scripts/check-core-feed-urls.sh
+++ b/Scripts/check-core-feed-urls.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# check-core-feed-urls.sh — Guardrail against regressing the core update channel.
+#
+# Fails if any tracked Info.plist still references the dormant upstream
+# OpenEmu-Update appcast host, and fails if a core's SUFeedURL points at an
+# Appcasts/<name>.xml file that doesn't exist in the working tree.
+#
+# Wired into Scripts/verify.sh as a precondition for --core runs. Cheap to run
+# everywhere else too.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+fail=0
+
+PLISTS=$(git ls-files '*.plist' | grep -v -E '(^|/)archived/')
+
+# 1. No upstream URLs anywhere in tracked plists.
+upstream_hits=$(echo "$PLISTS" \
+  | xargs grep -l -E 'OpenEmu-Update|raw\.github\.com/OpenEmu|appcast\.openemu\.org' 2>/dev/null \
+  || true)
+
+if [ -n "$upstream_hits" ]; then
+  echo "ERROR: upstream OpenEmu-Update/openemu.org SUFeedURL still present in:" >&2
+  echo "$upstream_hits" >&2
+  echo "Replace with https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<core>.xml" >&2
+  fail=1
+fi
+
+# 2. Every nickybmon SUFeedURL must resolve to an Appcasts/<name>.xml in the tree.
+missing=()
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  plist="${hit%%:*}"
+  appcast_name=$(echo "$hit" | sed -E 's#.*/Appcasts/([^"<]+)\.xml.*#\1#')
+  if [ ! -f "Appcasts/${appcast_name}.xml" ]; then
+    missing+=("$plist → Appcasts/${appcast_name}.xml")
+  fi
+done < <(echo "$PLISTS" \
+  | xargs grep -H -E 'raw\.githubusercontent\.com/nickybmon/OpenEmu-Silicon/main/Appcasts/' 2>/dev/null \
+  || true)
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "ERROR: SUFeedURL points at appcast files that don't exist in the tree:" >&2
+  for m in "${missing[@]}"; do
+    echo "  $m" >&2
+  done
+  fail=1
+fi
+
+if [ $fail -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: no upstream OpenEmu-Update references; all core SUFeedURLs resolve."

--- a/Scripts/update_core_appcast.py
+++ b/Scripts/update_core_appcast.py
@@ -3,66 +3,127 @@
 #
 # Usage:
 #   python3 Scripts/update_core_appcast.py <appcast.xml> <core_name> <version> \
-#       <download_url> <length>
+#       <download_url> <length> [--sign-zip <path/to/core.zip>]
 #
 # Arguments:
 #   appcast.xml    Path to the core's appcast file (e.g. Appcasts/flycast.xml)
 #   core_name      Display name of the core (e.g. Flycast)
 #   version        Version string — also used as sparkle:version (e.g. 2.5)
 #   download_url   Full URL to the .oecoreplugin.zip on GitHub Releases
-#   length         Byte size of the zip file
+#   length         Byte size of the zip file (overridden when --sign-zip parses one)
 #
-# Core appcasts use a simpler format than the main app appcast:
-#   - No EdDSA signature (the app has disable-library-validation entitlement)
-#   - No description/release notes block
-#   - version string doubles as both sparkle:version and sparkle:shortVersionString
+# Options:
+#   --sign-zip <path>   Run Sparkle's sign_update against the local zip and embed
+#                       sparkle:edSignature on the new <enclosure>. The host app's
+#                       Sparkle keypair (already in keychain for the host appcast)
+#                       is reused — no new keypair is generated.
+#   --sign-update <bin> Path to sign_update. Defaults to release.sh's lookup
+#                       (DerivedData → repo SPM cache).
 
-import sys
+import argparse
+import os
 import re
+import subprocess
+import sys
 
 
-def main():
-    if len(sys.argv) != 6:
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+
+def find_sign_update():
+    derived = os.path.expanduser('~/Library/Developer/Xcode/DerivedData')
+    candidates = []
+    for root in (derived, REPO_ROOT):
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(root):
+            if 'old_dsa_scripts' in dirpath:
+                continue
+            if 'sign_update' in filenames and dirpath.endswith('Sparkle/bin'):
+                candidates.append(os.path.join(dirpath, 'sign_update'))
+    return candidates[0] if candidates else None
+
+
+def sign_zip(sign_update_bin, zip_path):
+    if not sign_update_bin:
+        sign_update_bin = find_sign_update()
+    if not sign_update_bin or not os.path.isfile(sign_update_bin):
         print(
-            'Usage: update_core_appcast.py <appcast.xml> <core_name> <version> '
-            '<download_url> <length>',
+            'ERROR: sign_update not found. Build the project in Xcode first to '
+            'resolve the Sparkle SPM package, or pass --sign-update <path>.',
             file=sys.stderr,
         )
         sys.exit(1)
 
-    appcast_path = sys.argv[1]
-    core_name = sys.argv[2]
-    version = sys.argv[3]
-    download_url = sys.argv[4]
-    length = sys.argv[5]
+    out = subprocess.run(
+        [sign_update_bin, zip_path], capture_output=True, text=True, check=False
+    )
+    combined = (out.stdout or '') + (out.stderr or '')
+    if out.returncode != 0:
+        print(f'ERROR: sign_update failed:\n{combined}', file=sys.stderr)
+        sys.exit(1)
 
+    sig_match = re.search(r'sparkle:edSignature="([^"]+)"', combined)
+    len_match = re.search(r'length="([0-9]+)"', combined)
+    if not sig_match or not len_match:
+        print(
+            f'ERROR: could not parse sign_update output:\n{combined}',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return sig_match.group(1), len_match.group(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Prepend a new release entry to a per-core Sparkle appcast.'
+    )
+    parser.add_argument('appcast_path')
+    parser.add_argument('core_name')
+    parser.add_argument('version')
+    parser.add_argument('download_url')
+    parser.add_argument('length')
+    parser.add_argument('--sign-zip', default=None,
+                        help='Local zip to sign with Sparkle EdDSA.')
+    parser.add_argument('--sign-update', default=None,
+                        help='Path to sign_update binary.')
+    args = parser.parse_args()
+
+    ed_sig = None
+    length = args.length
+    if args.sign_zip:
+        ed_sig, length = sign_zip(args.sign_update, args.sign_zip)
+
+    sig_attr = f'\n        sparkle:edSignature="{ed_sig}"' if ed_sig else ''
     new_item = f"""    <item>
-      <title>{core_name} {version}</title>
+      <title>{args.core_name} {args.version}</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure
-        url="{download_url}"
-        sparkle:version="{version}"
-        sparkle:shortVersionString="{version}"
-        length="{length}"
+        url="{args.download_url}"
+        sparkle:version="{args.version}"
+        sparkle:shortVersionString="{args.version}"
+        length="{length}"{sig_attr}
         type="application/octet-stream" />
     </item>"""
 
-    with open(appcast_path, 'r') as f:
+    with open(args.appcast_path, 'r') as f:
         content = f.read()
 
-    # Insert after <title>CoreName</title> opening of the channel
     insert_after = re.search(r'(<title>[^<]*</title>\s*)', content)
     if not insert_after:
-        print(f'ERROR: could not find insertion point in {appcast_path}', file=sys.stderr)
+        print(f'ERROR: could not find insertion point in {args.appcast_path}',
+              file=sys.stderr)
         sys.exit(1)
 
     pos = insert_after.end()
     content = content[:pos] + new_item + '\n' + content[pos:]
 
-    with open(appcast_path, 'w') as f:
+    with open(args.appcast_path, 'w') as f:
         f.write(content)
 
-    print(f'Prepended {core_name} {version} entry to {appcast_path}')
+    suffix = ' (signed)' if ed_sig else ''
+    print(f'Prepended {args.core_name} {args.version} entry to '
+          f'{args.appcast_path}{suffix}')
 
 
 if __name__ == '__main__':

--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -93,6 +93,17 @@ pass() { echo "PASS  $1"; }
 fail() { echo "FAIL  $1"; FAILURES=$((FAILURES+1)); }
 info() { echo "----  $1"; }
 
+# --- Core feed-URL guardrail (precondition for --core runs) --------------
+
+if [ -n "$CORE" ] && [ -x "./Scripts/check-core-feed-urls.sh" ]; then
+  if ./Scripts/check-core-feed-urls.sh >/dev/null 2>&1; then
+    pass "check-core-feed-urls.sh"
+  else
+    fail "check-core-feed-urls.sh — upstream URL or missing appcast detected"
+    ./Scripts/check-core-feed-urls.sh || true
+  fi
+fi
+
 # --- Build ---------------------------------------------------------------
 
 if [ -n "$CORE" ]; then

--- a/Stella/Info.plist
+++ b/Stella/Info.plist
@@ -47,6 +47,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/stella_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/stella.xml</string>
 </dict>
 </plist>

--- a/VecXGL/VecXGL/VecXGL-Info.plist
+++ b/VecXGL/VecXGL/VecXGL-Info.plist
@@ -37,6 +37,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/vecxgl_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/vecxgl.xml</string>
 </dict>
 </plist>

--- a/VirtualJaguar/VirtualJaguar/VirtualJaguar-Info.plist
+++ b/VirtualJaguar/VirtualJaguar/VirtualJaguar-Info.plist
@@ -47,6 +47,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/virtualjaguar_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/virtualjaguar.xml</string>
 </dict>
 </plist>

--- a/blueMSX/blueMSX-Info.plist
+++ b/blueMSX/blueMSX-Info.plist
@@ -38,6 +38,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/blueMSX_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/bluemsx.xml</string>
 </dict>
 </plist>

--- a/docs/adr/0004-core-update-channel-ownership.md
+++ b/docs/adr/0004-core-update-channel-ownership.md
@@ -1,0 +1,56 @@
+# ADR-0004: Own the core auto-update channel
+
+## Status
+
+Accepted
+
+## Context
+
+Every emulator core plugin OpenEmu-Silicon ships embeds a `SUFeedURL` in its `Info.plist`. Sparkle reads that URL from the **installed** plugin bundle, not from `oecores.xml`, so it determines where updates come from for users who already have the core — regardless of where they originally installed it from.
+
+Until this ADR, 24 of the 27 shipped cores still pointed at `https://raw.github.com/OpenEmu/OpenEmu-Update/master/<core>_appcast.xml`. That repo is upstream-owned, has been dormant for years, and could be archived or deleted at any time. Three cores (Dolphin, 4DO, Flycast) had previously been migrated ad-hoc to nickybmon-hosted appcasts.
+
+The practical consequence: when a `cores-vX.Y.Z` release is published, existing installs of those 24 cores never see the update. Their Sparkle client polls a URL that returns the same stale appcast it has for years. Only brand-new installs (which fetch the bootstrap list from `oecores.xml`, already nickybmon-owned) receive the new build. The update channel was effectively write-only for 24 of 27 cores.
+
+This blocked the next coordinated host+cores release: there was no point cutting `cores-vX.Y.Z` if 24 cores' installed bundles couldn't see it.
+
+## Decision
+
+1. Migrate every shipped core's `SUFeedURL` to:
+
+   ```
+   https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<core>.xml
+   ```
+
+   `<core>` is the lowercased core name. The matching file already exists under `Appcasts/` in this repo. nickybmon is the sole source of truth for core updates going forward.
+
+2. Sign new core appcast entries with the host app's existing Sparkle EdDSA keypair (already used for the host appcast and stored in keychain). `Scripts/update_core_appcast.py` was extended with a `--sign-zip` flag that invokes Sparkle's `sign_update`, parses the resulting `sparkle:edSignature` and `length`, and embeds them on the new `<enclosure>`. The keypair lookup mirrors `Scripts/release.sh` — DerivedData first, repo SPM cache as fallback. No new keypair is generated.
+
+3. Add `Scripts/check-core-feed-urls.sh` as a CI guardrail that fails if any tracked `Info.plist` references the upstream host, or if a core's `SUFeedURL` points at an `Appcasts/<core>.xml` that doesn't exist in the working tree. Wire it into `Scripts/verify.sh --core` as a precondition.
+
+4. Existing entries in each `Appcasts/<core>.xml` are left unsigned. They point at already-shipped binaries; retroactive signing is not useful and not in scope. New entries published from the next cores release onward will carry signatures.
+
+## Alternatives considered
+
+- **Custom domain / CDN for appcast hosting.** Rejected for now. nickybmon chose to stay on `raw.githubusercontent.com` for operational simplicity; revisit if GitHub raw rate-limits or availability becomes an issue. Tracked as out-of-band follow-up.
+- **Generate a new EdDSA keypair specifically for cores.** Rejected. The host app and cores already share trust (cores are signed plugins loaded by the host); using a single keypair keeps the surface area small and removes a "which key was used" footgun at signature-verification time.
+- **Retroactively sign existing appcast entries.** Rejected as out of scope. Those entries describe binaries that were already published unsigned; signing the appcast entry without re-signing the binary doesn't add real protection, and re-signing every shipped core is real release work that belongs in the next coordinated cores release.
+
+## Consequences
+
+**Easier:**
+
+- A `cores-vX.Y.Z` release actually reaches existing users. The update channel is now read/write end-to-end.
+- The shipped product no longer has a structural dependency on upstream `OpenEmu/OpenEmu-Update`.
+- Future core updates are cryptographically signed; a compromised CDN cannot push a malicious payload to existing installs.
+- A regression that re-introduces an upstream URL fails `verify.sh --core` and any CI that runs `check-core-feed-urls.sh`.
+
+**Harder:**
+
+- nickybmon is the sole source of truth for core updates. There is no upstream fallback — though the upstream channel was already non-functional, so this is formalising reality rather than removing a real escape hatch.
+- Every new core must add its `Appcasts/<name>.xml` and set `SUFeedURL` correctly in the same commit; the guardrail enforces this but it is one more step.
+
+**Risks accepted:**
+
+- `raw.githubusercontent.com` is GitHub's discretion, not a contractual SLA. If GitHub ever rate-limits or removes raw hosting, every installed core stops seeing updates until the URL pattern changes — and changing the URL requires shipping a core update over the channel that just broke. Mitigation deferred (custom domain follow-up).
+- The plist edits are inert until each core is rebuilt with them. Until the next cores release, behaviour for existing users is unchanged.

--- a/mGBA/Info.plist
+++ b/mGBA/Info.plist
@@ -47,6 +47,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/mgba_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/mgba.xml</string>
 </dict>
 </plist>

--- a/picodrive/Info.plist
+++ b/picodrive/Info.plist
@@ -47,6 +47,6 @@
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/picodrive_appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/picodrive.xml</string>
 </dict>
 </plist>


### PR DESCRIPTION
## What does this PR do?

Migrates the `SUFeedURL` in 24 core `Info.plist` files from the dormant upstream `OpenEmu/OpenEmu-Update` repo to nickybmon-owned appcasts at `raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<core>.xml`. Sparkle reads `SUFeedURL` from the **installed** plugin bundle, so this is what controls updates for users who already have a core — without this change, future cores releases never reach existing installs of those 24 cores.

Also adds EdDSA signing support to `Scripts/update_core_appcast.py` (reusing the host app's existing Sparkle keypair), a `Scripts/check-core-feed-urls.sh` guardrail wired into `verify.sh --core`, an "Core update channel" section in `AGENTS.md`, and ADR-0004 capturing the decision.

## What did you test?

- `Scripts/check-core-feed-urls.sh` → OK (no upstream URLs remain; all SUFeedURLs resolve to existing `Appcasts/<core>.xml` files).
- `plutil -lint` on every modified plist → OK.
- `verify.sh --core Stella --worktree` → guardrail and plist lint PASS. (Stella's compile fails with a pre-existing `OEGameCoreDisplayModeLabelKey undeclared` error on `main`, unrelated to this PR — it never reaches the bundle stage.)
- The plist edits are inert until each core is rebuilt with them; runtime verification (Sparkle actually fetching from the new URL and validating the EdDSA signature) is deferred to the next cores release as called out in the plan.

## Which cores or systems are affected?

Every shipped core except Dolphin, 4DO, and Flycast (already migrated): Mupen64Plus, VecXGL, VirtualJaguar, JollyCV, Bliss, blueMSX, PokeMini, Gambatte, CrabEmu, O2EM, GenesisPlus, Stella, DeSmuME, Nestopia, mGBA, Potator, PPSSPP, Atari800, FCEU, SNES9x, picodrive, BSNES, Mednafen, ProSystem.

No code changes to any core, the host app, or `project.pbxproj` — only `Info.plist` `SUFeedURL` strings, plus tooling and docs.

## Did you use AI tools?

Used Claude to draft the migration, the Python signing extension, the guardrail script, and the ADR. Reviewed every plist change, ran the static checks, and confirmed the unrelated Stella build failure exists on `main`.

## Linked issues

Related to #51

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. This PR doesn't change any compiled code, so the Debug build of the main app should be unaffected; the meaningful checks are static (guardrail + plist lint).

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 369 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

Static checks specific to this PR:

```bash
./Scripts/check-core-feed-urls.sh
# Expected: OK: no upstream OpenEmu-Update references; all core SUFeedURLs resolve.

# Spot-check a migrated plist:
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" Stella/Info.plist
# Expected: https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/stella.xml
```

End-to-end Sparkle verification (fetching the new URL, validating an EdDSA signature on a freshly-built core) is deferred to the next cores release — those entries don't exist in the appcasts yet.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Static checks pass (`check-core-feed-urls.sh`, `plutil -lint` on all 24 plists)
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (`Scripts/check-core-feed-urls.sh`, `docs/adr/0004-core-update-channel-ownership.md`) are tooling/docs and don't need a license header

## Out-of-scope follow-ups

- Rebuild the 24 cores and cut `cores-vX.Y.Z` with signed appcasts (the actual release work this PR enables).
- Audit `oecores.xml` periodically against the source tree to catch divergence.
- Consider moving appcast hosting off `raw.githubusercontent.com` to a custom domain in the future.