### PR TITLE
chore: tighten /release-core skill (scheme + CURRENT_PROJECT_VERSION notes)

### DIFF
--- a/.claude/commands/release-core.md
+++ b/.claude/commands/release-core.md
@@ -51,6 +51,23 @@ plutil -lint <CoreName>/Info.plist
 /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" <CoreName>/Info.plist
 ```
 
+**Watch out for `$(CURRENT_PROJECT_VERSION)`.** Some cores (BSNES is the
+known case) have `<string>$(CURRENT_PROJECT_VERSION)</string>` in
+`Info.plist` instead of a literal version. For those, editing only the
+plist won't change the built binary — Xcode substitutes the value at
+build time from `CURRENT_PROJECT_VERSION` in the project file. The
+Step 7b guardrail will catch this (the zip's `CFBundleVersion` will
+come back as the old version, not what you wrote here). When that
+happens, you also need to bump `CURRENT_PROJECT_VERSION` in
+`<CoreName>/<CoreName>.xcodeproj/project.pbxproj` (or the relevant
+xcconfig). Detect this case before building:
+
+```bash
+grep -q '\$(CURRENT_PROJECT_VERSION)' <CoreName>/Info.plist \
+  && echo "WARNING: Info.plist uses CURRENT_PROJECT_VERSION — also bump it in the project file" \
+  || echo "Plist uses literal version — single edit is enough"
+```
+
 ## Step 4 — Build the main workspace in Release (produces frameworks the core needs)
 
 ```bash
@@ -66,22 +83,20 @@ If this fails, stop and report the errors. Do not continue.
 
 ## Step 5 — Build the core in Release
 
-Find the Release framework path:
-```bash
-DERIVED_RELEASE=$(find ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-* \
-  -maxdepth 3 -name "Release" -path "*/Build/Products/Release" 2>/dev/null | head -1)
-echo "$DERIVED_RELEASE"
-```
+Build via the workspace's `OpenEmu + <CoreName>` scheme — not the bare
+`<CoreName>` scheme. The bare scheme isn't configured for the build
+action on every core (4DO is one example) and will fail with
+`Scheme <CoreName> is not currently configured for the build action`.
+The combo scheme always builds both the host app and the plugin together,
+producing both into the same `OpenEmu-metal-*` DerivedData tree.
 
-Build the core:
 ```bash
 xcodebuild \
-  -project <CoreName>/<CoreName>.xcodeproj \
-  -scheme <CoreName> \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme "OpenEmu + <CoreName>" \
   -configuration Release \
   -destination 'platform=macOS,arch=arm64' \
   ONLY_ACTIVE_ARCH=YES \
-  FRAMEWORK_SEARCH_PATHS="$DERIVED_RELEASE" \
   build 2>&1 | tail -10
 ```
 
@@ -89,8 +104,11 @@ If the build fails, stop and report the errors.
 
 ## Step 6 — Locate the built plugin
 
+The plugin is built into the same `OpenEmu-metal-*` DerivedData tree as
+the host app, not into a per-core `<CoreName>-*` tree:
+
 ```bash
-PLUGIN=$(find ~/Library/Developer/Xcode/DerivedData/<CoreName>-* \
+PLUGIN=$(find ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-* \
   -name "<CoreName>.oecoreplugin" \
   -path "*/Release/*" \
   -not -path "*.dSYM*" \


### PR DESCRIPTION
## What does this PR do?

Two small follow-ups to `.claude/commands/release-core.md` based on what shipping the 4DO 2.3.2 smoke test (#382, reverted in #383) actually exposed:

1. **Step 5 build command** now uses the workspace's `OpenEmu + <CoreName>` scheme instead of the bare `<CoreName>` scheme. Some cores (4DO confirmed; possibly others) have their bare scheme not configured for the build action and fail with `Scheme <CoreName> is not currently configured for the build action`. The combo scheme always builds.

2. **Step 6 plugin lookup path** updated to match — the combo build produces the plugin into `OpenEmu-metal-*/Build/Products/Release`, not a per-core `<CoreName>-*/.../Release`.

3. **Step 3 now warns about `$(CURRENT_PROJECT_VERSION)`.** Some cores (BSNES is the known case) reference `$(CURRENT_PROJECT_VERSION)` in `Info.plist` instead of a literal version string, which means editing the plist alone won't change what gets baked into the built binary — Xcode substitutes from the project file at build time. The Step 7b guardrail will catch this, but the next operator shouldn't have to learn it the hard way.

## What did you test?

- The Step 5 build command is exactly what produced today's working 4DO 2.3.2 zip end-to-end.
- Skill text is markdown-only; nothing to compile.

## Which cores or systems are affected?

None directly — affects every future `/release-core` run.

## Did you use AI tools?

Yes — used Claude to draft the follow-ups based on observations from today's smoke test.

## Linked issues

Related to #378

---

## How to test locally

```bash
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
grep -n "OpenEmu + " .claude/commands/release-core.md  # should print the new scheme reference
grep -n "CURRENT_PROJECT_VERSION" .claude/commands/release-core.md  # should print the new warning
```

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No build logs, binaries, or credentials committed