### PR TITLE
fix: replace hardcoded dark sidebar/window colors with adaptive NSColor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,16 +29,20 @@ The PR number below is filled in automatically — just paste the whole block. F
 ```bash
 cd ~/Documents/Cursor/Open\ Emu
 gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
-./Scripts/verify.sh          # builds, prunes stale DerivedData, codesign-checks
-./Scripts/launch-debug.sh    # launches the freshest Debug build safely (no glob)
+./Scripts/verify.sh
+./Scripts/launch-debug.sh
 ```
+
+`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).
 
 If this PR touches a core, install it before launching:
 
 ```bash
-./Scripts/install-core.sh <CoreName>   # quits OpenEmu, copies correctly, re-signs
+./Scripts/install-core.sh <CoreName>
 ./Scripts/launch-debug.sh
 ```
+
+`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.
 
 <!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->
 

--- a/OpenEmu/LibraryGamesViewController.swift
+++ b/OpenEmu/LibraryGamesViewController.swift
@@ -108,7 +108,37 @@ final class LibraryGamesViewController: NSSplitViewController {
             sidebarItem.titlebarSeparatorStyle = .automatic
         }
         addSplitViewItem(sidebarItem)
-        
+
+        // The NSSplitViewItem sidebar wrapper spans the full left pane but the
+        // SidebarController's view may not cover its bottom edge (xib gap between
+        // the scroll view and the game-scanner panel). The system's
+        // NSVisualEffectView behind the wrapper samples the desktop colour, which
+        // renders dark on a dark wallpaper even in light mode.
+        //
+        // Fix: attach an NSBox directly to the wrapper so it covers every pixel
+        // of the pane. Clear in dark mode so it never touches the vibrancy
+        // compositor (an opaque fill in dark mode causes ghost-toolbar artifacts).
+        if let sidebarWrapper = splitView.subviews.first {
+            let gapFill = NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? .clear
+                    : NSColor(white: 0.88, alpha: 1)
+            }
+            let bg = NSBox()
+            bg.boxType = .custom
+            bg.borderWidth = 0
+            bg.contentViewMargins = .zero
+            bg.fillColor = gapFill
+            bg.translatesAutoresizingMaskIntoConstraints = false
+            sidebarWrapper.addSubview(bg, positioned: .below, relativeTo: nil)
+            NSLayoutConstraint.activate([
+                bg.topAnchor.constraint(equalTo: sidebarWrapper.topAnchor),
+                bg.bottomAnchor.constraint(equalTo: sidebarWrapper.bottomAnchor),
+                bg.leadingAnchor.constraint(equalTo: sidebarWrapper.leadingAnchor),
+                bg.trailingAnchor.constraint(equalTo: sidebarWrapper.trailingAnchor),
+            ])
+        }
+
         let collectionItem = NSSplitViewItem(viewController: collectionController)
         collectionItem.minimumThickness = collectionViewMinWidth
         if #available(macOS 11.0, *) {

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -167,8 +167,10 @@ final class MainWindowController: NSWindowController {
         window?.restorationClass = type(of: self)
         window?.titlebarAppearsTransparent = true
         window?.styleMask.insert(.fullSizeContentView)
-        // Lock in the dark content-area background regardless of OS version
-        window?.backgroundColor = NSColor(white: 0.15, alpha: 1)
+        // Adaptive window background: dark charcoal in dark mode, standard light in light/system mode.
+        if let window = window {
+            window.backgroundColor = Self.adaptiveWindowBackground(for: window.effectiveAppearance)
+        }
 
         assert(window?.identifier == .mainWindow, "Main library window identifier does not match between nib and code")
     }
@@ -399,6 +401,17 @@ extension MainWindowController: LibraryControllerDelegate {
 }
 
 extension MainWindowController: NSWindowDelegate {
+
+    func windowDidChangeEffectiveAppearance(_ window: NSWindow) {
+        window.backgroundColor = Self.adaptiveWindowBackground(for: window.effectiveAppearance)
+    }
+
+    private static func adaptiveWindowBackground(for appearance: NSAppearance) -> NSColor {
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(white: 0.15, alpha: 1)
+            : .windowBackgroundColor
+    }
+
     
     func windowDidBecomeKey(_ notification: Notification) {
         currentContentController?.viewWillAppear()

--- a/OpenEmu/OECollectionViewController.m
+++ b/OpenEmu/OECollectionViewController.m
@@ -42,6 +42,7 @@ NSString * const OELastGridSizeKey       = @"lastGridSize";
 NSString * const OELastCollectionViewKey = @"lastCollectionView";
 
 static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGameTitleKVOContext;
+static void *OEViewEffectiveAppearanceKVOContext      = &OEViewEffectiveAppearanceKVOContext;
 
 @implementation NSDate (OESortAdditions)
 
@@ -133,8 +134,7 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
     [_gridView setDataSource:self];
     [_gridView setDraggingDestinationDelegate:self];
     [_gridView setCellSize:defaultGridSize];
-    [_gridView setValue:[NSColor clearColor] forKey:IKImageBrowserBackgroundColorKey];
-    [[_gridView enclosingScrollView] setDrawsBackground:NO];
+    [self oe_updateCollectionBackground];
     
     // Set up list view
     [listView setTarget:self];
@@ -146,8 +146,7 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
     [listView setSortDescriptors:[self defaultSortDescriptors]];
     [listView setAllowsMultipleSelection:YES];
     [listView registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
-    [listView setBackgroundColor:[NSColor clearColor]];
-    [[listView enclosingScrollView] setDrawsBackground:NO];
+    // Background applied via oe_updateCollectionBackground above.
 
     // Setup BlankSlate View
     [blankSlateView setDelegate:self];
@@ -159,6 +158,13 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
     if ([self representedObject])
         [self reloadData];
     
+    // KVO on effectiveAppearance so we re-apply the background whenever the
+    // app switches between dark and light mode at runtime.
+    [self.view addObserver:self
+               forKeyPath:@"effectiveAppearance"
+                  options:NSKeyValueObservingOptionNew
+                  context:OEViewEffectiveAppearanceKVOContext];
+
     NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
     [standardUserDefaults addObserver:self
                            forKeyPath:OEDBGame.displayGameTitleKey
@@ -172,6 +178,43 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
     [notificationCenter addObserver:self selector:@selector(OE_managedObjectContextDidUpdate:) name:NSManagedObjectContextDidSaveNotification object:context];
     
     [notificationCenter addObserver:self selector:@selector(libraryLocationDidChange:) name:OELibraryDatabase.locationDidChangeNotification object:nil];
+}
+
+/// Returns the appropriate solid background color for the current effective appearance.
+/// IKImageBrowserView composites onto a black render target, so a transparent (clear)
+/// background produces an always-dark result. We resolve an explicit color here instead.
+- (BOOL)oe_isEffectiveAppearanceDark
+{
+    NSAppearance *app = self.view.window ? self.view.effectiveAppearance : NSApp.effectiveAppearance;
+    NSAppearanceName match = [app bestMatchFromAppearancesWithNames:
+                              @[NSAppearanceNameDarkAqua, NSAppearanceNameAqua]];
+    return [match isEqualToString:NSAppearanceNameDarkAqua];
+}
+
+- (void)oe_updateCollectionBackground
+{
+    if ([self oe_isEffectiveAppearanceDark]) {
+        // Dark mode: restore original behaviour. IKImageBrowserView's Metal
+        // compositor composites against the dark window background when the
+        // background colour key is clear; an explicit solid colour causes it
+        // to incorrectly blend the titlebar layer into its output (ghost
+        // toolbar artifacts when the window is active).
+        [_gridView setValue:NSColor.clearColor forKey:IKImageBrowserBackgroundColorKey];
+        [_gridView enclosingScrollView].drawsBackground = NO;
+        listView.backgroundColor = NSColor.clearColor;
+        [listView enclosingScrollView].drawsBackground = NO;
+    } else {
+        // Light mode: supply explicit colours so the views don't render dark
+        // against a light window background.
+        NSColor *bg = NSColor.windowBackgroundColor;
+        [_gridView setValue:bg forKey:IKImageBrowserBackgroundColorKey];
+        [_gridView enclosingScrollView].backgroundColor = bg;
+        [_gridView enclosingScrollView].drawsBackground = YES;
+        [_gridView setNeedsDisplay:YES];
+        listView.backgroundColor = NSColor.controlBackgroundColor;
+        [listView enclosingScrollView].backgroundColor = NSColor.controlBackgroundColor;
+        [listView enclosingScrollView].drawsBackground = YES;
+    }
 }
 
 - (void)viewDidAppear
@@ -201,6 +244,15 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
     if(context == OEUserDefaultsDisplayGameTitleKVOContext)
     {
         [self setNeedsReloadVisible];
+    }
+    else if(context == OEViewEffectiveAppearanceKVOContext)
+    {
+        // Defer until the runloop finishes. The KVO can fire during addSubview:
+        // while the split view hierarchy is still assembling, and calling into
+        // IKImageBrowserView via KVC at that moment throws internally.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self oe_updateCollectionBackground];
+        });
     }
     else
     {

--- a/OpenEmu/SidebarController.swift
+++ b/OpenEmu/SidebarController.swift
@@ -106,9 +106,14 @@ final class SidebarController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Lock in the dark charcoal sidebar background regardless of OS version
-        sidebarView.backgroundColor = NSColor(white: 0.13, alpha: 1)
-        sidebarView.enclosingScrollView?.backgroundColor = NSColor(white: 0.13, alpha: 1)
+        // Adaptive sidebar background: dark charcoal in dark mode, light gray in light/system mode.
+        let sidebarBG = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                ? NSColor(white: 0.13, alpha: 1)
+                : NSColor(white: 0.94, alpha: 1)
+        }
+        sidebarView.backgroundColor = sidebarBG
+        sidebarView.enclosingScrollView?.backgroundColor = sidebarBG
         sidebarView.enclosingScrollView?.drawsBackground = true
 
         sidebarView.registerForDraggedTypes([.fileURL, .game])

--- a/OpenEmu/SidebarController.swift
+++ b/OpenEmu/SidebarController.swift
@@ -106,14 +106,14 @@ final class SidebarController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Adaptive sidebar background: dark charcoal in dark mode, light gray in light/system mode.
-        let sidebarBG = NSColor(name: nil) { appearance in
+        // Adaptive sidebar color for the outline view rows and scroll view fill.
+        let sidebarColor = NSColor(name: nil) { appearance in
             appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
                 ? NSColor(white: 0.13, alpha: 1)
-                : NSColor(white: 0.94, alpha: 1)
+                : NSColor(white: 0.88, alpha: 1)
         }
-        sidebarView.backgroundColor = sidebarBG
-        sidebarView.enclosingScrollView?.backgroundColor = sidebarBG
+        sidebarView.backgroundColor = sidebarColor
+        sidebarView.enclosingScrollView?.backgroundColor = sidebarColor
         sidebarView.enclosingScrollView?.drawsBackground = true
 
         sidebarView.registerForDraggedTypes([.fileURL, .game])


### PR DESCRIPTION
## What does this PR do?

Makes the app look correct when the Appearance preference is set to **System** on a Mac running macOS in light mode. Previously, hardcoded near-black colours in the sidebar, main window, and game grid produced a near-black UI against a light window chrome. This PR replaces every hardcoded dark colour with adaptive values that resolve correctly in both dark and light mode.

## What did you test?

- Light mode (System appearance): sidebar, game grid, and window background all render with appropriate light colours. The dark strip below the sidebar list is gone.
- Dark mode (System or Dark appearance): original charcoal sidebar and dark grid are unchanged. No ghost-toolbar artifacts when the window is active.
- Switching appearance at runtime (via Secrets pane) correctly updates all areas.

## Which cores or systems are affected?

General app change — no cores affected.

## Did you use AI tools?

Used Claude Code to diagnose, implement, and iterate the fix through several rounds of testing. All changes reviewed before shipping.

## Linked issues

Fixes #405

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 413 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

**To verify the fix:**
1. In macOS System Settings → Appearance, set to **Light**
2. Run `defaults write org.openemu.OpenEmu OEAppearance 0` (selects System appearance in OpenEmu)
3. Launch OpenEmu — sidebar, game grid, and window background should all be light
4. Confirm no dark strip at the bottom of the sidebar

**Regression check (dark mode):**
1. Set macOS appearance to **Dark** (or set OEAppearance back to 1)
2. Sidebar should be dark charcoal, grid dark — identical to before
3. Click the window to make it active — confirm no ghost-toolbar artifacts

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M4 Mac mini)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header