### PR TITLE
fix: embed Arcade.oesystemplugin in app bundle so Arcade appears in Library

### DIFF
--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		8763A38F1D5694E90089C30B /* OEArcadeSystemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763A38E1D5694E90089C30B /* OEArcadeSystemController.swift */; };
 		877EDD191E24BC63004D68E7 /* Controller-Preferences-JAP.plist in Resources */ = {isa = PBXBuildFile; fileRef = 877EDD141E24BC63004D68E7 /* Controller-Preferences-JAP.plist */; };
 		877EDD231E24BEE0004D68E7 /* Controller-Preferences-JAP.plist in Resources */ = {isa = PBXBuildFile; fileRef = 877EDD1E1E24BEE0004D68E7 /* Controller-Preferences-JAP.plist */; };
+		1BB9BDE24AAA476991EB4F41 /* Arcade.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 945E42FB1517F2B500057D08 /* Arcade.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		87BD9E241C2A66B1006722DF /* Atari 5200.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 94A224B31707544100098DA0 /* Atari 5200.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		87BD9E251C2A66BC006722DF /* Atari 7800.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 941F5A0117A785AD0005D7EA /* Atari 7800.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		87BD9E261C2A66CE006722DF /* Lynx.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 94A22453170753C800098DA0 /* Lynx.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1078,6 +1079,7 @@
 				87BD9E271C2A66DC006722DF /* ColecoVision.oesystemplugin in Copy System Plugins to App Plugins */,
 				87BD9E261C2A66CE006722DF /* Lynx.oesystemplugin in Copy System Plugins to App Plugins */,
 				87BD9E251C2A66BC006722DF /* Atari 7800.oesystemplugin in Copy System Plugins to App Plugins */,
+				1BB9BDE24AAA476991EB4F41 /* Arcade.oesystemplugin in Copy System Plugins to App Plugins */,
 				87BD9E241C2A66B1006722DF /* Atari 5200.oesystemplugin in Copy System Plugins to App Plugins */,
 				946C7ABB19EE4AF4000F9466 /* Atari 2600.oesystemplugin in Copy System Plugins to App Plugins */,
 				94CEB29C17A8D507005A2107 /* Sega 32X.oesystemplugin in Copy System Plugins to App Plugins */,


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

Closes #391.

`Arcade.oesystemplugin` was compiled as a build target but was never added to the **"Copy System Plugins to App Plugins"** build phase. Every other system plugin (NES, SNES, Genesis, C64, Dreamcast, etc.) is listed there; Arcade was simply missing.

At startup, `OEPlugin.plugins()` discovers bundled system plugins by scanning `Contents/PlugIns/Systems/*.oesystemplugin` inside the app bundle. Because `Arcade.oesystemplugin` was never copied there, `OESystemPlugin.allPlugins` never returned it, `loadPlugins(with:)` never created an `OEDBSystem` Core Data record for it, and Arcade never appeared in Preferences → Library or the sidebar — regardless of which MAME or FBA RetroArch core the user installed.

## Change

One change to `project.pbxproj`:
- Adds `Arcade.oesystemplugin` (file ref `945E42FB`) to the **Copy System Plugins to App Plugins** build phase with the same `CodeSignOnCopy` + `RemoveHeadersOnCopy` attributes every other system plugin uses.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout 410 --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild   -workspace OpenEmu-metal.xcworkspace   -scheme OpenEmu   -configuration Debug   -destination 'platform=macOS,arch=arm64'   build 2>&1 | tail -20

# 3. Confirm the plugin is in the bundle (prints path if present, nothing if missing)
find ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-azlwhavhbkotiuegjntemrqykbkw   -name 'Arcade.oesystemplugin'
# Expected: …/Contents/PlugIns/Systems/Arcade.oesystemplugin

# 4. Launch (use the exact path, not a glob — multiple DerivedData dirs will open multiple apps)
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-azlwhavhbkotiuegjntemrqykbkw/Build/Products/Debug/OpenEmu.app
```

**Verify:**
- Preferences → Library shows an **Arcade** checkbox (enabled by default on first launch)
- The **Arcade** system appears in the sidebar under Consoles
- Preferences → Cores → Arcade row shows any installed MAME/FBA RetroArch cores as selectable options