### PR TITLE
fix: prevent main-thread blocks in Input Monitoring alert and XPC game launch

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -869,12 +869,14 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
 
         UserDefaults.standard.set(true, forKey: suppressionKey)
 
-        let res = alert.runModal()
-        if res == .alertFirstButtonReturn {
-            if #available(macOS 13.0, *) {
-                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_ListenEvent")!)
-            } else {
-                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!)
+        guard let window = mainWindowController.window else { return }
+        alert.beginSheetModal(for: window) { res in
+            if res == .alertFirstButtonReturn {
+                if #available(macOS 13.0, *) {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_ListenEvent")!)
+                } else {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!)
+                }
             }
         }
     }

--- a/OpenEmuKit/Source/OEXPCGameCoreManager.swift
+++ b/OpenEmuKit/Source/OEXPCGameCoreManager.swift
@@ -46,71 +46,73 @@ import OpenEmuKitPrivate
     public override func loadROM(completionHandler: @escaping StartupCompletionHandler) {
         guard let executableURL = executableURL
         else { fatalError("Missing XPC helper executable") }
-        
-        let cn: NSXPCConnection
-        do {
-            NSLog("[OEXPCGameCoreManager] Launching helper at \(executableURL.path)")
-            cn = try .makeConnection(serviceName: serviceName, executableURL: executableURL)
-            helperConnection = cn
-        } catch {
-            DispatchQueue.main.async {
-                completionHandler(error)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let cn: NSXPCConnection
+            do {
+                NSLog("[OEXPCGameCoreManager] Launching helper at \(executableURL.path)")
+                cn = try .makeConnection(serviceName: self.serviceName, executableURL: executableURL)
+            } catch {
+                DispatchQueue.main.async {
+                    completionHandler(error)
+                }
+                // There's no listener endpoint, so don't bother trying to create an NSXPCConnection.
+                // Returning now since calling initWithListenerEndpoint: and passing it nil results in a memory leak.
+                // Also, there's no point in trying to get the gameCoreHelper if there's no _helperConnection.
+                return
             }
-            
-            // There's no listener endpoint, so don't bother trying to create an NSXPCConnection.
-            // Returning now since calling initWithListenerEndpoint: and passing it nil results in a memory leak.
-            // Also, there's no point in trying to get the gameCoreHelper if there's no _helperConnection.
-            return
-        }
-        
-        cn.invalidationHandler = { [weak self] in
-            self?.notifyGameCoreDidTerminate()
-        }
-        
-        let proxy = OEThreadProxy(target: gameCoreOwner, thread: .main)
-        
-        cn.exportedInterface = .init(with: OEGameCoreOwner.self)
-        cn.exportedObject = proxy
-        
-        let intf = NSXPCInterface(with: OEXPCGameCoreHelper.self)
-        
-        // startup
-        let classes: NSSet = [OEGameStartupInfo.self]
-        // swiftlint:disable:next force_cast
-        intf.setClasses(classes as! Set<AnyHashable>,
-                        for: #selector(OEXPCGameCoreHelper.load(with:completionHandler:)),
-                        argumentIndex: 0,
-                        ofReply: false)
-        
-        cn.remoteObjectInterface = intf
-        cn.resume()
-        
-        let gameCoreHelper = cn.remoteObjectProxyWithErrorHandler { error in
-            os_log(.error, log: .helper, "Helper connection failed with error: %{public}@", error.localizedDescription)
-            DispatchQueue.main.async {
-                completionHandler(error)
-                self.stop()
+
+            self.helperConnection = cn
+
+            cn.invalidationHandler = { [weak self] in
+                self?.notifyGameCoreDidTerminate()
             }
-        } as? OEXPCGameCoreHelper
-        
-        guard let gameCoreHelper = gameCoreHelper
-        else { return }
-        
-        gameCoreHelper.load(with: startupInfo) { error in
-            if let error = error {
+
+            let proxy = OEThreadProxy(target: self.gameCoreOwner, thread: .main)
+
+            cn.exportedInterface = .init(with: OEGameCoreOwner.self)
+            cn.exportedObject = proxy
+
+            let intf = NSXPCInterface(with: OEXPCGameCoreHelper.self)
+
+            // startup
+            let classes: NSSet = [OEGameStartupInfo.self]
+            // swiftlint:disable:next force_cast
+            intf.setClasses(classes as! Set<AnyHashable>,
+                            for: #selector(OEXPCGameCoreHelper.load(with:completionHandler:)),
+                            argumentIndex: 0,
+                            ofReply: false)
+
+            cn.remoteObjectInterface = intf
+            cn.resume()
+
+            let gameCoreHelper = cn.remoteObjectProxyWithErrorHandler { error in
+                os_log(.error, log: .helper, "Helper connection failed with error: %{public}@", error.localizedDescription)
                 DispatchQueue.main.async {
                     completionHandler(error)
                     self.stop()
                 }
-                
-                // There's no listener endpoint, so don't bother trying to create an NSXPCConnection.
-                // Returning now since calling initWithListenerEndpoint: and passing it nil results in a memory leak.
-                return
-            }
-            
-            self.gameCoreHelper = gameCoreHelper
-            DispatchQueue.main.async {
-                completionHandler(nil)
+            } as? OEXPCGameCoreHelper
+
+            guard let gameCoreHelper = gameCoreHelper
+            else { return }
+
+            gameCoreHelper.load(with: self.startupInfo) { error in
+                if let error = error {
+                    DispatchQueue.main.async {
+                        completionHandler(error)
+                        self.stop()
+                    }
+
+                    // There's no listener endpoint, so don't bother trying to create an NSXPCConnection.
+                    // Returning now since calling initWithListenerEndpoint: and passing it nil results in a memory leak.
+                    return
+                }
+
+                self.gameCoreHelper = gameCoreHelper
+                DispatchQueue.main.async {
+                    completionHandler(nil)
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes two AppHang Sentry issues where the main thread was blocked waiting for UI dismissal or an XPC handshake, triggering macOS Tahoe's 2s AppHang watchdog.

**OPENEMU-SILICON-4D** — `showInputMonitoringPermissionsAlert` was calling `OEAlert.runModal()` synchronously on the main thread. Replaced with `beginSheetModal(for:completionHandler:)` so the alert is non-blocking. 2 users affected.

**OPENEMU-SILICON-4N** — `OEXPCGameCoreManager.loadROM` was called on the main thread and immediately hit `NSXPCConnection.makeConnection` → `DispatchSemaphore.wait` (up to 10s) during the broker XPC handshake. Moved the connection setup onto a `DispatchQueue.global(qos: .userInitiated)` background queue. All existing `DispatchQueue.main.async` completion callbacks are unchanged. 1 user affected (PPSSPP on macOS 26.4.1).

## What did you test?

`./Scripts/verify.sh --launch` passes clean. No new warnings introduced.

## Which cores or systems are affected?

General app change. Fix B affects all cores that use XPC game core manager (all non-libretro cores), but the change is structural — connection setup moves off-main, callbacks stay on-main as before.

## Did you use AI tools?

Used Claude to draft both fixes and verify. Reviewed and tested locally.

## Linked issues

Fixes OPENEMU-SILICON-4D
Fixes OPENEMU-SILICON-4N

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header