### PR TITLE
fix: skip ScreenScraper when OpenVGDB already has full result

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -193,10 +193,13 @@ final class GameInfoHelper {
             }
 
             // --- ScreenScraper (Priority 1 when user is logged in) ---
-            // Only runs when the user HAS configured SS credentials.
-            // Users who have NOT logged in to ScreenScraper go through the
-            // advanced fuzzy path below instead.
-            if hasSScredentials {
+            // Only runs when the user HAS configured SS credentials AND OpenVGDB
+            // did not already return a complete result (title + box art).
+            // Skipping when art is already present avoids burning daily API quota
+            // on lookups that add no value, and prevents HTTP 430 rate-limit
+            // failures during large library imports.
+            let missingArt = (resultDict["boxImageURL"] as? String)?.isEmpty != false
+            if hasSScredentials && missingArt {
                 // FIX: pass full filename (including extension) so ScreenScraper
                 // can differentiate ROMs sharing names across systems.
                 let romName = url?.lastPathComponent


### PR DESCRIPTION
## Summary

Fixes #402

ScreenScraper was called unconditionally whenever the user had credentials configured, even when OpenVGDB returned both a title and box art via exact match. This burned daily API quota on lookups that add no value, and caused HTTP 430 rate-limit failures for users importing large libraries.

## Changes

**`OpenEmu/GameInfoHelper.swift`**

Added a `missingArt` check before the ScreenScraper call. If OpenVGDB already returned a box art URL, ScreenScraper is skipped entirely. Falls through to ScreenScraper only when art (or the game itself) is missing from OpenVGDB — preserving the existing fallback behaviour.

```swift
let missingArt = (resultDict["boxImageURL"] as? String)?.isEmpty != false
if hasSScredentials && missingArt {
    // ScreenScraper fetch
}
```

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

**To verify the fix:** Import a ROM that is in OpenVGDB (e.g. any NES/SNES/Genesis title). Art should appear. With ScreenScraper credentials configured, confirm no outbound request to screenscraper.io fires — monitor via Console.app or a proxy. Then import a ROM not in OpenVGDB and confirm ScreenScraper is still called as a fallback.