### PR TITLE
fix: add BSNES to oecores.xml so users can install it from the picker

### DIFF
--- a/oecores.xml
+++ b/oecores.xml
@@ -10,7 +10,6 @@
   2. ARM64 native builds — appcast hosted in this repo (Appcasts/*.xml),
      download assets hosted on the cores-v1.0.0 GitHub Release.
 
-  BSNES excluded: experimental, not yet ready.
   Arcade (MAME) excluded: no emulation core exists yet — see issue #25.
 -->
 <cores>
@@ -65,6 +64,16 @@
     name="Snes9X"
     appcastURL="https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/snes9x.xml">
     <description>Super Nintendo emulator</description>
+    <systems>
+      <system id="openemu.system.snes">Super Nintendo (SNES)</system>
+    </systems>
+  </core>
+
+  <core
+    id="org.openemu.BSNES"
+    name="BSNES"
+    appcastURL="https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/bsnes.xml">
+    <description>Super Nintendo emulator (accuracy)</description>
     <systems>
       <system id="openemu.system.snes">Super Nintendo (SNES)</system>
     </systems>


### PR DESCRIPTION
Fixes #422.

## What this changes

Adds a `<core id="org.openemu.BSNES" …>` entry to `oecores.xml` alongside Snes9X, and removes the "BSNES excluded: experimental, not yet ready" line from the file's leading comment.

`oecores.xml` is the runtime-fetched core list the app uses to populate Preferences → Cores and to discover what's installable for first-time users (`CoreUpdater.swift:168`, via the `OECoreListURL` key in `OpenEmu-Info.plist`). Before this change, BSNES was the only core that had every other shipping piece in place — built source, working Xcode scheme, signed release asset in `cores-v1.2.0` (Apr 30, 2026), correct `Appcasts/bsnes.xml` pointing at that asset, and a correct `SUFeedURL` inside the plugin's `Info.plist` — but was invisible in the picker because no entry advertised it.

Per-plugin `SUFeedURL` only handles **updates** to already-installed plugins. **New installs** come from the picker, which reads `oecores.xml`. So users had no path to BSNES despite every other piece working. The reporter on #422 hit this; my own dev install masked it because `Scripts/install-core.sh` side-loads directly into `~/Library/Application Support/OpenEmu/Cores/`.

## Why now

#422 reporter asked why BSNES isn't selectable as a SNES core despite the docs claim. Triage confirmed the binary, appcast, and release asset are all already in place. This is a one-line discovery fix.

## Verification

- XML syntax: `xmllint --noout oecores.xml` — passes.
- No Swift/ObjC code is changed; `Scripts/verify.sh` was intentionally skipped via `SKIP_VERIFY=1` because the change is to a runtime-fetched data file, which has no compilation path. AGENTS.md rule 3 ("Build before committing") applies to Swift/ObjC changes.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. No build needed — oecores.xml is fetched at runtime from
#    raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/oecores.xml.
#    To test BEFORE merge, point CoreUpdater at this branch's copy:
#    temporarily edit OpenEmu/OpenEmu-Info.plist's OECoreListURL to
#    .../fix/ship-bsnes-in-core-picker/oecores.xml, then build:

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch and verify
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

In the running app:

1. Open Preferences → Cores → Super Nintendo (SNES). Confirm a "BSNES" entry appears alongside Snes9X with an "Install" button.
2. Click Install. Confirm BSNES downloads from `cores-v1.2.0` and installs to `~/Library/Application Support/OpenEmu/Cores/BSNES.oecoreplugin`.
3. Right-click any SNES game → Play With Core → BSNES. Confirm it launches.

Post-merge, the same verification works with the unmodified main app pointing at the live `oecores.xml`.

## Out of scope

- A separate runtime bug surfaced during triage (RetroAchievements silently fails on slow-loading SNES ROMs in BSNES) is filed as a distinct issue and is not addressed here.
- Wider docs/picker/binaries consistency work is tracked in the audit checklist.

🤖 Assisted by Claude Code.
