### PR TITLE
chore: strike DeSmuME and VICE from supported-cores docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,6 @@ xcodebuild \
 | Atari 7800 | ProSystem |
 | Atari Lynx | Mednafen |
 | ColecoVision | JollyCV |
-| Commodore 64 | VICE |
 | Famicom Disk System | Nestopia |
 | Game Boy / GBC | Gambatte |
 | Game Boy Advance | mGBA |
@@ -100,7 +99,6 @@ xcodebuild \
 | Intellivision | Bliss |
 | Nintendo (NES) | Nestopia, FCEU |
 | Nintendo 64 | Mupen64Plus |
-| Nintendo DS | DeSmuME |
 | Odyssey² / Videopac+ | O2EM |
 | Pokémon Mini | PokeMini |
 | Sega 32X | picodrive |

--- a/oecores.xml
+++ b/oecores.xml
@@ -188,16 +188,9 @@
     </systems>
   </core>
 
-  <!-- ✅ ARM64 native -->
-  <core
-    id="org.openemu.desmume"
-    name="DeSmuME"
-    appcastURL="https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/desmume.xml">
-    <description>Nintendo DS emulator</description>
-    <systems>
-      <system id="openemu.system.nds">Nintendo DS</system>
-    </systems>
-  </core>
+  <!-- DeSmuME (NDS) entry removed: no Xcode project exists in this fork and
+       no shipped asset has ever been published. NDS is not currently supported.
+       Tracked in #424. -->
 
   <!-- ✅ ARM64 native -->
   <core


### PR DESCRIPTION
Per maintainer direction in #424 audit: DeSmuME (NDS) and VICE (C64) are not currently supported by this fork. Strike both rows from the docs and remove the unreachable DeSmuME entry from the install picker.

## What this changes

- **`AGENTS.md`** — remove `Commodore 64 → VICE` and `Nintendo DS → DeSmuME` rows from the "Supported Cores" table.
- **`oecores.xml`** — remove the `<core id="org.openemu.desmume">` block. Replaced with an inline comment pointing at #424 for context.

## Why each strike is correct

**DeSmuME (NDS):**
- Source exists at `DeSmuME/` but **no Xcode project file** (`DeSmuME.xcodeproj/` does not exist) — cannot be built.
- `Appcasts/desmume.xml` is intentionally empty (`<!-- No item: build not yet available for ARM64 -->`).
- No `DeSmuME.oecoreplugin.zip` has been published in any `cores-v*` release.
- Previously listed in `oecores.xml`, so the picker advertised an unreachable core to NDS users.

**VICE (C64):**
- No `VICE/` source dir, no Xcode scheme, no `Appcasts/vice.xml`, no published asset.
- Only path C64 ROMs run today is via the libretro/RetroArch wrapper (a user-side install, not a fork-native core).
- AGENTS.md claim of "Commodore 64 → VICE" was inaccurate.

## What this does NOT touch

- `Flycast-Bridge/` and `Gambatte-Bridge/` directories — flagged in the audit but already removed from git tracking in commit `0af30562`. They persist as untracked local leftovers on the maintainer's filesystem; AGENTS.md's claim that they were removed is correct. No git change needed there.

## Verification

- `xmllint --noout oecores.xml` — passes.
- No Swift/ObjC code is changed; `Scripts/verify.sh` was skipped via `SKIP_VERIFY=1`.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. No build needed — both files are runtime-fetched / read by markdown viewers.
#    To verify the picker change without merge, temporarily edit
#    OpenEmu/OpenEmu-Info.plist's OECoreListURL to point at this branch's
#    oecores.xml, then build:

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -10

# 3. Launch and verify
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

In the running app:

1. Open Preferences → Cores. Confirm no "DeSmuME" entry appears under any system.
2. Open `AGENTS.md` and confirm the "Supported Cores" table no longer lists Commodore 64 or Nintendo DS rows.

Related to #424.

🤖 Assisted by Claude Code.
