### PR TITLE
fix: refresh stale SUFeedURL in installed core plugins on launch

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -62,6 +62,9 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
     /// Result of the most recent bridge auto-refresh sweep, surfaced in
     /// core-inventory.txt so we can confirm the mechanism ran.
     fileprivate var bridgeRefreshReport: (bridgeVersion: String, refreshed: [String], failed: [(String, String)]) = ("(unknown)", [], [])
+
+    /// Result of the most recent SUFeedURL refresh sweep on installed core plugins.
+    fileprivate var feedURLRefreshReport: (refreshed: [String], failed: [(String, String)]) = ([], [])
     
     var hidEventsMonitor: Any?
     var keyboardEventsMonitor: Any?
@@ -457,6 +460,75 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
         }
 
         bridgeRefreshReport = (runningVersion, refreshed, failed)
+    }
+
+    /// Walks every installed `*.oecoreplugin` (excluding RetroArch stubs) and
+    /// rewrites a stale `SUFeedURL` in its `Info.plist` to the canonical
+    /// nickybmon-hosted appcast. Sparkle and `CoreUpdater` both read the URL
+    /// from the installed plist, so cores installed before the URL migration
+    /// stay frozen on the dormant upstream URL until this runs.
+    ///
+    /// Staleness is detected by prefix: any URL that doesn't start with
+    /// `canonicalPrefix` is rewritten to `<prefix><lowercased-bundle-suffix>.xml`.
+    /// Only the plist is touched — the binary's signature is undisturbed and
+    /// the host's `disable-library-validation` entitlement covers any plugin
+    /// signature drift, so re-codesigning is not required.
+    fileprivate func refreshStaleCoreFeedURLs() {
+        let canonicalPrefix = "https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/"
+        feedURLRefreshReport = ([], [])
+
+        let coresDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/OpenEmu/Cores")
+        guard let entries = try? FileManager.default.contentsOfDirectory(at: coresDir, includingPropertiesForKeys: nil) else {
+            return
+        }
+
+        var refreshed: [String] = []
+        var failed: [(String, String)] = []
+
+        for plugin in entries
+            where plugin.pathExtension == "oecoreplugin"
+               && !plugin.deletingPathExtension().lastPathComponent.hasSuffix("-RetroArch")
+        {
+            let plistURL = plugin.appendingPathComponent("Contents/Info.plist")
+            guard
+                let data  = try? Data(contentsOf: plistURL),
+                var plist = (try? PropertyListSerialization.propertyList(from: data, options: [.mutableContainers], format: nil)) as? [String: Any]
+            else {
+                continue
+            }
+
+            guard
+                let bundleID    = plist["CFBundleIdentifier"] as? String,
+                let currentURL  = plist["SUFeedURL"] as? String
+            else {
+                continue
+            }
+
+            if currentURL.hasPrefix(canonicalPrefix) {
+                continue
+            }
+
+            let suffix = (bundleID.split(separator: ".").last.map(String.init) ?? "").lowercased()
+            guard !suffix.isEmpty else {
+                continue
+            }
+            let canonical = canonicalPrefix + suffix + ".xml"
+
+            do {
+                plist["SUFeedURL"] = canonical
+                let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+                try newData.write(to: plistURL)
+                refreshed.append(plugin.deletingPathExtension().lastPathComponent)
+                os_log(.info, log: .default, "SUFeedURL refresh: rewrote %{public}@ to %{public}@", plugin.lastPathComponent, canonical)
+            } catch {
+                failed.append((plugin.lastPathComponent, error.localizedDescription))
+                os_log(.error, log: .default, "SUFeedURL refresh failed for %{public}@: %{public}@", plugin.lastPathComponent, error.localizedDescription)
+            }
+        }
+
+        feedURLRefreshReport = (refreshed, failed)
+        os_log(.info, log: .default, "SUFeedURL refresh summary: refreshed=%{public}d failed=%{public}d", refreshed.count, failed.count)
     }
 
     /// One-shot diagnostic written at startup so we can see what core plugins
@@ -1064,6 +1136,7 @@ extension AppDelegate: NSMenuDelegate {
         // Refresh stale RetroArch stub bridges before any plugin enumeration so
         // newly-refreshed stubs load with the current translator code in this
         // same launch — not the next one.
+        refreshStaleCoreFeedURLs()
         refreshStaleRetroArchStubs()
 
         atexit {

--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -86,6 +86,9 @@ final class CoreUpdater: NSObject {
         for plugin in OECorePlugin.allPlugins {
             let coreID = plugin.bundleIdentifier.lowercased()
             guard !oeKnownCoreIDs.contains(coreID) else { continue }
+            // `infoDictionary` is cached at plugin load. Stale URLs on disk are
+            // rewritten by `AppDelegate.refreshStaleCoreFeedURLs()` at launch,
+            // but the rewrite only takes effect from the *next* launch onwards.
             if let appcastURLString = plugin.infoDictionary["SUFeedURL"] as? String,
                let feedURL = URL(string: appcastURLString) {
                 checkForUpdateInformation(url: feedURL, plugin: plugin) { item in


### PR DESCRIPTION
## What does this PR do?

Walks every installed `*.oecoreplugin` at app launch and rewrites any stale `SUFeedURL` in its `Info.plist` to the canonical nickybmon-hosted appcast. Cores installed before the URL migration in PR #369 keep the dormant upstream URL frozen on disk — Sparkle and `CoreUpdater` both read from that frozen plist, so users miss new releases. This self-heals on next launch (idempotent — only rewrites entries that don't already match the canonical prefix).

## What did you test?

- Built Debug via `Scripts/build-for-worktree.sh` — passes.
- Manual reproduction (per plan): corrupt an installed core's `SUFeedURL` to the dormant upstream URL via `PlistBuddy`, relaunch, confirm `os_log` shows the rewrite and the plist now points at the canonical URL. Relaunch a second time and confirm no further rewrites.

## Which cores or systems are affected?

App-level change. No core code or build settings touched. Affects Sparkle update discovery for all 24 native cores migrated in PR #369.

## Did you use AI tools?

Yes — used Claude to draft and verify the implementation, mirroring the pattern from `refreshStaleRetroArchStubs()`.

## Linked issues

Fixes #374

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

To reproduce the original bug and confirm the fix:

```bash
# 1. Corrupt an installed core's SUFeedURL to simulate a pre-migration install
/usr/libexec/PlistBuddy -c \
  "Set :SUFeedURL https://raw.github.com/OpenEmu/OpenEmu-Update/master/stella_appcast.xml" \
  ~/Library/Application\ Support/OpenEmu/Cores/Stella.oecoreplugin/Contents/Info.plist

# 2. Relaunch OpenEmu, then confirm the rewrite
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" \
  ~/Library/Application\ Support/OpenEmu/Cores/Stella.oecoreplugin/Contents/Info.plist
# Expect: https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/stella.xml

log show --predicate 'process == "OpenEmu"' --last 2m | grep "SUFeedURL refresh"
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header