### PR TITLE
chore: revert 4DO 2.3.2 smoke-test bump and close #378

### DIFF
--- a/4DO/Info.plist
+++ b/4DO/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.2</string>
+	<string>2.3.1</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Appcasts/4do.xml
+++ b/Appcasts/4do.xml
@@ -5,16 +5,6 @@
   <channel>
     <title>4DO</title>
     <item>
-      <title>4DO 2.3.2</title>
-      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-      <enclosure
-        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.1/4DO.oecoreplugin.zip"
-        sparkle:version="2.3.2"
-        sparkle:shortVersionString="2.3.2"
-        length="76552"
-        type="application/octet-stream" />
-    </item>
-    <item>
       <title>4DO 2.3.1</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure


### PR DESCRIPTION
## What does this PR do?

Reverts the 4DO 2.3.1 → 2.3.2 smoke-test bump from #382 and closes the parent issue.

The bump was a no-op version change shipped purely to validate the full release pipeline end-to-end. Both halves are now confirmed working:

- **PR #381's Step 7b guardrail passed** during the build — zip CFBundleVersion = 2.3.2 (expected: 2.3.2). This is what would have caught the cores-v1.2.0 silent failure if it had existed back then.
- **In-app install works.** Production OpenEmu auto-installed 4DO 2.3.2 on launch via Sparkle and the on-disk `~/Library/Application Support/OpenEmu/Cores/4DO.oecoreplugin/Contents/Info.plist` updated from 2.3.1 → 2.3.2 with binary mtime matching the install moment.

The cores-v1.3.1 prerelease is being deleted alongside this revert so users on 2.3.2 aren't left pointing at a 404 URL after merge. Net effect: 4DO returns to 2.3.1 across plist + appcast, matching cores-v1.0.0 / cores-v1.2.0.

## What did you test?

- `xmllint --noout Appcasts/4do.xml` — valid.
- `/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" 4DO/Info.plist` returns 2.3.1.
- `git diff` shows only the smoke-test entry removed and `CFBundleVersion` reverted.

After merge, in-app verification: relaunch production OpenEmu → Preferences → Cores → 4DO should show `Ver: 2.3.1 / Lat: 2.3.1` and no update offered. (The installed plugin is currently 2.3.2 from the smoke test; after the cores-v1.3.1 release is deleted and this revert lands, the appcast offers 2.3.1, which is older than the installed 2.3.2 — so OpenEmu will simply not offer any update. The on-disk 2.3.2 binary remains harmless.)

## Which cores or systems are affected?

4DO only (revert).

## Did you use AI tools?

Yes — used Claude to drive the smoke test, validate the install path, and prepare this revert.

## Linked issues

Fixes #378

---

## How to test locally

```bash
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xmllint --noout Appcasts/4do.xml && /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" 4DO/Info.plist
# expect: 2.3.1
```

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files