### PR TITLE
chore: enforce zip-version match in update_core_appcast.py

### DIFF
--- a/.claude/commands/release-core.md
+++ b/.claude/commands/release-core.md
@@ -141,6 +141,12 @@ contain (because the plist bump didn't take, or an old zip got reused).
 Stop here if it fails — the appcast must never claim a version that
 isn't in the zip.
 
+**Note:** since `chore/release-skill-version-precondition`,
+`Scripts/update_core_appcast.py` ALSO enforces this check automatically
+whenever `--sign-zip` is passed (Step 10 below). The manual check here
+is kept as defense-in-depth and to surface the failure earlier in the
+pipeline (before signing/uploading rather than after).
+
 ```bash
 VERIFY_DIR=$(mktemp -d)
 ditto -x -k "$ZIP" "$VERIFY_DIR"

--- a/Scripts/update_core_appcast.py
+++ b/Scripts/update_core_appcast.py
@@ -22,12 +22,96 @@
 
 import argparse
 import os
+import plistlib
 import re
 import subprocess
 import sys
+import tempfile
+import zipfile
 
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+
+def verify_zip_version(zip_path, expected_version):
+    """Open the zip's Info.plist and confirm CFBundleVersion matches.
+
+    This is the mechanical enforcement of release-core.md Step 7b. It exists
+    because cores-v1.2.0 (Apr 30, 2026) shipped 5 cores whose appcast advertised
+    bumped versions but whose zipped binaries' Info.plist still reported the
+    previous version. Sparkle entered an infinite "update available" loop and
+    the May 6 revert (98141d56) had to roll the appcasts back, leaving every
+    user on the older binary. The release-core skill grew a documented Step 7b
+    after that, but a human or agent could still skip it. This function makes
+    it impossible to skip when --sign-zip is in play.
+
+    Refuses (sys.exit(1)) on mismatch. Returns silently on match.
+    """
+    if not os.path.isfile(zip_path):
+        print(f'ERROR: --sign-zip path does not exist: {zip_path}',
+              file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            # The bundle root inside the zip is e.g. "Foo.oecoreplugin/".
+            # Find the Info.plist at the top of any *.oecoreplugin/Contents/.
+            info_plist_paths = [
+                n for n in zf.namelist()
+                if n.endswith('.oecoreplugin/Contents/Info.plist')
+            ]
+            if not info_plist_paths:
+                print(f'ERROR: no .oecoreplugin/Contents/Info.plist found '
+                      f'inside {zip_path}', file=sys.stderr)
+                sys.exit(1)
+            if len(info_plist_paths) > 1:
+                print(f'ERROR: multiple .oecoreplugin bundles inside '
+                      f'{zip_path}: {info_plist_paths}', file=sys.stderr)
+                sys.exit(1)
+            with zf.open(info_plist_paths[0]) as plist_f:
+                info = plistlib.load(plist_f)
+    except (zipfile.BadZipFile, plistlib.InvalidFileException) as exc:
+        print(f'ERROR: could not read Info.plist from {zip_path}: {exc}',
+              file=sys.stderr)
+        sys.exit(1)
+
+    bundle_version = info.get('CFBundleVersion')
+    short_version = info.get('CFBundleShortVersionString')
+
+    # The appcast's sparkle:version is what Sparkle compares against the
+    # installed bundle's CFBundleVersion. CFBundleVersion is the authoritative
+    # check. CFBundleShortVersionString is a softer match — when present, it
+    # should also agree, but some cores omit it entirely.
+    if bundle_version != expected_version:
+        print(f'ERROR: version mismatch — refusing to write appcast.\n'
+              f'  Appcast about to advertise: sparkle:version="{expected_version}"\n'
+              f'  Zip\'s Info.plist reports:   CFBundleVersion="{bundle_version}"\n'
+              f'\n'
+              f'This is the cores-v1.2.0 class of bug. If we write the appcast\n'
+              f'as requested, every user already on "{bundle_version}" will see\n'
+              f'an update prompt, download this zip, install it, still report\n'
+              f'"{bundle_version}" internally, and loop on the same prompt forever.\n'
+              f'\n'
+              f'Likely causes:\n'
+              f'  - The Info.plist version bump was saved to the wrong path.\n'
+              f'  - The build cached an old binary; clean and rebuild.\n'
+              f'  - Info.plist uses $(CURRENT_PROJECT_VERSION); also bump\n'
+              f'    CURRENT_PROJECT_VERSION in the .xcodeproj/project.pbxproj.\n'
+              f'\n'
+              f'Fix the bundle, rebuild, then re-run this script. Do not edit\n'
+              f'the appcast to match the wrong zip.',
+              file=sys.stderr)
+        sys.exit(1)
+
+    if short_version is not None and short_version != expected_version:
+        print(f'WARNING: CFBundleShortVersionString="{short_version}" inside '
+              f'the zip does not match the version about to be advertised '
+              f'("{expected_version}"). Proceeding because CFBundleVersion '
+              f'matches, but consider aligning both fields.',
+              file=sys.stderr)
+
+    print(f'Verified: zip\'s CFBundleVersion="{bundle_version}" matches '
+          f'requested sparkle:version="{expected_version}".')
 
 
 def find_sign_update():
@@ -92,6 +176,10 @@ def main():
     ed_sig = None
     length = args.length
     if args.sign_zip:
+        # Enforce the cores-v1.2.0 class of bug at the script level. Refuses
+        # to continue if the zip's CFBundleVersion does not match the version
+        # we're about to advertise in the appcast. See verify_zip_version().
+        verify_zip_version(args.sign_zip, args.version)
         ed_sig, length = sign_zip(args.sign_update, args.sign_zip)
 
     sig_attr = f'\n        sparkle:edSignature="{ed_sig}"' if ed_sig else ''


### PR DESCRIPTION
Adds a mechanical version-check precondition to `Scripts/update_core_appcast.py` so the cores-v1.2.0 class of bug becomes structurally impossible regardless of who or what is driving the release.

## Background

On April 30, 2026, `cores-v1.2.0` shipped with five cores' appcasts advertising bumped versions (`SNES9x 1.63.1`, `Gambatte 0.5.2`, `Nestopia 1.52.1`, `mGBA 0.10.6`, `GenesisPlus 1.7.5.2`) while the zipped binaries inside reported the previous versions in their `Info.plist`. Sparkle saw "advertised 1.63.1, installed 1.63" and entered an infinite update loop.

The May 6 revert (`98141d56`) misdiagnosed this as "the zip contains the old binary" and rolled the appcasts back to point at `cores-v1.0.0` — leaving every user on the older Apr 2 binary that doesn't include the RetroAchievements wiring from #279. Empirical verification (in #424 comment): the `cores-v1.2.0` SNES9x.zip has 120 `rc_client` symbols and is 400 KB larger than `cores-v1.0.0` — the binary is genuinely new, only the version metadata was stale.

The release-core skill grew a documented Step 7b on May 6 (`98847995`) that asks the operator to extract the freshly-built zip and confirm `CFBundleVersion` matches the version about to be advertised. That check works, but is **manual**: any future agent or operator can skip Step 7b and ship the same class of bug.

## What this changes

`Scripts/update_core_appcast.py` now opens the zip, reads `<CoreName>.oecoreplugin/Contents/Info.plist`, and **refuses to write the appcast** unless `CFBundleVersion` equals the `version` argument. The check fires whenever `--sign-zip` is passed (which is the standard release path).

The error message explains the cores-v1.2.0 class of bug inline so the failure is debuggable without opening this file:

```
ERROR: version mismatch — refusing to write appcast.
  Appcast about to advertise: sparkle:version="1.99"
  Zip's Info.plist reports:   CFBundleVersion="1.63"

This is the cores-v1.2.0 class of bug. If we write the appcast as
requested, every user already on "1.63" will see an update prompt,
download this zip, install it, still report "1.63" internally, and
loop on the same prompt forever.

Likely causes:
  - The Info.plist version bump was saved to the wrong path.
  - The build cached an old binary; clean and rebuild.
  - Info.plist uses $(CURRENT_PROJECT_VERSION); also bump
    CURRENT_PROJECT_VERSION in the .xcodeproj/project.pbxproj.

Fix the bundle, rebuild, then re-run this script. Do not edit
the appcast to match the wrong zip.
```

`CFBundleShortVersionString` is checked softly (warns on mismatch but does not block) because some cores omit it. `CFBundleVersion` is what Sparkle compares against, so it's the authoritative gate.

`.claude/commands/release-core.md` updated with a note that Step 7b is now mechanically enforced when `--sign-zip` is used. The manual step is kept as defense-in-depth and to surface mismatches earlier in the pipeline (before signing/uploading rather than after).

## Smoke tests run before push

| Test | Result |
|---|---|
| `--sign-zip <v1.0.0 SNES9x zip (CFBundleVersion=1.63)>` + `version=1.99` | Refuses with the error block above ✅ |
| `--sign-zip <v1.0.0 SNES9x zip>` + `version=1.63` | Verifies, signs, prepends item ✅ |
| No `--sign-zip` (backfill scenario) | No version check, prepends item — preserves existing flow ✅ |

## Why this is the right place to enforce

- It's the smallest possible code change (90 lines including the error message).
- It runs at the moment the appcast is about to be written — the last-mile decision point.
- It's unbypassable for the release path: `--sign-zip` is required for any release that needs an EdDSA signature, which is every release that goes to users.
- It does not touch the build, signing, notarization, or upload steps — purely a precondition on the appcast write.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. No build needed — Python script + markdown only.

# 3. Smoke test using any existing core zip from a release:
gh release download cores-v1.0.0 --repo nickybmon/OpenEmu-Silicon \
  -p "SNES9x.oecoreplugin.zip" -D /tmp/snes9x-test

# Should refuse:
python3 Scripts/update_core_appcast.py /tmp/test-appcast.xml SNES9x 1.99 \
  https://example.com/foo.zip 100 \
  --sign-zip /tmp/snes9x-test/SNES9x.oecoreplugin.zip
# Expected: ERROR exit 1 with cores-v1.2.0 explainer

# Should pass:
echo '<?xml version="1.0"?><rss><channel><title>SNES9x</title>
</channel></rss>' > /tmp/test-appcast.xml
python3 Scripts/update_core_appcast.py /tmp/test-appcast.xml SNES9x 1.63 \
  https://example.com/foo.zip 100
# Expected: "Prepended SNES9x 1.63 entry to /tmp/test-appcast.xml"
```

## Out of scope

- The actual `cores-v1.4.0` rebuild that brings the 5 affected cores back to a known-good state (tracked in #424; the maintainer drives that cut using this hardened skill).
- The `chore/strike-unsupported-cores-and-bridge-dirs` PR that strikes DeSmuME and VICE from docs (separate PR, also tracked in #424).

Related to #424.

🤖 Assisted by Claude Code.
