### PR TITLE
fix: add Sentry to XPC helper and upload core plugin dSYMs on release

### DIFF
--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		1E4B7FC710DE4156A46DAB79 /* OEWiiSystemController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C6AA00A0A44B609186B94D /* OEWiiSystemController.m */; };
 		22041F6779860DD69DB04FDD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38F89E810430637386DA95E8 /* Cocoa.framework */; };
 		22477F282F81F85500C2A0BD /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 22477F272F81F85500C2A0BD /* Sentry */; };
+		22477F2B2F82A00000C2A0BD /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 22477F2C2F82A00000C2A0BD /* Sentry */; };
 		22477F2A2F81F99300C2A0BD /* SentryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22477F292F81F99300C2A0BD /* SentryService.swift */; };
 		277CBA3719DE54200059A2C1 /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120C417112E1300E868A8 /* OpenEmuSystem.framework */; };
 		277CBA4A19DE54A80059A2C1 /* OEIntellivisionSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 277CBA4819DE54A80059A2C1 /* OEIntellivisionSystemResponder.m */; };
@@ -1993,6 +1994,7 @@
 				C6D120C917112E9E00E868A8 /* OpenEmuBase.framework in Frameworks */,
 				C6D120CA17112E9E00E868A8 /* OpenEmuSystem.framework in Frameworks */,
 				0547FD9A24E77695005C1FFC /* OpenEmuKit.framework in Frameworks */,
+				22477F2B2F82A00000C2A0BD /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4475,6 +4477,9 @@
 			dependencies = (
 			);
 			name = OpenEmuHelperApp;
+			packageProductDependencies = (
+				22477F2C2F82A00000C2A0BD /* Sentry */,
+			);
 			productName = OpenEmuHelperApp;
 			productReference = 1BEF2A9411682A530090F72B /* OpenEmuHelperApp */;
 			productType = "com.apple.product-type.tool";
@@ -9282,6 +9287,11 @@
 			productName = OrderedCollections;
 		};
 		22477F272F81F85500C2A0BD /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 22477F262F81F85500C2A0BD /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+		22477F2C2F82A00000C2A0BD /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 22477F262F81F85500C2A0BD /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;

--- a/OpenEmu/OpenEmuHelperApp/main.swift
+++ b/OpenEmu/OpenEmuHelperApp/main.swift
@@ -24,6 +24,27 @@
 
 import Foundation
 import OpenEmuKit
+import Sentry
+
+// Initialize Sentry in the helper process if the user opted in via the host app.
+// CFPreferencesCopyValue reads the host app's preference domain directly, which is
+// safe in this non-sandboxed helper process and avoids any IPC or file-sharing setup.
+let consentValue = CFPreferencesCopyValue(
+    "OESentryCrashReportingEnabled" as CFString,
+    "org.openemu.OpenEmu" as CFString,
+    kCFPreferencesAnyUser,
+    kCFPreferencesAnyHost
+)
+if (consentValue as? Bool) == true {
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    let build   = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    SentrySDK.start { options in
+        options.dsn         = "https://387777a8153aae33cb514deea3601946@o4511164820815872.ingest.us.sentry.io/4511164891529216"
+        options.releaseName = "openemu-silicon@\(version)+\(build)"
+        options.environment = "production"
+        options.debug       = false
+    }
+}
 
 if let wait = ProcessInfo.processInfo.environment["OE_HELPER_WAIT_FOR_DEBUGGER"] as? NSString, wait.boolValue {
     XPCDebugSupport.waitForDebugger(until: .distantFuture)

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -141,11 +141,32 @@ echo "Archive: $ARCHIVE_PATH"
 step "Uploading dSYMs to Sentry (symbolicated crash reports)"
 
 if command -v sentry-cli &>/dev/null; then
+  # Upload host app + framework dSYMs from the archive
   sentry-cli debug-files upload \
     --org openemu-silicon \
     --project openemu-silicon \
     "$ARCHIVE_PATH/dSYMs/" \
     || echo "WARNING: dSYM upload to Sentry failed — crash stack traces may be unreadable. Check sentry-cli auth."
+
+  # Upload core plugin dSYMs from DerivedData (Xcode does not copy them into the archive).
+  # Find the DerivedData folder for this workspace by matching the OpenEmu-metal prefix.
+  DERIVED_DATA=$(find ~/Library/Developer/Xcode/DerivedData -maxdepth 1 -name "OpenEmu-metal-*" -type d 2>/dev/null | head -1)
+  if [ -n "$DERIVED_DATA" ]; then
+    CORE_DSYM_DIR="$DERIVED_DATA/Build/Products/Release"
+    mapfile -d '' CORE_DSYMS < <(find "$CORE_DSYM_DIR" -maxdepth 1 -name "*.oecoreplugin.dSYM" -type d -print0 2>/dev/null)
+    if [ "${#CORE_DSYMS[@]}" -gt 0 ]; then
+      echo "Uploading ${#CORE_DSYMS[@]} core plugin dSYM(s)..."
+      sentry-cli debug-files upload \
+        --org openemu-silicon \
+        --project openemu-silicon \
+        "${CORE_DSYMS[@]}" \
+        || echo "WARNING: Core plugin dSYM upload failed — core crash traces may be unsymbolicated."
+    else
+      echo "NOTE: No core plugin dSYMs found in DerivedData. Build the full workspace in Release first."
+    fi
+  else
+    echo "NOTE: DerivedData folder for OpenEmu-metal not found — skipping core plugin dSYM upload."
+  fi
 else
   echo "WARNING: sentry-cli not installed. Crash stack traces in Sentry will not be symbolicated."
   echo "         Install with: brew install getsentry/tools/sentry-cli"


### PR DESCRIPTION
## What does this PR do?

Fixes two gaps that caused fatal crashes in the XPC game-core helper process to appear in Sentry with empty stack traces (just `at <unknown> (<unknown>)`). Adds Sentry crash reporting to the helper process itself, and updates the release script to also upload core plugin dSYMs that Xcode omits from the archive.

## What did you test?

- Built and launched the app in Debug; confirmed `OpenEmuHelperApp` binary now contains Sentry symbols (`nm` verified).
- Confirmed `release.sh` dSYM upload block now includes `.oecoreplugin.dSYM` files from DerivedData.
- Verified consent check reads correctly from the host app's preference domain via `CFPreferencesCopyValue`.

## Which cores or systems are affected?

General app change — affects crash reporting for all cores running in the XPC helper process.

## Did you use AI tools?

Used Claude to identify the two root causes (missing XPC-helper Sentry init and missing core dSYM uploads), write the fixes, and verify the build. Reviewed and tested myself.

## Linked issues

Related to #329

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 398 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [ ] No build logs, binaries, or credentials committed
- [ ] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header