### PR TITLE
chore: prune stale DerivedData in verify.sh; fix PR template launch command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,27 +29,15 @@ The PR number below is filled in automatically — just paste the whole block. F
 ```bash
 cd ~/Documents/Cursor/Open\ Emu
 gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
-xcodebuild \
-  -workspace OpenEmu.xcworkspace \
-  -scheme OpenEmu \
-  -configuration Debug \
-  -destination 'platform=macOS,arch=arm64' \
-  build 2>&1 | tail -20
-DEBUG_DIR=$(ls -dt ~/Library/Developer/Xcode/DerivedData/OpenEmu-*/Build/Products/Debug 2>/dev/null | head -1)
-SIGN_ID=$(security find-identity -v -p codesigning | awk -F'"' '/Apple Development/ {print $2; exit}')
-codesign --force --deep --sign "${SIGN_ID:--}" "$DEBUG_DIR/OpenEmu.app"
-open "$DEBUG_DIR/OpenEmu.app"
+./Scripts/verify.sh          # builds, prunes stale DerivedData, codesign-checks
+./Scripts/launch-debug.sh    # launches the freshest Debug build safely (no glob)
 ```
 
-The `SIGN_ID` line auto-picks your local Apple Development identity so the binary gets a **stable** code signature across rebuilds. Without it, ad-hoc signing (`-`) would cause macOS to treat each rebuild as a new app and revoke Input Monitoring, Keychain ACLs, and other TCC permissions every time you test. Falls back to ad-hoc only if you have no Apple Development cert.
-
-If this PR touches a core, install it before the `open` line:
+If this PR touches a core, install it before launching:
 
 ```bash
-cp -R "$DEBUG_DIR/<CoreName>.oecoreplugin" \
-  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
-codesign --force --sign - \
-  ~/Library/Application\ Support/OpenEmu/Cores/<CoreName>.oecoreplugin
+./Scripts/install-core.sh <CoreName>   # quits OpenEmu, copies correctly, re-signs
+./Scripts/launch-debug.sh
 ```
 
 <!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->
@@ -59,7 +47,7 @@ codesign --force --sign - \
 ## PR checklist
 
 - [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
-- [ ] Build passes: `xcodebuild -workspace OpenEmu.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
+- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
 - [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
 - [ ] No build logs, binaries, or credentials committed
 - [ ] Copyright headers preserved on all modified files

--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -93,6 +93,33 @@ pass() { echo "PASS  $1"; }
 fail() { echo "FAIL  $1"; FAILURES=$((FAILURES+1)); }
 info() { echo "----  $1"; }
 
+# --- Prune stale DerivedData directories -----------------------------------
+# Xcode rotates OpenEmu-metal-<hash> whenever the workspace path or scheme
+# hash changes, leaving old dirs behind. Keeping only the newest means that
+# `open ... OpenEmu-metal-*/...` globs never accidentally open multiple apps.
+# Worktree builds go to ~/Builds/openemu/<branch>/ and are unaffected.
+if [ "$WORKTREE" -eq 0 ]; then
+  DD="$HOME/Library/Developer/Xcode/DerivedData"
+  pruned=0
+  newest=""
+  while IFS= read -r dir; do
+    if [ -z "$newest" ]; then
+      newest="$dir"
+    else
+      rm -rf "$dir"
+      pruned=$((pruned+1))
+    fi
+  done < <(
+    find "$DD" -maxdepth 1 -name 'OpenEmu-metal-*' -type d -print0 2>/dev/null \
+      | xargs -0 stat -f '%m %N' 2>/dev/null \
+      | sort -rn \
+      | awk '{print $2}'
+  )
+  if [ $pruned -gt 0 ]; then
+    info "pruned $pruned stale DerivedData dir(s); keeping $(basename "${newest:-none}")"
+  fi
+fi
+
 # --- Core feed-URL guardrail (precondition for --core runs) --------------
 
 if [ -n "$CORE" ] && [ -x "./Scripts/check-core-feed-urls.sh" ]; then


### PR DESCRIPTION
> *This was generated by AI during triage.*

## What does this PR do?

Two housekeeping fixes that came out of testing PR #410:

**1. verify.sh prunes stale DerivedData dirs on every run**

Xcode rotates the `OpenEmu-metal-<hash>` DerivedData directory whenever the workspace path or scheme hash changes. Old dirs are left behind. When the PR template told contributors to run `open .../OpenEmu-metal-*/...`, the shell glob matched one app per stale dir, opening 5+ copies simultaneously.

`verify.sh` now prunes all but the newest `OpenEmu-metal-*` dir at the top of every run, before the build step. This is a one-time cleanup on first use, then stays tidy. Worktree builds (`~/Builds/openemu/<branch>/`) are unaffected.

**2. PR template uses `./Scripts/launch-debug.sh` instead of the glob**

`launch-debug.sh` already handles multiple DerivedData dirs correctly (picks the branch-matched or newest app). The template now directs contributors to use it instead of the raw glob. Also fixed:
- Wrong workspace name: `OpenEmu.xcworkspace` → `OpenEmu-metal.xcworkspace`
- Removed `cp -Rf` core install block (AGENTS.md forbids it; replaced with `install-core.sh`)
- Removed a now-orphaned SIGN_ID paragraph

## How to test locally

```bash
gh pr checkout 411 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

**Verify:**
- If you have multiple `OpenEmu-metal-*` dirs in DerivedData before running, only one remains after `verify.sh` completes
- `launch-debug.sh` opens exactly one OpenEmu app