### PR TITLE
fix: dispatch PrefBiosController.reloadData to main thread

### DIFF
--- a/OpenEmu/PrefBiosController.swift
+++ b/OpenEmu/PrefBiosController.swift
@@ -87,7 +87,7 @@ final class PrefBiosController: NSViewController {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         
         if context == &PrefBiosCoreListKVOContext {
-            reloadData()
+            DispatchQueue.main.async { [weak self] in self?.reloadData() }
         } else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }


### PR DESCRIPTION
## What does this PR do?

KVO notifications on `OECorePlugin.allPlugins` can fire on a background thread. The previous code called `reloadData()` — which calls `tableView.reloadData()` — directly from that callback, triggering an `NSInternalInconsistencyException` (Sentry OPENEMU-SILICON-4J). The fix wraps the call in `DispatchQueue.main.async`.

## What did you test?

Built and smoke-launched via `verify.sh --launch`. App launches clean, no new crash reports, no faults in the unified log related to this change.

## Which cores or systems are affected?

General app change — System Files preferences pane only.

## Did you use AI tools?

Used Claude to identify the threading issue from Sentry data and draft the fix. Reviewed and verified with verify.sh.

## Linked issues

Fixes #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 386 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header