### PR TITLE
chore: add launch-debug.sh to defeat stale-DerivedData launches

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,6 +36,8 @@ What this looks like in practice:
 
 The script chains build → static analyzer → plist lint → codesign verify → optional smoke launch with log + crash-report scan. Read its full output — don't pipe through `tail`. Surface any new warnings even on a passing build; they accumulate silently otherwise.
 
+**Launching the debug app:** use `./Scripts/launch-debug.sh` instead of `open <path>`. It picks the build matching the current git branch, refuses to launch when source is newer than the binary, and replaces any running instance (debug or production) cleanly. Plain `open` will silently launch a stale build from an old DerivedData hash whenever Xcode rotates hashes.
+
 **If `verify.sh` fails in a way unrelated to your change** (a script bug, a missing scheme, a permissions prompt, a stuck process), don't get stuck trying to fix the script. Fall back to a plain `xcodebuild build` check, note the verify.sh issue in your task report, and continue. The script is best-effort — it should help, not block.
 
 Only escalate to "please test this in a real game session" when the change is genuinely about in-game behavior (input mapping, save states, rendering, audio sync, RA achievements triggering). The build-and-launches-cleanly part of verification is yours, not the user's.

--- a/Scripts/launch-debug.sh
+++ b/Scripts/launch-debug.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# launch-debug.sh — launch the freshest debug OpenEmu.app, refusing stale builds.
+#
+# Why this script exists:
+#   `open <path>` and bare `open -a OpenEmu` happily launch a stale debug build
+#   from an old DerivedData hash whenever Xcode rotates the hash (workspace path
+#   change, scheme change, system cleanup). The user only finds out when the UI
+#   looks wrong. This script picks the newest OpenEmu.app across all known build
+#   locations, refuses to launch if source is newer than the binary, and force-
+#   replaces any running instance.
+#
+# Usage:
+#   ./Scripts/launch-debug.sh            # newest Debug build
+#   ./Scripts/launch-debug.sh --release  # newest Release build instead
+#   ./Scripts/launch-debug.sh --force    # skip staleness check
+
+set -uo pipefail
+
+CONFIG="Debug"
+FORCE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --release) CONFIG="Release" ;;
+        --force) FORCE=1 ;;
+        -h|--help)
+            sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "launch-debug: unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# 1a. Prefer the build for the current git branch if one exists. This avoids
+#     accidentally launching another worktree's newer binary just because it
+#     was built more recently. Falls through to global newest-wins below.
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|-|g')
+BRANCH_APP=""
+if [[ -n "$BRANCH" && "$BRANCH" != "HEAD" ]]; then
+    candidate="$HOME/Builds/openemu/$BRANCH/Build/Products/$CONFIG/OpenEmu.app"
+    if [[ -f "$candidate/Contents/MacOS/OpenEmu" ]]; then
+        BRANCH_APP="$candidate"
+    fi
+fi
+
+# 1b. Find newest OpenEmu.app across both DerivedData and the worktree-stable build dir.
+APPS=()
+while IFS= read -r p; do APPS+=("$p"); done < <(
+    {
+        find "$HOME/Library/Developer/Xcode/DerivedData" \
+            -maxdepth 5 \
+            -path "*/Build/Products/$CONFIG/OpenEmu.app" \
+            -prune 2>/dev/null
+        find "$HOME/Builds/openemu" \
+            -maxdepth 5 \
+            -path "*/Build/Products/$CONFIG/OpenEmu.app" \
+            -prune 2>/dev/null
+    }
+)
+
+if [[ ${#APPS[@]} -eq 0 ]]; then
+    echo "launch-debug: no OpenEmu.app found in DerivedData or ~/Builds/openemu for config $CONFIG." >&2
+    echo "  build first: ./Scripts/verify.sh" >&2
+    exit 1
+fi
+
+NEWEST=""
+NEWEST_MTIME=0
+for app in "${APPS[@]}"; do
+    bin="$app/Contents/MacOS/OpenEmu"
+    [[ -f "$bin" ]] || continue
+    mt=$(stat -f %m "$bin")
+    if (( mt > NEWEST_MTIME )); then
+        NEWEST_MTIME=$mt
+        NEWEST="$app"
+    fi
+done
+
+if [[ -z "$NEWEST" ]]; then
+    echo "launch-debug: found .app bundles but no OpenEmu binary inside any of them." >&2
+    exit 1
+fi
+
+# Branch-match wins over global newest. Note when this differs so the user can
+# tell whether they're running a build that's branch-correct vs just freshest.
+if [[ -n "$BRANCH_APP" ]]; then
+    if [[ "$BRANCH_APP" != "$NEWEST" ]]; then
+        echo "launch-debug: using current-branch build ($BRANCH); a newer build exists for a different branch."
+        echo "  current : $BRANCH_APP"
+        echo "  newer   : $NEWEST"
+    fi
+    NEWEST="$BRANCH_APP"
+    NEWEST_MTIME=$(stat -f %m "$NEWEST/Contents/MacOS/OpenEmu")
+fi
+
+# 2. Staleness check — refuse if any source file is newer than the binary.
+if [[ $FORCE -eq 0 ]]; then
+    NEWEST_SRC=$(find "$REPO_ROOT/OpenEmu" \
+        \( -name '*.swift' -o -name '*.m' -o -name '*.h' \) \
+        -type f -print0 2>/dev/null \
+        | xargs -0 stat -f '%m %N' 2>/dev/null \
+        | sort -rn | head -n1)
+    if [[ -n "$NEWEST_SRC" ]]; then
+        SRC_MTIME=${NEWEST_SRC%% *}
+        SRC_PATH=${NEWEST_SRC#* }
+        if (( SRC_MTIME > NEWEST_MTIME )); then
+            echo "launch-debug: source newer than build — refusing to launch a stale binary." >&2
+            echo "  newest source : $SRC_PATH" >&2
+            echo "  newest build  : $NEWEST" >&2
+            echo "  fix: ./Scripts/verify.sh   (or pass --force to launch anyway)" >&2
+            exit 1
+        fi
+    fi
+fi
+
+echo "launch-debug: launching $NEWEST"
+
+# 3. Kill any running OpenEmu (debug + production share a bundle ID).
+if pgrep -x OpenEmu >/dev/null; then
+    echo "launch-debug: killing running OpenEmu instance(s)..."
+    pkill -x OpenEmu || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        pgrep -x OpenEmu >/dev/null || break
+        sleep 0.2
+    done
+fi
+
+# 4. Force a new instance bound to this bundle.
+open -n "$NEWEST"


### PR DESCRIPTION
## What does this PR do?

Adds `Scripts/launch-debug.sh`, a one-shot launcher that always runs the freshest matching debug build of OpenEmu and refuses to launch a stale one. Plain `open <path>` (and `open -a OpenEmu`) silently launches a stale binary whenever Xcode rotates DerivedData hashes (workspace path change, scheme change, machine cleanup) — because the previous-hash app still claims the OpenEmu bundle ID. This has wasted hours of debugging time in past sessions.

The script:
- Prefers the build matching the current git branch (`~/Builds/openemu/<branch>/...`), falling back to global newest-by-mtime across DerivedData and the worktree-stable path.
- Refuses to launch when any `.swift`/`.m`/`.h` under `OpenEmu/` is newer than the chosen binary. `--force` overrides.
- Runs `pkill -x OpenEmu` before `open -n` so a running production or stale debug instance is replaced cleanly (shared bundle ID otherwise traps `open`).
- Prints the resolved path so the user sees what actually launched.

Also adds a one-line pointer in `.claude/CLAUDE.md` under "Verification" so future Claude sessions reach for this instead of `open`.

## What did you test?

All four scenarios from the implementation plan, locally on this machine (12 debug builds across 5 DerivedData hashes + 7 worktrees):

1. Cold launch → picks newest matching build, launches, exit 0.
2. Touch a `.swift` file → refuses with "source newer than build", names both files, exit 1.
3. Touch the binary forward (simulates a fresh build) → launches, exit 0.
4. Production OpenEmu running → `pkill -x` kills production, `open -n` launches debug, exit 0.

Also verified the current-branch-wins behavior by staging a fake older bundle for the active branch — script chose it over a globally-newer build from a different worktree and printed both paths so the choice is visible.

## Which cores or systems are affected?

None. Tooling-only. No app or core code changes.

## Did you use AI tools?

Yes — Claude drafted the script and the CLAUDE.md note from a plan I wrote, then ran the four-step verification end-to-end. I reviewed each test result and asked for the current-branch refinement after observing the original "newest globally wins" picked another worktree's binary.

## Linked issues

Related to #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
./Scripts/launch-debug.sh
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

To exercise the stale-build refusal, `touch` any `.swift` under `OpenEmu/` after building and re-run the launcher — it should refuse and name the offending file.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header