### PR TITLE
fix: add Flycast SUFeedURL and require it on every core plist

### DIFF
--- a/Flycast/OpenEmu/Info.plist
+++ b/Flycast/OpenEmu/Info.plist
@@ -26,6 +26,8 @@
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>
 	<string>FlycastGameCore</string>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/flycast.xml</string>
 	<key>OEGameCoreOptions</key>
 	<dict>
 		<key>openemu.system.dc</key>

--- a/Scripts/check-core-feed-urls.sh
+++ b/Scripts/check-core-feed-urls.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # check-core-feed-urls.sh — Guardrail against regressing the core update channel.
 #
-# Fails if any tracked Info.plist still references the dormant upstream
-# OpenEmu-Update appcast host, and fails if a core's SUFeedURL points at an
-# Appcasts/<name>.xml file that doesn't exist in the working tree.
+# Three rules:
+#   1. No tracked Info.plist references the dormant upstream OpenEmu-Update
+#      appcast host (raw.github.com/OpenEmu, appcast.openemu.org).
+#   2. Every nickybmon SUFeedURL points at an Appcasts/<name>.xml file that
+#      actually exists in the tree.
+#   3. Every core Info.plist (one that defines OEGameCoreClass) MUST have a
+#      SUFeedURL key. Catches the Flycast-class slip-through where a core was
+#      shipped without any SUFeedURL at all, leaving it dependent on
+#      CoreUpdater's oecores.xml override for updates.
 #
 # Wired into Scripts/verify.sh as a precondition for --core runs. Cheap to run
 # everywhere else too.
@@ -50,8 +56,37 @@ if [ ${#missing[@]} -gt 0 ]; then
   fail=1
 fi
 
+# 3. Every core plist (defines OEGameCoreClass) must have a SUFeedURL key.
+#    Without this, Sparkle's per-plugin update path is broken; the core's
+#    updates only flow through CoreUpdater's oecores.xml override, which is
+#    not guaranteed to exist forever and is silently bypassed by anything
+#    that drives Sparkle directly.
+# OpenEmu/LibretroBridge/ ships bundled inside the host app and updates with
+# the app itself (refreshed at launch via refreshStaleRetroArchStubs in
+# AppDelegate.swift). It legitimately has no per-plugin Sparkle channel.
+missing_sufeedurl=()
+while IFS= read -r plist; do
+  [ -z "$plist" ] && continue
+  case "$plist" in
+    OpenEmu/LibretroBridge/*) continue ;;
+  esac
+  if grep -q '<key>OEGameCoreClass</key>' "$plist" 2>/dev/null \
+     && ! grep -q '<key>SUFeedURL</key>' "$plist" 2>/dev/null; then
+    missing_sufeedurl+=("$plist")
+  fi
+done <<< "$PLISTS"
+
+if [ ${#missing_sufeedurl[@]} -gt 0 ]; then
+  echo "ERROR: core Info.plist (has OEGameCoreClass) is missing SUFeedURL:" >&2
+  for p in "${missing_sufeedurl[@]}"; do
+    echo "  $p" >&2
+  done
+  echo "Add: <key>SUFeedURL</key><string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/<core>.xml</string>" >&2
+  fail=1
+fi
+
 if [ $fail -ne 0 ]; then
   exit 1
 fi
 
-echo "OK: no upstream OpenEmu-Update references; all core SUFeedURLs resolve."
+echo "OK: no upstream references; all core SUFeedURLs resolve; all core plists have SUFeedURL."


### PR DESCRIPTION
Two changes that close a Flycast-class slip-through where a core was shipped without any `SUFeedURL` at all.

## What this changes

### 1. `Flycast/OpenEmu/Info.plist` — add `SUFeedURL`

Per AGENTS.md "Core update channel", every shipped core plugin must embed a fork-owned `SUFeedURL` pointing at its `Appcasts/<core>.xml`. Flycast had **no `SUFeedURL` key at all** — neither in source nor in the released `cores-v1.3.0` zip. Updates to Flycast worked in practice only because OpenEmu's `CoreUpdater` (`CoreUpdater.swift:218`) overrides per-plugin `SUFeedURL` with `oecores.xml`'s `appcastURL` for installed cores. If anything ever bypasses that override (a third-party launcher invoking Sparkle directly, a future refactor, etc.), Flycast users would have no update path.

Adds:

```xml
<key>SUFeedURL</key>
<string>https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/Appcasts/flycast.xml</string>
```

The plist edit is inert until Flycast is rebuilt — the `cores-v1.3.1` cut will pick this up. `CFBundleVersion` bump from `2.4.1` to whatever the release uses happens at release time, not in this prep PR.

### 2. `Scripts/check-core-feed-urls.sh` — third rule

The existing guardrail had two rules:

1. No tracked plist references the dormant upstream `OpenEmu-Update`.
2. Every nickybmon `SUFeedURL` resolves to an `Appcasts/<name>.xml` that exists.

It did **not** verify that a `SUFeedURL` was present in the first place. That's why Flycast's missing key slipped through. Adds a third rule:

> 3. Every `Info.plist` that defines `OEGameCoreClass` (i.e., is a core plugin) **must** have a `SUFeedURL` key.

`OpenEmu/LibretroBridge/*` is explicitly excluded because it ships bundled inside the host app and updates with the app itself (refreshed at launch via `refreshStaleRetroArchStubs` in `AppDelegate.swift`), not via Sparkle per-core.

## Smoke tests run before push

| Test | Result |
|---|---|
| Run guardrail with Flycast change applied | exit 0 ("OK: ...all core plists have SUFeedURL") ✓ |
| Stash Flycast change, run guardrail | exit 1, prints `Flycast/OpenEmu/Info.plist` as missing SUFeedURL ✓ |
| Restore Flycast change, run guardrail | exit 0 ✓ |
| Libretro bridge `OEGameCoreClass` plist | correctly excluded — no spurious failure ✓ |

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

# 2. Run the guardrail directly
./Scripts/check-core-feed-urls.sh
# Expected: "OK: no upstream references; all core SUFeedURLs resolve; all core plists have SUFeedURL."

# 3. Verify it catches the regression by temporarily reverting:
git stash push -- Flycast/OpenEmu/Info.plist
./Scripts/check-core-feed-urls.sh; echo "exit=$?"
# Expected: ERROR with Flycast/OpenEmu/Info.plist listed; exit=1

# 4. Restore
git stash pop
```

## Out of scope

- The actual `cores-v1.3.1` rebuild that ships Flycast 2.4.x with the new SUFeedURL bundled, plus the 24 other cores in the consolidated sweep. That's tracked in #424; the maintainer drives that cut once #428, #429, and this PR are merged.

Related to #424.

🤖 Assisted by Claude Code.
