### PR TITLE
fix: Sentry App Hang fixes + dSYM upload for core releases

### DIFF
--- a/.claude/commands/release-core.md
+++ b/.claude/commands/release-core.md
@@ -157,6 +157,33 @@ saved to the wrong path, the build cached an old binary, or
 Info.plist. Investigate before continuing — do not edit the appcast to
 match a wrong zip.
 
+### Step 7c — Upload dSYM to Sentry
+
+```bash
+if command -v sentry-cli &>/dev/null; then
+  DERIVED_DATA=$(find ~/Library/Developer/Xcode/DerivedData \
+    -maxdepth 1 -name "OpenEmu-metal-*" -type d 2>/dev/null | head -1)
+  if [ -n "$DERIVED_DATA" ]; then
+    DSYM="$DERIVED_DATA/Build/Products/Release/<CoreName>.oecoreplugin.dSYM"
+    if [ -d "$DSYM" ]; then
+      sentry-cli debug-files upload \
+        --org openemu-silicon \
+        --project openemu-silicon \
+        "$DSYM" && echo "dSYM uploaded to Sentry" \
+        || echo "WARNING: dSYM upload failed — check sentry-cli auth"
+    else
+      echo "WARNING: dSYM not found at $DSYM — build may not have produced one"
+    fi
+  else
+    echo "WARNING: DerivedData for OpenEmu-metal not found — skipping dSYM upload"
+  fi
+else
+  echo "WARNING: sentry-cli not installed — install with: brew install getsentry/tools/sentry-cli"
+fi
+```
+
+Non-fatal: warns but does not abort the release.
+
 ## Step 8 — Determine the release tag
 
 Check existing cores releases:

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -338,9 +338,10 @@ extension MainWindowController: LibraryControllerDelegate {
                         alert.informativeText = NSLocalizedString("Sometimes a crash may occur while loading a save state because of incompatibilities between different versions of the same core. Do you want to open the game without loading a save state?", comment: "")
                         alert.defaultButtonTitle = NSLocalizedString("Reopen without loading state", comment: "")
                         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
-                        let resp = alert.runModal()
-                        if resp == .alertFirstButtonReturn {
-                            self.openGameDocument(with: state?.rom?.game, saveState: nil, secondAttempt: true, disableAutoReload: true)
+                        alert.beginSheetModal(for: window) { response in
+                            if response == .alertFirstButtonReturn {
+                                self.openGameDocument(with: state?.rom?.game, saveState: nil, secondAttempt: true, disableAutoReload: true)
+                            }
                         }
                     } else {
                         alert.messageText = String(format: NSLocalizedString("The %@ core has quit unexpectedly", comment: ""), coreName)
@@ -353,7 +354,7 @@ extension MainWindowController: LibraryControllerDelegate {
                             alert.messageUsesHTML = true
                         }
                         alert.defaultButtonTitle = NSLocalizedString("OK", comment: "")
-                        alert.runModal()
+                        alert.beginSheetModal(for: window) { _ in }
                     }
                 }
                 else if let error = error as NSError?, !(error.domain == NSCocoaErrorDomain && error.code == NSUserCancelledError) {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -503,17 +503,16 @@ final class OEGameDocument: NSDocument {
                 alert.defaultButtonTitle = NSLocalizedString("Play Game", comment: "")
                 alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
                 
-                if alert.runModal() == .alertFirstButtonReturn {
+                // Ugly hack to start imported games in main window
+                let mainWindowController = (NSApp.delegate as! AppDelegate).mainWindowController
+                alert.beginSheetModal(for: mainWindowController.window!) { response in
+                    guard response == .alertFirstButtonReturn else { return }
                     let rom = OEDBRom.object(with: romID, in: context)!
-                    
-                    // Ugly hack to start imported games in main window
-                    let mainWindowController = (NSApp.delegate as! AppDelegate).mainWindowController
                     if !mainWindowController.mainWindowRunsGame {
                         mainWindowController.startGame(rom.game)
                     } else {
                         if let url = rom.url {
-                            NSDocumentController.shared.openDocument(withContentsOf: url, display: false) { document, documentWasAlreadyOpen, error in
-                            }
+                            NSDocumentController.shared.openDocument(withContentsOf: url, display: false) { _, _, _ in }
                         }
                     }
                 }
@@ -1859,10 +1858,21 @@ final class OEGameDocument: NSDocument {
                     coreName: corePlugin.displayName,
                     savedVersion: savedVersion,
                     installedVersion: corePlugin.version)
-                if alert.runModal() == .alertFirstButtonReturn {
-                    loadState()
+                if let win = gameWindowController?.window {
+                    alert.beginSheetModal(for: win) { [weak self] response in
+                        guard let self else { return }
+                        if response == .alertFirstButtonReturn {
+                            self.loadState()
+                        } else {
+                            self.startEmulation()
+                        }
+                    }
                 } else {
-                    startEmulation()
+                    if alert.runModal() == .alertFirstButtonReturn {
+                        loadState()
+                    } else {
+                        startEmulation()
+                    }
                 }
             } else {
                 loadState()

--- a/OpenEmu/PrefScreenScraperController.swift
+++ b/OpenEmu/PrefScreenScraperController.swift
@@ -181,36 +181,46 @@ final class PrefScreenScraperController: NSViewController {
 
     private func loadSavedCredentials() {
         usernameField.stringValue = UserDefaults.standard.string(forKey: "ScreenScraperUsername") ?? ""
-        // Password is in Keychain — show placeholder only, don't pre-fill for security
-        if ScreenScraperCredentials.hasStoredPassword() {
-            passwordField.placeholderString = "••••••••  (saved)"
+        // SecItemCopyMatching blocks on Security daemon — do not call on main thread.
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let hasPassword = ScreenScraperCredentials.hasStoredPassword()
+            await MainActor.run {
+                if hasPassword {
+                    self.passwordField.placeholderString = "••••••••  (saved)"
+                }
+            }
         }
     }
 
     private func updateStatus() {
         let username = UserDefaults.standard.string(forKey: "ScreenScraperUsername") ?? ""
-        let isSignedIn = !username.isEmpty && ScreenScraperCredentials.hasStoredPassword()
-
-        if isSignedIn {
-            // Show the last fetch error if one occurred, so users know why art lookup failed.
-            // If no fetch has been attempted yet, show a neutral "credentials saved" state
-            // rather than a green "signed in" that implies verified authentication.
-            Task { @MainActor in
-                if let fetchError = ScreenScraperClient.shared.lastFetchError,
-                   let description = fetchError.errorDescription {
-                    self.statusLabel.stringValue = description
-                    self.statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
-                } else if ScreenScraperClient.shared.hasVerifiedCredentials {
-                    self.statusLabel.stringValue = "✓  Signed in as \(username)"
-                    self.statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+        // SecItemCopyMatching blocks on Security daemon — do not call on main thread.
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let hasPassword = ScreenScraperCredentials.hasStoredPassword()
+            await MainActor.run {
+                let isSignedIn = !username.isEmpty && hasPassword
+                if isSignedIn {
+                    // Show the last fetch error if one occurred, so users know why art lookup failed.
+                    // If no fetch has been attempted yet, show a neutral "credentials saved" state
+                    // rather than a green "signed in" that implies verified authentication.
+                    if let fetchError = ScreenScraperClient.shared.lastFetchError,
+                       let description = fetchError.errorDescription {
+                        self.statusLabel.stringValue = description
+                        self.statusLabel.textColor = NSColor(red: 0.87, green: 0.20, blue: 0.18, alpha: 1)
+                    } else if ScreenScraperClient.shared.hasVerifiedCredentials {
+                        self.statusLabel.stringValue = "✓  Signed in as \(username)"
+                        self.statusLabel.textColor = NSColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
+                    } else {
+                        self.statusLabel.stringValue = "Credentials saved — not yet verified. Save to confirm."
+                        self.statusLabel.textColor = .secondaryLabelColor
+                    }
                 } else {
-                    self.statusLabel.stringValue = "Credentials saved — not yet verified. Save to confirm."
+                    self.statusLabel.stringValue = "Not signed in — ScreenScraper will be skipped. OpenVGDB and libretro-thumbnails are still active."
                     self.statusLabel.textColor = .secondaryLabelColor
                 }
             }
-        } else {
-            statusLabel.stringValue = "Not signed in — ScreenScraper will be skipped. OpenVGDB and libretro-thumbnails are still active."
-            statusLabel.textColor = .secondaryLabelColor
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Three Sentry-driven fixes in one branch: stops App Hang reports on macOS Tahoe, moves a Keychain read off the main thread, and ensures future core releases upload dSYMs so core crash stacks are readable in Sentry.

## What did you test?

Built Debug and verified no new errors or warnings. Each change was confirmed against the Sentry stack trace that identified it.

- **Change 1 (dSYM skill):** Skill file change only — no build needed. Verified the bash block matches the pattern in `Scripts/release.sh`.
- **Change 2 (ScreenScraper):** Build passes. Open Preferences → Cover Art and confirm the pane loads without a hang. The "saved" password placeholder still appears after credentials are stored.
- **Change 3 (runModal → sheet):** Build passes. Affected paths are error/edge-case flows (post-import dialog, core crash, save-state version mismatch) that are hard to hit on-demand — confirmed by Sentry stack traces that the right call sites were converted.

## Which cores or systems are affected?

General app change. No core-specific code modified.

## Did you use AI tools?

Yes — Claude Sonnet 4.6 identified the call sites from Sentry stack traces, wrote the fixes, and composed this PR. Reviewed and verified manually.

## Linked issues

Fixes OPENEMU-SILICON-4T
Fixes OPENEMU-SILICON-41
Fixes OPENEMU-SILICON-4Y
Fixes OPENEMU-SILICON-4V

Note: OPENEMU-SILICON-51 (`corePlugin.bundle.loadAndReturnError` blocking via `dlopen`) is a separate issue not addressed here — it needs its own investigation.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header