### PR TITLE
fix: improve ScreenScraper match rate and always run art fallbacks

### DIFF
--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -63,8 +63,9 @@ final class GameInfoHelper {
                 // FIX: preserve the file extension so ScreenScraper can disambiguate
                 // ROMs that share the same name across platforms (e.g. .n64 vs .sfc).
                 let romName = url?.lastPathComponent
+                let romSize = url?.fileSize ?? 0
                 var fallback: [String: Any] = [:]
-                if case .success(let ss) = ScreenScraperClient.shared.fetchGameInfo(md5: md5, romName: romName, systemIdentifier: systemIdentifier), let ss = ss {
+                if case .success(let ss) = ScreenScraperClient.shared.fetchGameInfo(md5: md5, romName: romName, fileSize: romSize, systemIdentifier: systemIdentifier), let ss = ss {
                     if let boxURL = ss.boxImageURL { fallback["boxImageURL"] = boxURL.absoluteString }
                     if let title = ss.gameTitle   { fallback["gameTitle"] = title }
                     if let desc  = ss.gameDescription { fallback["gameDescription"] = desc }
@@ -202,10 +203,14 @@ final class GameInfoHelper {
             if hasSScredentials && missingArt {
                 // FIX: pass full filename (including extension) so ScreenScraper
                 // can differentiate ROMs sharing names across systems.
+                // Also pass file size — significantly boosts SS match accuracy for
+                // ROMs whose MD5 doesn't match (headered/byte-swapped dumps).
                 let romName = url?.lastPathComponent
+                let romSize = url?.fileSize ?? 0
                 let ssResult = ScreenScraperClient.shared.fetchGameInfo(
                     md5: md5,
                     romName: romName,
+                    fileSize: romSize,
                     systemIdentifier: systemIdentifier
                 )
                 if case .success(let ss) = ssResult, let ss = ss {
@@ -228,22 +233,18 @@ final class GameInfoHelper {
                     }
                 }
 
-                // Only skip the fuzzy fallback when ScreenScraper actually responded
-                // (success or not-found). If SS returned a hard error (bad credentials,
-                // network down, rate limited), fall through so fuzzy OpenVGDB + libretro
-                // still have a chance to find art.
-                switch ssResult {
-                case .success:
-                    return resultDict
-                case .failure:
-                    break  // fall through to fuzzy path below
-                }
+                // No early return: fuzzy OpenVGDB + libretro-thumbnails always get
+                // a chance to fill in missing art, whether SS succeeded with partial
+                // data, returned not-found, or failed outright. The fuzzy block below
+                // is gated on `missingBoxArt`, so it's a no-op when SS already provided art.
             }
 
-            // --- Advanced fuzzy fallback (only for users NOT logged in to ScreenScraper) ---
-            // Runs when: hasSScredentials == false
-            // i.e., the user has not provided ScreenScraper credentials, so we do our
-            // best with OpenVGDB fuzzy matching instead of leaving them with nothing.
+            // --- Advanced fuzzy fallback (runs whenever box art is still missing) ---
+            // Previously gated on `!hasSScredentials`, but that left SS-logged-in users
+            // with nothing when SS didn't have a particular ROM. Now runs for everyone
+            // when art is missing — covers ROMs SS doesn't know about but OpenVGDB does.
+            // The libretro-thumbnails request inside this block provides a final 2D-art
+            // fallback for titles missing from both SS and OpenVGDB.
             let missingBoxArt = resultDict["boxImageURL"] == nil
                              || (resultDict["boxImageURL"] as? String)?.isEmpty == true
 

--- a/OpenEmu/ScreenScraperClient.swift
+++ b/OpenEmu/ScreenScraperClient.swift
@@ -180,7 +180,15 @@ final class ScreenScraperClient {
     /// Also writes to `lastFetchError` (main actor) for UI display.
     ///
     /// Pass `debugMode: true` to attach the developer debug password (100 uses/day limit).
-    func fetchGameInfo(md5: String?, romName: String?, systemIdentifier: String, debugMode: Bool = false) -> Result<ScreenScraperResult?, ScreenScraperFetchError> {
+    /// - Parameters:
+    ///   - md5: ROM MD5 hash (uppercased internally). Sent as `rommd5` when non-empty.
+    ///   - romName: Full ROM filename including extension. Sent as `romnom`.
+    ///   - fileSize: ROM file size in bytes. Sent as `romtaille` when > 0. Significantly
+    ///     improves match accuracy for ROMs whose MD5 doesn't match SS's canonical hash
+    ///     (headered/byte-swapped/trainer-modified dumps).
+    ///   - systemIdentifier: OpenEmu system identifier, mapped to SS `systemeid`.
+    ///   - debugMode: Developer cache-bypass mode (100/day limit, never use in production).
+    func fetchGameInfo(md5: String?, romName: String?, fileSize: Int? = nil, systemIdentifier: String, debugMode: Bool = false) -> Result<ScreenScraperResult?, ScreenScraperFetchError> {
 
         guard let systemID = ScreenScraperClient.systemIDs[systemIdentifier] else {
             return .success(nil)
@@ -206,6 +214,9 @@ final class ScreenScraperClient {
         }
         if let romName = romName, !romName.isEmpty {
             queryItems.append(URLQueryItem(name: "romnom", value: romName))
+        }
+        if let fileSize = fileSize, fileSize > 0 {
+            queryItems.append(URLQueryItem(name: "romtaille", value: String(fileSize)))
         }
 
         // User credentials — optional, attached when the user has saved their own account.


### PR DESCRIPTION
## Summary

Two related improvements to cover-art fetching in `GameInfoHelper`:

### 1. Send file size to ScreenScraper

`fetchGameInfo` now accepts a `fileSize` parameter and forwards it as `romtaille`. ScreenScraper uses both MD5 and file size when matching ROMs — sending size significantly improves match rate for ROMs whose MD5 doesn't match SS's canonical hash (headered, byte-swapped, or trainer-modified dumps).

### 2. Always run fuzzy + libretro-thumbnails fallbacks

Previously, the fuzzy OpenVGDB matcher and libretro-thumbnails only ran when the user had **no** ScreenScraper credentials. SS-logged-in users got nothing when SS didn't know about a particular ROM, even though those fallbacks could have filled the gap.

Now the fuzzy block runs whenever box art is still missing, regardless of credentials. The block is already gated on `missingBoxArt`, so it's a no-op for the common exact-match case — no quota or performance impact when art is already present.

## Files changed

- `OpenEmu/ScreenScraperClient.swift` — add `fileSize: Int?` parameter, send as `romtaille` query item
- `OpenEmu/GameInfoHelper.swift` — pass `url?.fileSize` at both SS call sites; remove early-return so fuzzy fallback always runs when art is still missing

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

**To verify:**
- Common ROM (NES/SNES, in OpenVGDB) — art should appear from OpenVGDB exact match (regression check)
- Homebrew or hack not in OpenVGDB or SS — fuzzy/libretro-thumbnails should now find art for SS-logged-in users (new behavior)
- Headered ROM where MD5 normally fails — `romtaille` should help SS match

Note: re-importing existing library entries won't re-trigger lookups (OpenEmu caches game info on import). Test against fresh ROMs.

## Notes

This is the first of a planned two-PR sequence to improve cover art reliability. Follow-up PR will add a Core Data schema migration to capture ScreenScraper's `jeuid` and full `medias` array for future UI use, while keeping displayed art strictly 2D box art.