### PR TITLE
fix: ScreenScraper auth 403 — verify credentials on save and fix fallback chain

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -200,11 +200,12 @@ final class GameInfoHelper {
                 // FIX: pass full filename (including extension) so ScreenScraper
                 // can differentiate ROMs sharing names across systems.
                 let romName = url?.lastPathComponent
-                if case .success(let ss) = ScreenScraperClient.shared.fetchGameInfo(
+                let ssResult = ScreenScraperClient.shared.fetchGameInfo(
                     md5: md5,
                     romName: romName,
                     systemIdentifier: systemIdentifier
-                ), let ss = ss {
+                )
+                if case .success(let ss) = ssResult, let ss = ss {
                     if let boxURL = ss.boxImageURL {
                         resultDict["boxImageURL"] = boxURL.absoluteString
                     }
@@ -224,8 +225,16 @@ final class GameInfoHelper {
                     }
                 }
 
-                // ScreenScraper (+ libretro fallback) handled it; no need for fuzzy fallback.
-                return resultDict
+                // Only skip the fuzzy fallback when ScreenScraper actually responded
+                // (success or not-found). If SS returned a hard error (bad credentials,
+                // network down, rate limited), fall through so fuzzy OpenVGDB + libretro
+                // still have a chance to find art.
+                switch ssResult {
+                case .success:
+                    return resultDict
+                case .failure:
+                    break  // fall through to fuzzy path below
+                }
             }
 
             // --- Advanced fuzzy fallback (only for users NOT logged in to ScreenScraper) ---

--- a/OpenEmu/PrefScreenScraperController.swift
+++ b/OpenEmu/PrefScreenScraperController.swift
@@ -192,15 +192,20 @@ final class PrefScreenScraperController: NSViewController {
         let isSignedIn = !username.isEmpty && ScreenScraperCredentials.hasStoredPassword()
 
         if isSignedIn {
-            // Show the last fetch error if one occurred, so users know why art lookup failed
+            // Show the last fetch error if one occurred, so users know why art lookup failed.
+            // If no fetch has been attempted yet, show a neutral "credentials saved" state
+            // rather than a green "signed in" that implies verified authentication.
             Task { @MainActor in
                 if let fetchError = ScreenScraperClient.shared.lastFetchError,
                    let description = fetchError.errorDescription {
                     self.statusLabel.stringValue = description
                     self.statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
-                } else {
+                } else if ScreenScraperClient.shared.hasVerifiedCredentials {
                     self.statusLabel.stringValue = "✓  Signed in as \(username)"
                     self.statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+                } else {
+                    self.statusLabel.stringValue = "Credentials saved — not yet verified. Save to confirm."
+                    self.statusLabel.textColor = .secondaryLabelColor
                 }
             }
         } else {
@@ -213,7 +218,7 @@ final class PrefScreenScraperController: NSViewController {
 
     @objc private func saveCredentials() {
         let username = usernameField.stringValue.trimmingCharacters(in: .whitespaces)
-        let password = passwordField.stringValue
+        let password = passwordField.stringValue.trimmingCharacters(in: .whitespaces)
 
         guard !username.isEmpty else {
             statusLabel.stringValue = "Username cannot be empty."
@@ -230,7 +235,31 @@ final class PrefScreenScraperController: NSViewController {
         ScreenScraperCredentials.storePassword(password)
         passwordField.stringValue = ""
         passwordField.placeholderString = "••••••••  (saved)"
-        updateStatus()
+
+        saveButton.isEnabled = false
+        clearButton.isEnabled = false
+        statusLabel.stringValue = "Verifying credentials…"
+        statusLabel.textColor = .secondaryLabelColor
+
+        Task { @MainActor in
+            do {
+                let ok = try await ScreenScraperClient.shared.verifyCredentials(username: username, password: password)
+                if ok {
+                    // Clear any prior fetch error so the pane reflects the fresh verification.
+                    ScreenScraperClient.shared.clearLastFetchError()
+                    statusLabel.stringValue = "✓  Signed in as \(username)"
+                    statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+                } else {
+                    statusLabel.stringValue = "ScreenScraper rejected these credentials. Check your username and password."
+                    statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
+                }
+            } catch {
+                statusLabel.stringValue = "Could not reach ScreenScraper — check your connection."
+                statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
+            }
+            saveButton.isEnabled = true
+            clearButton.isEnabled = true
+        }
     }
 
     @objc private func clearCredentials() {

--- a/OpenEmu/ScreenScraperClient.swift
+++ b/OpenEmu/ScreenScraperClient.swift
@@ -65,6 +65,34 @@ final class ScreenScraperClient {
     /// Updated on every call to fetchGameInfo. Thread-safe via main-queue dispatch.
     @MainActor private(set) var lastFetchError: ScreenScraperFetchError?
 
+    /// True once verifyCredentials() has returned success this session.
+    /// Lets the Cover Art pane distinguish "credentials saved but unverified"
+    /// from "credentials confirmed by ScreenScraper."
+    @MainActor private(set) var hasVerifiedCredentials: Bool = false
+
+    @MainActor func clearLastFetchError() { lastFetchError = nil }
+
+    /// Verify that a username/password pair is accepted by ScreenScraper.
+    /// Calls ssuserInfos.php — lightweight, does not burn game-lookup quota.
+    /// Returns true on 2xx, false on 403, throws on network error.
+    func verifyCredentials(username: String, password: String) async throws -> Bool {
+        var components = URLComponents(string: "https://www.screenscraper.fr/api2/ssuserInfos.php")!
+        components.queryItems = [
+            URLQueryItem(name: "devid",       value: ScreenScraperClient.devID),
+            URLQueryItem(name: "devpassword", value: ScreenScraperClient.devPassword),
+            URLQueryItem(name: "ssid",        value: username),
+            URLQueryItem(name: "sspassword",  value: password),
+            URLQueryItem(name: "output",      value: "json"),
+            URLQueryItem(name: "softname",    value: "OpenEmu-Silicon"),
+        ]
+        guard let url = components.url else { return false }
+        let (_, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse else { return false }
+        let ok = (200..<300).contains(http.statusCode)
+        if ok { await MainActor.run { hasVerifiedCredentials = true } }
+        return ok
+    }
+
     // ScreenScraper numeric system IDs keyed by OpenEmu system identifier
     static let systemIDs: [String: Int] = [
         // Nintendo
@@ -255,7 +283,10 @@ final class ScreenScraperClient {
 
             let parsed = self.parseGameInfo(jeu: jeu)
             fetchResult = .success(parsed)
-            Task { @MainActor in self.lastFetchError = nil }
+            Task { @MainActor in
+                self.lastFetchError = nil
+                self.hasVerifiedCredentials = true
+            }
         }
 
         task.resume()


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in the cover art pipeline triggered by ScreenScraper authentication failures. First, the Cover Art preferences pane showed a false green "Signed in" status immediately on save without making any network call — users only discovered their credentials were wrong when an import failed. Second, when ScreenScraper returned a hard error (403, network failure, rate limit), an unconditional early return blocked the fuzzy OpenVGDB and libretro-thumbnails fallbacks from running, making it look like all three tiers had failed.

## What did you test?

- Entered correct ScreenScraper credentials → Save now shows "Verifying…" then green ✓
- Entered wrong credentials → Save shows red rejection error immediately
- With valid credentials, triggered cover art download on a previously failing game → succeeded
- Confirmed fallback chain behaviour is preserved when SS is unavailable

## Which cores or systems are affected?

General app change — cover art / metadata pipeline.

## Did you use AI tools?

Used Claude to investigate root cause, draft and test the fix.

## Linked issues

Fixes #397

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 401 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20
DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
open "$DEBUG_DIR/OpenEmu.app"
```

The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.

If this PR touches a core, install it before the `open` line:

```bash
cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
codesign --force --sign - \
  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
```

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header