### PR TITLE
chore: revert phantom appcast version bumps from cores-v1.2.0

### DIFF
--- a/Appcasts/bsnes.xml
+++ b/Appcasts/bsnes.xml
@@ -5,12 +5,12 @@
   <channel>
     <title>BSNES</title>
       <item>
-      <title>BSNES 115.1</title>
+      <title>BSNES 115</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure
         url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/BSNES.oecoreplugin.zip"
-        sparkle:version="115.1"
-        sparkle:shortVersionString="115.1"
+        sparkle:version="115"
+        sparkle:shortVersionString="115"
         length="918198"
         type="application/octet-stream" />
     </item>

--- a/Appcasts/gambatte.xml
+++ b/Appcasts/gambatte.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>Gambatte</title>
         <item>
-      <title>Gambatte 0.5.2</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/Gambatte.oecoreplugin.zip"
-        sparkle:version="0.5.2"
-        sparkle:shortVersionString="0.5.2"
-        length="393699"
-        type="application/octet-stream" />
-    </item>
-<item>
       <title>Gambatte 0.5.1</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/genesisplus.xml
+++ b/Appcasts/genesisplus.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>GenesisPlus</title>
         <item>
-      <title>GenesisPlus 1.7.5.2</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/GenesisPlus.oecoreplugin.zip"
-        sparkle:version="1.7.5.2"
-        sparkle:shortVersionString="1.7.5.2"
-        length="641674"
-        type="application/octet-stream" />
-    </item>
-<item>
       <title>GenesisPlus 1.7.5.1</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mgba.xml
+++ b/Appcasts/mgba.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>mGBA</title>
         <item>
-      <title>mGBA 0.10.6</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/mGBA.oecoreplugin.zip"
-        sparkle:version="0.10.6"
-        sparkle:shortVersionString="0.10.6"
-        length="369630"
-        type="application/octet-stream" />
-    </item>
-<item>
       <title>mGBA 0.10.5</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/nestopia.xml
+++ b/Appcasts/nestopia.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>Nestopia</title>
         <item>
-      <title>Nestopia 1.52.1</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/Nestopia.oecoreplugin.zip"
-        sparkle:version="1.52.1"
-        sparkle:shortVersionString="1.52.1"
-        length="799998"
-        type="application/octet-stream" />
-    </item>
-<item>
       <title>Nestopia 1.52</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/snes9x.xml
+++ b/Appcasts/snes9x.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>SNES9x</title>
         <item>
-      <title>SNES9x 1.63.1</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.2.0/SNES9x.oecoreplugin.zip"
-        sparkle:version="1.63.1"
-        sparkle:shortVersionString="1.63.1"
-        length="852888"
-        type="application/octet-stream" />
-    </item>
-<item>
       <title>SNES9x 1.63</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure


### PR DESCRIPTION
## What does this PR do?

Stops the app from offering users non-existent core updates.

The cores-v1.2.0 release advertised new versions in appcast XMLs but the zipped artifacts on the release contain the previous versions. Users who "updated" got the same binary back, so the app kept offering the same non-update on every launch.

For the 6 cores still pointing at cores-v1.2.0 with a phantom claim, this removes the top item so the appcast advertises only versions that have real artifacts:

| Core | Phantom version | Real version in zip |
|---|---|---|
| Nestopia | 1.52.1 | 1.52 |
| Gambatte | 0.5.2 | 0.5.1 |
| mGBA | 0.10.6 | 0.10.5 |
| SNES9x | 1.63.1 | 1.63 |
| GenesisPlus | 1.7.5.2 | 1.7.5.1 |
| BSNES | 115.1 | 115 |

BSNES had no historical entry to fall back to (it was added in cores-v1.2.0), so its lone entry is corrected to advertise 115 — matching what the zip actually contains — rather than removed entirely.

FCEU, Mednafen, and Mupen64Plus are not touched: they were re-released under cores-v1.3.0 with real artifacts, so their current appcast entries are legitimate.

## What did you test?

- XML well-formedness validated for all 6 modified files via `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"`.
- Spot-checked cores-v1.3.0 zips for FCEU, Mednafen, Mupen64Plus to confirm their CFBundleVersion matches the appcast claim before deciding not to touch them.

In a fresh OpenEmu Debug build after merge: open Preferences → Cores and confirm the 6 listed cores no longer offer a non-existent update.

## Which cores or systems are affected?

Appcasts only for: Nestopia, Gambatte, mGBA, SNES9x, GenesisPlus, BSNES.

## Did you use AI tools?

Yes — used Claude to diagnose the artifact/appcast mismatch and draft the revert. Reviewed and tested locally.

## Linked issues

Related to #378 (paired with #379, which fixes the workflow bug that caused this in the first place)

---

## How to test locally

```bash
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
for f in nestopia gambatte mgba snes9x genesisplus bsnes; do
  python3 -c "import xml.etree.ElementTree as ET; ET.parse('Appcasts/$f.xml'); print('OK $f')"
done
```

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files