### PR TITLE
chore: sign core appcast entries in release-core workflow

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -56,6 +56,16 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           rm "$RUNNER_TEMP/cert.p12"
 
+      # ── Restore Sparkle private key ─────────────────────────────────────────
+      - name: Restore Sparkle private key
+        env:
+          SPARKLE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          PREFS_DIR="$HOME/Library/Preferences/Sparkle"
+          mkdir -p "$PREFS_DIR"
+          echo "$SPARKLE_KEY" > "$PREFS_DIR/private_ed25519_key"
+          chmod 600 "$PREFS_DIR/private_ed25519_key"
+
       # ── Store notarytool keychain profile ───────────────────────────────────
       - name: Store notarytool credentials
         env:
@@ -269,12 +279,21 @@ jobs:
       # ── Update core appcast ─────────────────────────────────────────────────
       - name: Update ${{ env.APPCAST_FILE }}
         run: |
+          SIGN_UPDATE=$(find "${{ env.DERIVED_DATA_PATH }}" \
+            -path "*/Sparkle/bin/sign_update" \
+            -not -path "*/old_dsa_scripts/*" \
+            2>/dev/null | head -1)
+          [ -n "$SIGN_UPDATE" ] || { echo "ERROR: sign_update not found in $DERIVED_DATA_PATH" >&2; exit 1; }
+          echo "sign_update: $SIGN_UPDATE"
+
           python3 Scripts/update_core_appcast.py \
             "${{ env.APPCAST_FILE }}" \
             "${{ env.CORE }}" \
             "${{ env.VERSION }}" \
             "${{ env.DOWNLOAD_URL }}" \
-            "${{ env.ZIP_SIZE }}"
+            "${{ env.ZIP_SIZE }}" \
+            --sign-zip "${{ env.ZIP_PATH }}" \
+            --sign-update "$SIGN_UPDATE"
 
       # ── Commit appcast back to main ─────────────────────────────────────────
       - name: Commit and push updated appcast


### PR DESCRIPTION
## What does this PR do?

Wires Sparkle EdDSA signing into `.github/workflows/release-core.yml`. After this lands, every `/release-core` run produces a signed `<enclosure>` entry on the appropriate `Appcasts/<core>.xml`.

## Why

PR #369 migrated 24 cores' `SUFeedURL` to nickybmon-owned appcasts and added `--sign-zip` support to `Scripts/update_core_appcast.py` — but the actual CI workflow that drives `/release-core` was still calling the script without `--sign-zip`. Without this PR, future core releases would continue producing unsigned appcast entries, leaving Sparkle clients vulnerable to a CDN compromise being able to push a malicious payload.

This PR closes that gap with three changes to `release-core.yml`:

1. **Restore the Sparkle private key** in `~/Library/Preferences/Sparkle/private_ed25519_key` from the existing `SPARKLE_PRIVATE_KEY` GitHub Actions secret (same step `release.yml` uses for host releases — no new secrets needed).
2. **Locate `sign_update`** under the build's `DerivedData` after the core build completes and pass it through `--sign-update`.
3. **Pass `--sign-zip`** with the freshly-built `${{ env.ZIP_PATH }}` so the script invokes `sign_update`, parses `sparkle:edSignature` and `length`, and embeds them on the new `<enclosure>`.

## What did you test?

- YAML structure reviewed against the working pattern in `release.yml`.
- The `--sign-zip` / `--sign-update` codepath in `Scripts/update_core_appcast.py` was added and locally tested as part of #369.
- End-to-end CI verification will happen the first time `/release-core` is dispatched after merge — by design, since the workflow can't be exercised from a PR.

## Which cores or systems are affected?

All 27 cores, going forward only. Existing unsigned entries are left as-is per ADR-0004 (they describe already-shipped binaries; retroactive signing would be cosmetic).

## Did you use AI tools?

Used Claude to identify the gap in the release-core workflow and write the wiring. Reviewed manually.

## Linked issues

Related to #51

---

## How to test locally

This PR only modifies a GitHub Actions workflow — there is no local build to verify. The workflow is exercised when `/release-core <CoreName> <Version>` is run after merge. The first such run will produce the first signed appcast entry; verification:

```bash
# After /release-core <Core> <Ver> completes:
grep "sparkle:edSignature" Appcasts/<core>.xml
# Expected: the topmost <enclosure> carries a sparkle:edSignature attribute
```

If the workflow fails on the new "Restore Sparkle private key" step, the `SPARKLE_PRIVATE_KEY` secret may need to be re-confirmed in the repo settings — but it's already in active use by the host `release.yml`.

## PR checklist

- [x] Branched from up-to-date `main`
- [x] Workflow YAML reviewed
- [x] No new secrets required
- [x] Existing host-release pattern reused verbatim