### PR TITLE
fix: resolve 5 AppHang Sentry issues on macOS Tahoe

### DIFF
--- a/OpenEmu-metal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenEmu-metal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7acc79c7e8bd2b0f6e137970910445e4a85a2a8c39da16100f82b961884a0e07",
+  "originHash" : "9adbacc98e371d6e7b4e99d8e8bb1ba15d640c8f626feea6b0fffec633dbc1de",
   "pins" : [
     {
       "identity" : "cwlcatchexception",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "47d3d90aee3c52b6f61d04ceae426e607df62347",
-        "version" : "2.5.2"
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {

--- a/OpenEmu/CoreDownload.swift
+++ b/OpenEmu/CoreDownload.swift
@@ -129,31 +129,28 @@ extension CoreDownload: URLSessionDownloadDelegate {
         let coresFolder = URL.oeApplicationSupportDirectory
             .appendingPathComponent("Cores", isDirectory: true)
         
-        // TODO: per URLSession docs
-        //  "If you choose to open the file for reading, you should do the actual reading in another thread to avoid blocking the delegate queue."
         guard
             let fileName = ArchiveHelper.decompressFileInArchive(at: location, toDirectory: coresFolder)
         else { return }
-        
+
         let fullPluginURL = coresFolder.appendingPathComponent(fileName)
-        
+
         DLog("Core (\(bundleIdentifier)) extracted to application support folder.")
 
-        adHocSign(fullPluginURL)
+        adHocSign(fullPluginURL) {
+            guard let plugin = OECorePlugin.corePlugin(bundleAtURL: fullPluginURL) else {
+                return assertionFailure()
+            }
 
-        guard let plugin = OECorePlugin.corePlugin(bundleAtURL: fullPluginURL) else {
-            return assertionFailure()
-        }
-        
-        if hasUpdate {
-            // flush bundle cache as NSBundle still returns the infoDictionary of the previous version
-            plugin.flushBundleCache()
-            version = plugin.version
-            hasUpdate = false
-            canBeInstalled = false
-        }
-        else if canBeInstalled {
-            updateProperties(with: plugin)
+            if self.hasUpdate {
+                // flush bundle cache as NSBundle still returns the infoDictionary of the previous version
+                plugin.flushBundleCache()
+                self.version = plugin.version
+                self.hasUpdate = false
+                self.canBeInstalled = false
+            } else if self.canBeInstalled {
+                self.updateProperties(with: plugin)
+            }
         }
     }
 }
@@ -165,19 +162,22 @@ extension CoreDownload {
     /// Ad-hoc signs the plugin bundle so macOS 26+ will load it.
     /// Downloaded cores arrive unsigned; the OS refuses to dlopen them even
     /// with disable-library-validation unless they carry at least an ad-hoc signature.
-    private func adHocSign(_ bundleURL: URL) {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-        task.arguments = ["--force", "--sign", "-", bundleURL.path]
+    private func adHocSign(_ bundleURL: URL, completion: @escaping () -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+            task.arguments = ["--force", "--sign", "-", bundleURL.path]
 
-        do {
-            try task.run()
-            task.waitUntilExit()
-            if task.terminationStatus != 0 {
-                DLog("codesign exited with status \(task.terminationStatus) for \(bundleURL.lastPathComponent)")
+            do {
+                try task.run()
+                task.waitUntilExit()
+                if task.terminationStatus != 0 {
+                    DLog("codesign exited with status \(task.terminationStatus) for \(bundleURL.lastPathComponent)")
+                }
+            } catch {
+                DLog("Failed to run codesign for \(bundleURL.lastPathComponent): \(error)")
             }
-        } catch {
-            DLog("Failed to run codesign for \(bundleURL.lastPathComponent): \(error)")
+            DispatchQueue.main.async { completion() }
         }
     }
 }

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -356,7 +356,8 @@ extension MainWindowController: LibraryControllerDelegate {
                 }
                 else if let error = error as NSError?, !(error.domain == NSCocoaErrorDomain && error.code == NSUserCancelledError) {
                     DispatchQueue.main.async {
-                        self.presentError(error)
+                        self.presentError(error, modalFor: self.window!, delegate: nil,
+                                          didPresent: nil, contextInfo: nil)
                     }
                 }
                 

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -631,8 +631,10 @@ final class OEGameDocument: NSDocument {
                 self.lastPlayStartDate = Date()
                 
                 if let saveStateForGameStart = self.saveStateForGameStart {
-                    self.loadState(state: saveStateForGameStart)
                     self.saveStateForGameStart = nil
+                    DispatchQueue.main.async {
+                        self.loadState(state: saveStateForGameStart)
+                    }
                 }
                 
                 // set initial volume

--- a/OpenEmu/OEGridView.m
+++ b/OpenEmu/OEGridView.m
@@ -554,17 +554,27 @@ NSString *const OEImageBrowserGroupSubtitleKey = @"OEImageBrowserGroupSubtitleKe
         if(image == nil)
         {
             NSURL *url = [[pboard readObjectsForClasses:@[[NSURL class]] options:@{}] lastObject];
-            QLThumbnailRef thumbnailRef = QLThumbnailCreate(NULL, (__bridge CFURLRef)url, [self cellSize], NULL);
-            if(thumbnailRef)
-            {
-                CGImageRef thumbnailImageRef = QLThumbnailCopyImage(thumbnailRef);
-                if(thumbnailImageRef)
+            if(url == nil) { [self setProposedImage:nil]; return; }
+
+            CGSize cellSize = [self cellSize];
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                NSImage *thumbnail = nil;
+                QLThumbnailRef thumbnailRef = QLThumbnailCreate(NULL, (__bridge CFURLRef)url, cellSize, NULL);
+                if(thumbnailRef)
                 {
-                    image = [[NSImage alloc] initWithCGImage:thumbnailImageRef size:NSMakeSize(CGImageGetWidth(thumbnailImageRef), CGImageGetHeight(thumbnailImageRef))];
-                    CGImageRelease(thumbnailImageRef);
+                    CGImageRef thumbnailImageRef = QLThumbnailCopyImage(thumbnailRef);
+                    if(thumbnailImageRef)
+                    {
+                        thumbnail = [[NSImage alloc] initWithCGImage:thumbnailImageRef size:NSMakeSize(CGImageGetWidth(thumbnailImageRef), CGImageGetHeight(thumbnailImageRef))];
+                        CGImageRelease(thumbnailImageRef);
+                    }
+                    CFRelease(thumbnailRef);
                 }
-                CFRelease(thumbnailRef);
-            }
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self setProposedImage:thumbnail];
+                });
+            });
+            return;
         }
     }
 

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -9699,8 +9699,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.5.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
 			};
 		};
 		8F7C2953288A2D7C00A16C09 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {


### PR DESCRIPTION
## What does this PR do?

Fixes 5 of the 7 open AppHang events reported by Sentry — all caused by the main thread being blocked for ≥2000 ms, a pattern macOS Tahoe (26.x) surfaces more aggressively than earlier OS versions. Covers root causes: synchronous QuickLook during drag, codesign blocking the URLSession delegate, nested modal alerts during emulation setup, blocking `presentError` on game open failure, and Sparkle's modal during a manual update check.

## What did you test?

- Build passes and codesign verifies clean (`verify.sh --launch` — all pass)
- Code review of each change against the Sentry stack traces to confirm the blocked call is removed from the main thread

## Which cores or systems are affected?

General app change — no core code modified.

## Did you use AI tools?

Used Claude to draft all fixes, reviewed each change against the plan and Sentry traces myself.

## Linked issues

Fixes OPENEMU-SILICON-3X, OPENEMU-SILICON-3S, OPENEMU-SILICON-3Y, OPENEMU-SILICON-4F, OPENEMU-SILICON-4M
Related to OPENEMU-SILICON-47

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 393 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header