### PR TITLE
chore: bump 4DO to 2.3.2 (cores-v1.3.1 pipeline smoke test)

### DIFF
--- a/4DO/Info.plist
+++ b/4DO/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.1</string>
+	<string>2.3.2</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Appcasts/4do.xml
+++ b/Appcasts/4do.xml
@@ -5,6 +5,16 @@
   <channel>
     <title>4DO</title>
     <item>
+      <title>4DO 2.3.2</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.1/4DO.oecoreplugin.zip"
+        sparkle:version="2.3.2"
+        sparkle:shortVersionString="2.3.2"
+        length="76552"
+        type="application/octet-stream" />
+    </item>
+    <item>
       <title>4DO 2.3.1</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure


### PR DESCRIPTION
## What does this PR do?

Pipeline smoke test. Bumps 4DO 2.3.1 → 2.3.2 with no functional change to validate that the full release path actually delivers an updated plugin to users on disk after PRs #379, #380, and #381.

The cores-v1.3.1 prerelease is already created and uploaded:
https://github.com/nickybmon/OpenEmu-Silicon/releases/tag/cores-v1.3.1

## What did you test?

End-to-end via the fixed `/release-core` skill:

- Step 4 main workspace built Release.
- Step 5 4DO core built Release via `OpenEmu + 4DO` scheme (the bare `4DO` scheme isn't configured for build).
- Step 6 plugin found, CFBundleVersion = 2.3.2.
- Step 7 signed with Developer ID, zipped (76552 bytes).
- **Step 7b guardrail passed:** zip CFBundleVersion = 2.3.2 (expected: 2.3.2).
- Step 9 cores-v1.3.1 prerelease created with 4DO.oecoreplugin.zip attached.

Post-merge in-app verification (the actual point of this exercise):

```bash
# Before relaunching OpenEmu, expected:
/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" \
  "$HOME/Library/Application Support/OpenEmu/Cores/4DO.oecoreplugin/Contents/Info.plist"
# 2.3.1
```

1. Quit OpenEmu, launch fresh, Preferences → Cores → 4DO should show `Lat: 2.3.2` with "Update Available."
2. Click install, wait for completion, quit OpenEmu.
3. Re-check installed plist — must show 2.3.2.
4. Relaunch, confirm Preferences → Cores shows 4DO `Ver: 2.3.2` with no further update offered.

## Which cores or systems are affected?

4DO only.

## Did you use AI tools?

Yes — used Claude to drive `/release-core` end-to-end and produce this PR.

## Linked issues

Related to #378

---

## How to test locally

This PR contains only an appcast + plist bump; no app build needed locally. The actual test is the in-app update flow described above.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes (Release, arm64)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files