### PR TITLE
fix: defer CoreUpdater error callback to prevent launch crash on first install

### DIFF
--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -161,7 +161,7 @@ final class CoreUpdater: NSObject {
     
     func checkForNewCores(completionHandler handler: ((_ error: Error?) -> Void)? = nil) {
         guard lastCoreListURLTask == nil else {
-            handler?(Errors.newCoreCheckAlreadyPendingError)
+            DispatchQueue.main.async { handler?(Errors.newCoreCheckAlreadyPendingError) }
             return
         }
         


### PR DESCRIPTION
## What does this PR do?

Fixes a launch crash that hit every new user on first install. On first launch, the app fires two back-to-back calls to `CoreUpdater.checkForNewCores` — one from `AppDelegate.libraryDatabaseDidLoad` and one from `SetupAssistant.viewDidLoad` a few milliseconds later. The second call sees the first already running and returns an error immediately — but it did so **synchronously**, before the SetupAssistant view had finished loading and attached to a window. When the error handler reached for `view.window!` to show an alert sheet, it got `nil` and crashed.

One-line fix: `DispatchQueue.main.async` on the early-return handler in `CoreUpdater.swift:163`, matching the behaviour of the normal async path.

Diagnosed via dSYM symbolication of the reporter's crash log (issue #392).

## What did you test?

- `verify.sh --launch` — all pass
- Confirmed crash site via `atos` against the 1.1.0 dSYM matching the reporter's crash log UUID

## Which cores or systems are affected?

General app change — no core code modified. Only affects first-launch users who see the Setup Assistant.

## Did you use AI tools?

Used Claude to diagnose and write the fix, reviewed against the symbolicated stack trace.

## Linked issues

Fixes #392

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 394 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header