### PR TITLE
fix: repair release-core workflow + add zip-version guardrail

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -100,7 +100,7 @@ jobs:
             || { echo "ERROR: Core project not found at $CORE_PROJ"; exit 1; }
 
           # Check appcast exists — file uses lowercase core name
-          APPCAST_FILE="Appcasts/${CORE,,}.xml"
+          APPCAST_FILE="Appcasts/$(echo "$CORE" | tr '[:upper:]' '[:lower:]').xml"
           [ -f "$APPCAST_FILE" ] \
             || { echo "ERROR: Appcast not found at $APPCAST_FILE"; exit 1; }
 
@@ -140,8 +140,8 @@ jobs:
       # ── Bump CFBundleVersion in core Info.plist ─────────────────────────────
       - name: Bump ${{ inputs.core_name }} Info.plist version to ${{ inputs.version }}
         run: |
-          # Core Info.plists live at <Core>/OpenEmu/Info.plist
-          PLIST="${{ env.CORE }}/OpenEmu/Info.plist"
+          # Core Info.plists live at <Core>/Info.plist
+          PLIST="${{ env.CORE }}/Info.plist"
           [ -f "$PLIST" ] || {
             echo "ERROR: Info.plist not found at $PLIST"
             exit 1
@@ -228,6 +228,26 @@ jobs:
           ZIP_SIZE=$(stat -f%z "$ZIP_PATH")
           echo "ZIP_SIZE=$ZIP_SIZE" >> $GITHUB_ENV
           echo "Zip created: $ZIP_PATH ($ZIP_SIZE bytes)"
+
+      # ── Verify zip contents match input version ─────────────────────────────
+      # Guardrail against the cores-v1.2.0 class of bug, where the appcast
+      # advertised versions that the zipped artifact didn't actually contain.
+      - name: Verify zip CFBundleVersion matches input
+        run: |
+          VERIFY_DIR="${{ runner.temp }}/verify-zip"
+          rm -rf "$VERIFY_DIR" && mkdir -p "$VERIFY_DIR"
+          ditto -x -k "${{ env.ZIP_PATH }}" "$VERIFY_DIR"
+          ZIP_PLIST="$VERIFY_DIR/${{ env.CORE }}.oecoreplugin/Contents/Info.plist"
+          [ -f "$ZIP_PLIST" ] || {
+            echo "ERROR: Info.plist not found in unzipped artifact at $ZIP_PLIST"
+            exit 1
+          }
+          ACTUAL=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$ZIP_PLIST")
+          if [ "$ACTUAL" != "${{ env.VERSION }}" ]; then
+            echo "ERROR: Zip CFBundleVersion is '$ACTUAL', expected '${{ env.VERSION }}'"
+            exit 1
+          fi
+          echo "Verified: zip CFBundleVersion = $ACTUAL"
 
       # ── Find or create cores-v* tag ─────────────────────────────────────────
       - name: Compute next cores release tag


### PR DESCRIPTION
## What does this PR do?

Repairs `.github/workflows/release-core.yml`, which has been failing on every run since macos-26, and adds a guardrail so the cores-v1.2.0 class of bug (appcast advertising versions the zip artifact didn't actually contain) can't silently ship again.

Three changes:

1. **bash 4+ syntax** — replaced `${CORE,,}` with a portable `tr` substitution. The runner shell rejected the bash 4+ form with `bad substitution`, failing every workflow run.
2. **Wrong plist path** — changed `<Core>/OpenEmu/Info.plist` to `<Core>/Info.plist`. Verified across all 10 native cores; the `OpenEmu/` subdirectory does not exist for any of them.
3. **New verification step** — after the zip is created, unzip it and assert the embedded `CFBundleVersion` equals the version input. Fail loudly on mismatch.

## What did you test?

Workflow shape checks locally:

- `grep -nE '\$\{[^}]+,,\}|\$\{[^}]+\^\^\}' .github/workflows/release-core.yml` → no remaining bash 4+ subs.
- `for c in 4DO BSNES FCEU Gambatte GenesisPlus Mednafen mGBA Mupen64Plus Nestopia SNES9x; do test -f "$c/Info.plist"; done` → all 10 present.

End-to-end test: trigger Release Core for `4DO 2.3.2` (cheapest source change, no build risk) once this lands. The new verification step is itself the regression test going forward.

## Which cores or systems are affected?

Workflow only — affects every native core's release path.

## Did you use AI tools?

Yes — used Claude to draft and apply the workflow fix. Reviewed and tested locally.

## Linked issues

Related to #378

---

## How to test locally

This change is in CI workflow YAML; no local app build required.

```bash
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
grep -nE '\$\{[^}]+,,\}|\$\{[^}]+\^\^\}' .github/workflows/release-core.yml
# (should print nothing)
```

After merging, the canonical end-to-end test is to run the Release Core workflow for one core (e.g. `4DO 2.3.2`) and confirm:
1. Validate-inputs step passes (no `bad substitution`).
2. Bump-plist step finds `4DO/Info.plist` and writes to it.
3. New verification step confirms zipped artifact's `CFBundleVersion = 2.3.2`.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files