### PR TITLE
chore: add pre-push hook that enforces verify.sh

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# .githooks/pre-push — verification gate before any push reaches origin.
+#
+# Runs Scripts/verify.sh. If it fails, the push is blocked.
+#
+# Bypass options (use sparingly, audit when used):
+#   • Single push:  git push --no-verify
+#   • This shell:   SKIP_VERIFY=1 git push
+#
+# Setup (once per clone):  ./Scripts/install-hooks.sh
+#
+# Why this exists: AGENTS.md requires a verification floor before pushing
+# Swift/ObjC changes to origin. Running Scripts/verify.sh is the canonical
+# way to satisfy that. AI-assisted sessions in particular should not be
+# trusted to remember to run it manually — this hook is the mechanical
+# enforcement of the documented rule.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ "${SKIP_VERIFY:-0}" = "1" ]; then
+  echo "[pre-push] SKIP_VERIFY=1 set — skipping Scripts/verify.sh"
+  exit 0
+fi
+
+if [ ! -x ./Scripts/verify.sh ]; then
+  echo "[pre-push] Scripts/verify.sh not found or not executable — skipping (nothing to enforce)"
+  exit 0
+fi
+
+echo "[pre-push] Running Scripts/verify.sh ..."
+if ./Scripts/verify.sh; then
+  echo "[pre-push] verify.sh PASSED — push allowed"
+  exit 0
+else
+  rc=$?
+  echo ""
+  echo "[pre-push] verify.sh FAILED ($rc check(s) failed) — push blocked"
+  echo "[pre-push] Fix the failures above, or bypass with: git push --no-verify"
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,16 @@ The goal is to honor the original OpenEmu spirit — a beautifully designed, fir
 
 ## Build Command
 
+The canonical verification floor is `Scripts/verify.sh`. It builds, runs the static analyzer, validates Info.plist and entitlements, and checks codesign — a stricter floor than a bare `xcodebuild build`.
+
+```bash
+./Scripts/verify.sh                 # build + analyze + plist + codesign
+./Scripts/verify.sh --launch        # above + 5s smoke launch with crash check
+./Scripts/verify.sh --test          # above + run OpenEmuTests unit target
+```
+
+A bare build check is acceptable for quick iteration:
+
 ```bash
 xcodebuild \
   -workspace OpenEmu-metal.xcworkspace \
@@ -55,7 +65,7 @@ xcodebuild \
   build 2>&1 | tail -30
 ```
 
-A clean build is the definition of "passing." Run this before every commit touching source files.
+**A clean `verify.sh` run is the definition of "passing."** Run it before every push touching source files. The pre-push git hook in `.githooks/pre-push` enforces this mechanically — install it once per clone with `./Scripts/install-hooks.sh`.
 
 ---
 

--- a/Scripts/install-hooks.sh
+++ b/Scripts/install-hooks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Scripts/install-hooks.sh — wire this clone's git hooks to the tracked .githooks/ directory.
+#
+# Usage:  ./Scripts/install-hooks.sh
+#
+# Run once per fresh clone or worktree. Re-running is safe (idempotent).
+# To uninstall:  git config --unset core.hooksPath
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ ! -d .githooks ]; then
+  echo "error: .githooks directory not found at $REPO_ROOT" >&2
+  exit 1
+fi
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "Hooks installed:"
+echo "  core.hooksPath = $(git config core.hooksPath)"
+echo ""
+echo "Active hooks:"
+for h in .githooks/*; do
+  [ -f "$h" ] && echo "  - $(basename "$h")"
+done
+echo ""
+echo "Bypass a hook for one push:  git push --no-verify"
+echo "Disable hooks for this clone: git config --unset core.hooksPath"


### PR DESCRIPTION
## Summary

Adds a tracked pre-push git hook that runs `Scripts/verify.sh` and refuses the push on any failure. Mechanical enforcement of the verification floor that AGENTS.md has always required.

### Why

`AGENTS.md` says "Build before committing" and treats `verify.sh` as the canonical floor (build + analyzer + plist + codesign), but until now compliance was honor-system. AI-assisted sessions in particular can't be trusted to run `verify.sh` from memory — recent PRs were pushed and merged with only a bare `xcodebuild build` check, skipping the analyzer / plist / codesign passes.

This makes the rule mechanical instead of advisory.

### Files changed

- `.githooks/pre-push` — runs `Scripts/verify.sh`, blocks push on failure. Tracked in repo so all clones share the same gate.
- `Scripts/install-hooks.sh` — one-line setup per clone (`git config core.hooksPath .githooks`).
- `AGENTS.md` — Build Command section now points at `verify.sh` as the canonical floor and references the hook setup.

### Bypass options (use sparingly)

```bash
git push --no-verify          # single push
SKIP_VERIFY=1 git push        # this shell, audited in history
```

### Setup

```bash
./Scripts/install-hooks.sh
```

Idempotent. Run once per clone or fresh worktree.

## How to test locally

```bash
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon
./Scripts/install-hooks.sh

# Confirm the hook is wired up
git config --get core.hooksPath   # → .githooks

# Try pushing (no real changes needed; touch a file to force a push)
echo "" >> README.md && git add README.md && git commit -m "test" && git push
# Should run Scripts/verify.sh, print PASS lines, then push
git reset --hard HEAD~1 && git push --force-with-lease   # tidy up
```