### PR TITLE
fix: SDK header — import OEGameCoreDisplayModes in OEGameCore.h

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -33,6 +33,7 @@
 #import <OpenEmuBase/OESystemResponderClient.h>
 #import <OpenEmuBase/OEGeometry.h>
 #import <OpenEmuBase/OEDiffQueue.h>
+#import <OpenEmuBase/OEGameCoreDisplayModes.h>
 
 @class OEGameCoreController, OEGameCore;
 


### PR DESCRIPTION
## What does this PR do?

Adds `#import <OpenEmuBase/OEGameCoreDisplayModes.h>` to `OEGameCore.h` so that any core importing `<OpenEmuBase/OEGameCore.h>` gets the `OEGameCoreDisplayMode*Key` constants without needing the umbrella `OpenEmuBase.h`.

## Why

7 cores (DeSmuME, FCEU, Gambatte, GenesisPlus, Mednafen, Nestopia, Stella) build dictionaries using these constants, but their `.mm` files only import `<OpenEmuBase/OEGameCore.h>`. From CLI builds the constants were unreachable, producing `use of undeclared identifier 'OEGameCoreDisplayModeNameKey'` etc. across all 7 cores. Xcode IDE may have masked this via different module resolution, but `xcodebuild` from the terminal failed cleanly. This blocks the upcoming `cores-vX.Y.Z` release where every core needs to build from CLI.

## What did you test?

```bash
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + Stella"   -configuration Debug -destination 'platform=macOS,arch=arm64' build
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + Gambatte" -configuration Debug -destination 'platform=macOS,arch=arm64' build
```

Both core targets compile clean — `OEGameCoreDisplayMode*` errors are gone, `Stella.oecoreplugin` and `Gambatte.oecoreplugin` build successfully.

## Which cores or systems are affected?

All 7 cores that use display-mode dictionaries: DeSmuME, FCEU, Gambatte, GenesisPlus, Mednafen, Nestopia, Stella. No code changes outside the SDK header.

## Did you use AI tools?

Used Claude to diagnose the import gap and write the fix. Reviewed and tested the build manually.

## Linked issues

(no tracked issue)

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 372 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + Stella" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -10
# Expected: BUILD SUCCEEDED, no "use of undeclared identifier" errors
```

## PR checklist

- [x] Branched from up-to-date `main`
- [x] Build passes for affected cores from CLI
- [x] Tested on Apple Silicon
- [x] Copyright headers preserved