### PR TITLE
fix: replace OEAlert spin loop with NSApp.runModal to stop App Hang false positives

### DIFF
--- a/OpenEmu/OEAlert.swift
+++ b/OpenEmu/OEAlert.swift
@@ -53,7 +53,8 @@ final class OEAlert: NSObject {
     private(set) var result = NSApplication.ModalResponse(0)
     private(set) var window: NSWindow!
     
-    private var blocks = [(() -> Void)]()
+    // blocks array removed — performBlockInModalSession now dispatches directly
+    // onto the main queue, which NSApp.runModal(for:) processes normally.
     private var sheetMode = false
     private var needsRebuild = true
     
@@ -194,28 +195,12 @@ final class OEAlert: NSObject {
         
         window.animationBehavior = .alertPanel
         
-        window.makeKeyAndOrderFront(nil)
-        
-        let executeBlocks = {
-            DispatchQueue(label: "org.openemu.OEAlert").sync {
-                while !self.blocks.isEmpty {
-                    if let block = self.blocks.first {
-                        block()
-                    }
-                    self.blocks.removeFirst()
-                }
-            }
-            self.layoutWindowIfNeeded()
-        }
-        
-        let session = NSApp.beginModalSession(for: window)
-        while NSApp.runModalSession(session) == .continue {
-            executeBlocks()
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
-        }
-        executeBlocks()
-        
-        NSApp.endModalSession(session)
+        // Use NSApp.runModal(for:) — the proper AppKit modal API.
+        // macOS Tahoe's App Hang watchdog does not flag this path, unlike a
+        // custom beginModalSession/runModalSession spin loop. Any blocks
+        // queued via performBlockInModalSession are dispatched onto the main
+        // queue and execute normally inside NSApp.runModal's event loop.
+        NSApp.runModal(for: window)
         
         window.close()
         
@@ -228,8 +213,10 @@ final class OEAlert: NSObject {
             return
         }
         
-        DispatchQueue(label: "org.openemu.OEAlert").sync {
-            blocks.append(block)
+        // Dispatch onto the main queue so it runs inside NSApp.runModal's event loop.
+        DispatchQueue.main.async {
+            block()
+            self.layoutWindowIfNeeded()
         }
     }
     


### PR DESCRIPTION
## Summary

`OEAlert.runModal()` used a custom `beginModalSession`/`runModalSession` spin loop ticking every 50ms. macOS Tahoe's App Hang watchdog fires after **2000ms of main-thread activity** regardless of whether the loop is processing events — so every alert a user reads for more than 2 seconds was logged as a hang in Sentry.

This was generating the bulk of our open hang issues: OPENEMU-SILICON-4Y, 41, 2E, 54, 53, 51, 4X, 4V, 4T, 4R, 4R, 48 and others. These aren't real UX freezes — they're users reading dialogs.

## Change

Replace the custom spin loop with `NSApp.runModal(for:)`, the proper AppKit modal API, which macOS Tahoe does not flag as a hang. The `performBlockInModalSession` mechanism (used for progress-style alerts) is updated to dispatch directly onto the main queue, which `NSApp.runModal(for:)` processes normally.

**One 12-line change fixes all 60+ `runModal` call sites at the root.** No call site changes needed.

## How to test locally

```bash
gh pr checkout  --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -5

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

**Verify:**
1. Open any game → let a save-state prompt appear → wait 5+ seconds before clicking → confirm no App Hang in Sentry
2. Try: reset system, stop emulation, remove game from library, missing BIOS dialog — all should work normally
3. Import a ROM to exercise the progress-style alert path (`performBlockInModalSession`)

## Related Sentry issues

Closes: OPENEMU-SILICON-4Y, OPENEMU-SILICON-41, OPENEMU-SILICON-2E, OPENEMU-SILICON-54, OPENEMU-SILICON-53, OPENEMU-SILICON-51, OPENEMU-SILICON-4X, OPENEMU-SILICON-4V, OPENEMU-SILICON-4T, OPENEMU-SILICON-4R, OPENEMU-SILICON-48