### PR TITLE
feat: RetroAchievements hardcore mode compliance

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -121,6 +121,8 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     NSMutableDictionary <NSString *, id> *_displayModes;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
 }
 
@@ -314,7 +316,8 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, bsnes_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, bsnes_rc_log);
 
         __weak BSNESGameCore *weakSelf = self;
@@ -335,6 +338,20 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -448,6 +465,10 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -77,6 +77,8 @@ static uint32_t palette[256];
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
 }
 
@@ -308,7 +310,8 @@ static __weak FCEUGameCore *_current;
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, fceu_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, fceu_rc_log);
 
         __weak FCEUGameCore *weakSelf = self;
@@ -329,6 +332,20 @@ static __weak FCEUGameCore *_current;
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -376,6 +393,10 @@ static __weak FCEUGameCore *_current;
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -72,6 +72,8 @@ public:
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
     int _rcConsole;
 }
@@ -224,7 +226,8 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, gambatte_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, gambatte_rc_log);
 
         __weak GBGameCore *weakSelf = self;
@@ -245,6 +248,20 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -279,6 +296,10 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -122,6 +122,8 @@ typedef NS_ENUM(NSInteger, MultiTapType)
     MultiTapType _multiTapType;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     int _rcConsole;
 }
 - (void)applyCheat:(NSString *)code;
@@ -297,7 +299,8 @@ static __weak GenPlusGameCore *_current;
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, genplus_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, genplus_rc_log);
 
         __weak GenPlusGameCore *weakSelf = self;
@@ -318,6 +321,20 @@ static __weak GenPlusGameCore *_current;
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -414,6 +431,10 @@ static __weak GenPlusGameCore *_current;
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -109,6 +109,8 @@ namespace MDFN_IEN_VB
 
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
     int _rcConsole;
     BOOL _isSystemPCECD;
@@ -3625,7 +3627,8 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
         if (_rcClient) {
             rc_client_set_userdata(_rcClient, (__bridge void *)self);
             rc_client_set_event_handler(_rcClient, mednafen_rc_event_handler);
-            rc_client_set_hardcore_enabled(_rcClient, 0);
+            _raHardcoreEnabled = YES;
+            rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
             // Defer address validation to executeFrame so emulated RAM is live before rcheevos
             // validates achievement memrefs. Without this, activation runs on the HTTP callback
             // thread before Mednafen's core is fully started, returning 0 for every address and
@@ -3651,6 +3654,20 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
                                                      (__bridge void *)s);
                 } else {
                     rc_client_logout(s->_rcClient);
+                }
+            }];
+
+            _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:OEHardcoreModeDidChangeNotification
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *note) {
+                NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+                if (enabled) {
+                    self->_raHardcoreEnabled = enabled.boolValue;
+                    if (self->_rcClient) {
+                        rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                    }
                 }
             }];
         }
@@ -3726,6 +3743,10 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -82,6 +82,8 @@ NSString *MupenControlNames[] = {
 
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
 }
 
@@ -421,7 +423,8 @@ static void MupenSetAudioSpeed(int percent)
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, mupen_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         // Defer memory validation to do_frame (videoInterrupt) so RDRAM is live before rcheevos
         // validates achievement addresses. Without this, activation runs on the HTTP callback thread
         // before M64CMD_EXECUTE sets up g_dev.rdram.dram, returning 0 for every address and
@@ -447,6 +450,20 @@ static void MupenSetAudioSpeed(int percent)
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -562,6 +579,10 @@ static void MupenSetAudioSpeed(int percent)
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -90,6 +90,8 @@ static void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event,
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     int _rcConsole;
 }
 
@@ -306,7 +308,8 @@ static __weak NESGameCore *_current;
     if (_rcClient) {
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, nestopia_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, nestopia_rc_log);
 
         __weak NESGameCore *weakSelf = self;
@@ -327,6 +330,20 @@ static __weak NESGameCore *_current;
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -422,6 +439,10 @@ static __weak NESGameCore *_current;
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -240,6 +240,10 @@ OE_EXPORTED_CLASS
 @property(nonatomic, readonly) NSUInteger                     rewindBufferSeconds;
 @property(nonatomic, readonly) OEDiffQueue                   *rewindQueue;
 
+/// When YES, the base implementations of rewind, fast-forward, and frame-step
+/// become no-ops. Set by the helper when RetroAchievements hardcore mode is on.
+@property(nonatomic)           BOOL                           hardcoreEnabled;
+
 @property(nonatomic, copy)     NSString                      *systemIdentifier;
 @property(nonatomic, copy)     NSString                      *systemRegion;
 @property(nonatomic, copy)     NSString                      *ROMMD5 NS_SWIFT_NAME(romMD5);

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -579,8 +579,9 @@ static Class GameCoreClass = Nil;
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)fastForward:(BOOL)flag
 {
+    if (self.hardcoreEnabled) return;
     float newrate = flag ? 5.0 : 1.0;
-  
+
     if (self.isEmulationPaused) {
         lastRate = newrate;
     } else {
@@ -593,6 +594,7 @@ static Class GameCoreClass = Nil;
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)rewind:(BOOL)flag
 {
+    if (self.hardcoreEnabled) { isRewinding = NO; return; }
     if(flag && [self supportsRewinding] && ![[self rewindQueue] isEmpty])
     {
         isRewinding = YES;
@@ -643,11 +645,13 @@ static Class GameCoreClass = Nil;
 
 - (void)stepFrameForward
 {
+    if (self.hardcoreEnabled) return;
     singleFrameStep = YES;
 }
 
 - (void)stepFrameBackward
 {
+    if (self.hardcoreEnabled) return;
     singleFrameStep = isRewinding = YES;
 }
 

--- a/OpenEmu/GameControlsBar.swift
+++ b/OpenEmu/GameControlsBar.swift
@@ -418,23 +418,27 @@ final class GameControlsBar: NSWindow {
     
     var cheatsMenu: NSMenu {
         let menu = NSMenu()
-        
+        let hardcoreOn = gameViewController.document.isHardcoreModeEnabled
+        if hardcoreOn { menu.autoenablesItems = false }
+
         let item = NSMenuItem(title: NSLocalizedString("Add Cheat…", comment: ""), action: #selector(OEGameDocument.addCheat(_:)), keyEquivalent: "")
+        if hardcoreOn { item.isEnabled = false }
         menu.addItem(item)
-        
+
         let cheats = gameViewController.document.cheats
         if !cheats.isEmpty {
             menu.addItem(.separator())
-            
+
             for cheat in cheats {
                 let item = NSMenuItem(title: cheat.name, action: #selector(OEGameDocument.toggleCheat(_:)), keyEquivalent: "")
                 item.representedObject = cheat
                 item.state = cheat.isEnabled ? .on : .off
-                
+                if hardcoreOn { item.isEnabled = false }
+
                 menu.addItem(item)
             }
         }
-        
+
         return menu
     }
     

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -335,6 +335,10 @@ extension GameViewController {
     func showRewindNotification(_ enable: Bool) {
         notificationView.showRewind(enabled: enable)
     }
+
+    func showHardcoreNotification(_ enable: Bool) {
+        notificationView.showHardcore(enabled: enable)
+    }
     
     func showStepForwardNotification() {
         notificationView.showStepForward()

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -44,6 +44,17 @@ let OEScreenshotAspectRatioCorrectionDisabled = "disableScreenshotAspectRatioCor
 
 let OEGameCoreManagerModePreferenceKey = "OEGameCoreManagerModePreference"
 
+/// User preference key controlling whether RetroAchievements hardcore mode is on.
+/// Default `true` per RA's recommendation. Disables save state loading, rewind,
+/// frame advance, and cheats while enabled.
+let RAHardcoreEnabledKey = "RAHardcoreEnabled"
+
+/// Posted by `PrefRetroAchievementsController` when the user toggles hardcore mode.
+/// `userInfo[OEHardcoreEnabledKey]` carries the new `Bool`.
+extension Notification.Name {
+    static let OERAHardcoreDidChange = Notification.Name("OERAHardcoreDidChange")
+}
+
 @objc
 final class OEGameDocument: NSDocument {
     
@@ -132,6 +143,7 @@ final class OEGameDocument: NSDocument {
         UserDefaults.standard.register(defaults: [
             OEScreenshotFileFormatKey : NSBitmapImageRep.FileType.png.rawValue,
             OEScreenshotPropertiesKey : [NSBitmapImageRep.PropertyKey : Any](),
+            RAHardcoreEnabledKey      : true,
         ])
     }()
     
@@ -148,6 +160,13 @@ final class OEGameDocument: NSDocument {
     
     private var gameCoreManager: GameCoreManager?
     private var raCredentialObserver: Any?
+    private var raHardcoreObserver: Any?
+
+    /// Whether RetroAchievements hardcore mode is currently enabled.
+    /// Read from `UserDefaults` — writes go through `PrefRetroAchievementsController`.
+    @objc var isHardcoreModeEnabled: Bool {
+        UserDefaults.standard.bool(forKey: RAHardcoreEnabledKey)
+    }
 
     private var displaySleepAssertionID: IOPMAssertionID = 0
     
@@ -575,6 +594,10 @@ final class OEGameDocument: NSDocument {
                     NotificationCenter.default.removeObserver(observer)
                     self.raCredentialObserver = nil
                 }
+                if let observer = self.raHardcoreObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                    self.raHardcoreObserver = nil
+                }
 
                 self.emulationStatus = .notSetup
                 
@@ -667,6 +690,21 @@ final class OEGameDocument: NSDocument {
                     let token    = note.userInfo?[RACredentialsTokenKey]    as? String
                     let username = note.userInfo?[RACredentialsUsernameKey] as? String
                     self.gameCoreManager?.setRetroAchievementsToken(token, username: username)
+                }
+
+                // Push the current hardcore preference to the helper at game start.
+                self.gameCoreManager?.setHardcoreEnabled(self.isHardcoreModeEnabled)
+
+                // Forward mid-session hardcore toggles. soft→hard requires a reset
+                // (RA spec: switching into hardcore must restart the run).
+                self.raHardcoreObserver = NotificationCenter.default.addObserver(
+                    forName: .OERAHardcoreDidChange,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] note in
+                    guard let self = self else { return }
+                    let enabled = (note.userInfo?[OEHardcoreEnabledKey] as? Bool) ?? self.isHardcoreModeEnabled
+                    self.handleHardcoreToggle(enabled: enabled)
                 }
 
                 handler(true, nil)
@@ -1045,10 +1083,14 @@ final class OEGameDocument: NSDocument {
         emulationStatus = .starting
         gameCoreManager?.startEmulation() {
             self.emulationStatus = .playing
-            self.cheats.filter(\.isEnabled).forEach { self.setCheat($0) }
+            // Cheats are disabled in hardcore mode (RA spec).
+            if !self.isHardcoreModeEnabled {
+                self.cheats.filter(\.isEnabled).forEach { self.setCheat($0) }
+            }
         }
-        
+
         gameViewController.reflectEmulationPaused(false)
+        gameViewController.showHardcoreNotification(isHardcoreModeEnabled)
     }
     
     var isEmulationPaused: Bool {
@@ -1102,6 +1144,34 @@ final class OEGameDocument: NSDocument {
             gameCoreManager?.resetEmulation() {
                 self.isEmulationPaused = false
             }
+        }
+    }
+
+    /// Handle a mid-session hardcore toggle. Soft→hard requires confirming a reset
+    /// (RA spec). Hard→soft drops to softcore immediately with no prompt. Either
+    /// way, the new value is forwarded to the helper and the HUD is updated.
+    private func handleHardcoreToggle(enabled: Bool) {
+        if enabled {
+            isEmulationPaused = true
+            let alert = OEAlert()
+            alert.messageText = NSLocalizedString("Switching to hardcore mode requires restarting the game.", comment: "")
+            alert.informativeText = NSLocalizedString("Save states, rewind, frame advance, and cheats will be disabled.", comment: "")
+            alert.defaultButtonTitle = NSLocalizedString("Restart Game", comment: "")
+            alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
+            if alert.runModal() == .alertFirstButtonReturn {
+                gameCoreManager?.setHardcoreEnabled(true)
+                gameCoreManager?.resetEmulation { [weak self] in
+                    self?.isEmulationPaused = false
+                }
+                gameViewController.showHardcoreNotification(true)
+            } else {
+                // User cancelled — revert the preference so UI and state agree.
+                UserDefaults.standard.set(false, forKey: RAHardcoreEnabledKey)
+                isEmulationPaused = false
+            }
+        } else {
+            gameCoreManager?.setHardcoreEnabled(false)
+            gameViewController.showHardcoreNotification(false)
         }
     }
     
@@ -1372,8 +1442,9 @@ final class OEGameDocument: NSDocument {
     }
     
     @IBAction func addCheat(_ sender: Any?) {
+        if isHardcoreModeEnabled { return }
         let alert = OEAlert()
-        
+
         alert.otherInputLabelText = NSLocalizedString("Title:", comment: "")
         alert.showsOtherInputField = true
         alert.otherInputPlaceholderText = NSLocalizedString("Cheat Description", comment: "")
@@ -1406,6 +1477,7 @@ final class OEGameDocument: NSDocument {
     
     /// expects `sender.representedObject` to be a `Cheat` object
     @IBAction func toggleCheat(_ sender: AnyObject) {
+        if isHardcoreModeEnabled { return }
         guard let cheat = sender.representedObject as? Cheat
         else { return }
 
@@ -1413,8 +1485,9 @@ final class OEGameDocument: NSDocument {
         setCheat(cheat)
         if cheat.isUserAdded { saveUserCheats() }
     }
-    
+
     func setCheat(_ cheat: Cheat) {
+        if isHardcoreModeEnabled { return }
         gameCoreManager?.setCheat(cheat.code, withType: cheat.type, enabled: cheat.isEnabled)
     }
     
@@ -1833,7 +1906,16 @@ final class OEGameDocument: NSDocument {
         if state.rom != rom {
             return
         }
-        
+
+        if isHardcoreModeEnabled {
+            let alert = OEAlert()
+            alert.messageText = NSLocalizedString("Save state loading is disabled in hardcore mode.", comment: "")
+            alert.informativeText = NSLocalizedString("Turn off hardcore mode in Preferences ▸ RetroAchievements to load save states.", comment: "")
+            alert.defaultButtonTitle = NSLocalizedString("OK", comment: "")
+            alert.runModal()
+            return
+        }
+
         let loadState: (() -> Void) = {
             self.gameCoreManager?.loadStateFromFile(at: state.dataFileURL) { success, error in
                 if !success {
@@ -2055,12 +2137,14 @@ extension OEGameDocument: OESystemBindingsObserver {
     }
     
     func rewindGameplay(_ enable: Bool) {
+        if isHardcoreModeEnabled { return }
         let supportsRewinding = corePlugin.supportsRewinding(forSystemIdentifier: systemIdentifier)
         if !supportsRewinding || emulationStatus != .playing { return }
         gameViewController.showRewindNotification(enable)
     }
-    
+
     func stepGameplayFrameForward() {
+        if isHardcoreModeEnabled { return }
         if emulationStatus == .playing {
             toggleEmulationPaused(self)
         }
@@ -2068,8 +2152,9 @@ extension OEGameDocument: OESystemBindingsObserver {
             gameViewController.showStepForwardNotification()
         }
     }
-    
+
     func stepGameplayFrameBackward() {
+        if isHardcoreModeEnabled { return }
         if emulationStatus == .playing {
             toggleEmulationPaused(self)
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2132,6 +2132,7 @@ extension OEGameDocument: OESystemBindingsObserver {
     }
     
     func fastForwardGameplay(_ enable: Bool) {
+        if isHardcoreModeEnabled { return }
         if emulationStatus != .playing { return }
         gameViewController.showFastForwardNotification(enable)
     }

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -137,9 +137,18 @@ final class OEGameLayerNotificationView: NSImageView {
     lazy var rewindImage        = NSImage(named: "hud_rewind_notification")
     lazy var stepForwardImage   = NSImage(named: "hud_stepforward_notification")
     lazy var stepBackwardImage  = NSImage(named: "hud_stepbackward_notification")
-    
+    /// Hardcore overlay image. Falls back to an SF Symbol when no custom asset exists
+    /// so the indicator works before final art ships.
+    lazy var hardcoreImage: NSImage? = {
+        if let named = NSImage(named: "hud_hardcore_notification") { return named }
+        let config = NSImage.SymbolConfiguration(pointSize: 64, weight: .bold)
+        return NSImage(systemSymbolName: "lock.shield.fill", accessibilityDescription: "Hardcore Mode")?
+            .withSymbolConfiguration(config)
+    }()
+
     var isFastForwarding: Bool  = false
     var isRewinding: Bool       = false
+    var isHardcoreMode: Bool    = false
     
     override var wantsUpdateLayer: Bool { return true }
     
@@ -177,6 +186,13 @@ final class OEGameLayerNotificationView: NSImageView {
         performNotification(img: rewindImage, enabled: enabled, state: &isRewinding)
         if enabled {
             postAccessibilityNotification(announcement: NSLocalizedString("Rewind", tableName: "ControlLabels", comment: ""))
+        }
+    }
+
+    @objc public func showHardcore(enabled: Bool) {
+        performNotification(img: hardcoreImage, enabled: enabled, state: &isHardcoreMode)
+        if enabled {
+            postAccessibilityNotification(announcement: NSLocalizedString("Hardcore Mode", tableName: "ControlLabels", comment: ""))
         }
     }
     

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -23,6 +23,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import OpenEmuKit
 
 // MARK: - Notification
 
@@ -53,11 +54,14 @@ final class PrefRetroAchievementsController: NSViewController {
     private let signOutButton   = NSButton()
     private let statusLabel     = NSTextField(labelWithString: "")
     private let registerLabel   = NSTextField(labelWithString: "")
+    private let hardcoreDivider = NSBox()
+    private let hardcoreCheckbox = NSButton(checkboxWithTitle: "Hardcore mode (recommended)", target: nil, action: nil)
+    private let hardcoreSubtitle = NSTextField(wrappingLabelWithString: "")
 
     // MARK: - Lifecycle
 
     override func loadView() {
-        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 300))
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 400))
         buildUI()
     }
 
@@ -131,6 +135,22 @@ final class PrefRetroAchievementsController: NSViewController {
         registerLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(registerLabel)
 
+        hardcoreDivider.boxType = .separator
+        hardcoreDivider.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hardcoreDivider)
+
+        hardcoreCheckbox.target = self
+        hardcoreCheckbox.action = #selector(toggleHardcore(_:))
+        hardcoreCheckbox.state = UserDefaults.standard.bool(forKey: RAHardcoreEnabledKey) ? .on : .off
+        hardcoreCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hardcoreCheckbox)
+
+        hardcoreSubtitle.stringValue = "Disables save state loading, rewind, frame advance, and cheats. Required for ranked achievements."
+        hardcoreSubtitle.font = .systemFont(ofSize: 11)
+        hardcoreSubtitle.textColor = .secondaryLabelColor
+        hardcoreSubtitle.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hardcoreSubtitle)
+
         NSLayoutConstraint.activate([
             headerLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
             headerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
@@ -171,7 +191,30 @@ final class PrefRetroAchievementsController: NSViewController {
             registerLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 8),
             registerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
             registerLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            hardcoreDivider.topAnchor.constraint(equalTo: registerLabel.bottomAnchor, constant: 24),
+            hardcoreDivider.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            hardcoreDivider.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+            hardcoreDivider.heightAnchor.constraint(equalToConstant: 1),
+
+            hardcoreCheckbox.topAnchor.constraint(equalTo: hardcoreDivider.bottomAnchor, constant: 16),
+            hardcoreCheckbox.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            hardcoreCheckbox.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            hardcoreSubtitle.topAnchor.constraint(equalTo: hardcoreCheckbox.bottomAnchor, constant: 4),
+            hardcoreSubtitle.leadingAnchor.constraint(equalTo: hardcoreCheckbox.leadingAnchor, constant: 20),
+            hardcoreSubtitle.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
         ])
+    }
+
+    @objc private func toggleHardcore(_ sender: NSButton) {
+        let enabled = (sender.state == .on)
+        UserDefaults.standard.set(enabled, forKey: RAHardcoreEnabledKey)
+        NotificationCenter.default.post(
+            name: .OERAHardcoreDidChange,
+            object: nil,
+            userInfo: [OEHardcoreEnabledKey: enabled]
+        )
     }
 
     // MARK: - Credential Management
@@ -274,7 +317,7 @@ extension PrefRetroAchievementsController: PreferencePane {
 
     var panelTitle: String { "Achievements" }
 
-    var viewSize: NSSize { NSSize(width: 468, height: 300) }
+    var viewSize: NSSize { NSSize(width: 468, height: 400) }
 }
 
 

--- a/OpenEmuKit/Source/GameCoreManager.swift
+++ b/OpenEmuKit/Source/GameCoreManager.swift
@@ -228,6 +228,10 @@ extension GameCoreManager: OEGameCoreHelper {
     public func setRetroAchievementsToken(_ token: String?, username: String?) {
         gameCoreHelper?.setRetroAchievementsToken(token, username: username)
     }
+
+    public func setHardcoreEnabled(_ enabled: Bool) {
+        gameCoreHelper?.setHardcoreEnabled(enabled)
+    }
 }
 
 // MARK: - Synchronous image capture APIs

--- a/OpenEmuKit/Source/OEGameCoreHelper.swift
+++ b/OpenEmuKit/Source/OEGameCoreHelper.swift
@@ -101,4 +101,12 @@ import AudioToolbox
     ///   - token: The stored RA token, or `nil` to log out.
     ///   - username: The RA username associated with the token.
     func setRetroAchievementsToken(_ token: String?, username: String?)
+
+    /// Toggle RetroAchievements hardcore mode in the helper process.
+    ///
+    /// The helper posts a notification received by active cores, which call
+    /// `rc_client_set_hardcore_enabled` with the new value.
+    ///
+    /// - Parameter enabled: `true` to enable hardcore mode, `false` for softcore.
+    func setHardcoreEnabled(_ enabled: Bool)
 }

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -34,6 +34,15 @@ public extension Notification.Name {
 public let OERetroAchievementsTokenKey    = "token"
 public let OERetroAchievementsUsernameKey = "username"
 
+/// Posted by `OpenEmuHelperApp` when the user toggles RA hardcore mode.
+/// - `userInfo[OEHardcoreEnabledKey]`: the new value as `Bool`.
+public extension Notification.Name {
+    static let OEHardcoreModeDidChange = Notification.Name("OEHardcoreModeDidChange")
+}
+
+/// Key in the `OEHardcoreModeDidChange` notification's `userInfo` dictionary.
+public let OEHardcoreEnabledKey = "hardcoreEnabled"
+
 /// Posted by a core plugin when an achievement is earned.
 public extension Notification.Name {
     static let OEAchievementUnlocked = Notification.Name("OEAchievementUnlocked")

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -35,6 +35,11 @@
 #define OERetroAchievementsTokenKey                   @"token"
 #define OERetroAchievementsUsernameKey                @"username"
 
+/// NSNotificationCenter name posted by OpenEmuHelperApp when the RA hardcore mode toggle flips.
+/// userInfo key: `OEHardcoreEnabledKey` (NSNumber boolValue).
+#define OEHardcoreModeDidChangeNotification @"OEHardcoreModeDidChange"
+#define OEHardcoreEnabledKey                @"hardcoreEnabled"
+
 /// NSNotificationCenter name posted by a core plugin when an achievement is unlocked.
 /// userInfo keys: `OEAchievementIDKey` (NSNumber UInt32), `OEAchievementTitleKey` (NSString),
 /// `OEAchievementDescriptionKey` (NSString), `OEAchievementBadgeURLKey` (NSString),

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -51,7 +51,14 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
 
     char rcClause[64] = {0};
     rc_client_get_user_agent_clause(client, rcClause, sizeof(rcClause));
-    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu %@", [NSString stringWithUTF8String:rcClause]];
+
+    // RA expects an identifying User-Agent so they can correlate traffic to the host app.
+    // Format: OpenEmu/<host-version> (macOS <os-version>) rcheevos/<...>
+    NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
+    NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSString *osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld", (long)osv.majorVersion, (long)osv.minorVersion, (long)osv.patchVersion];
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu/%@ (macOS %@) %@",
+                            hostVersion, osVersion, [NSString stringWithUTF8String:rcClause]];
     [urlRequest setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
     if (request->post_data) {

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -94,6 +94,10 @@ extension OSLog {
     // Stored here so the core can pick it up at load time and on mid-session token delivery.
     var _retroAchievementsToken: String?
 
+    // RA hardcore mode flag received from the main app via XPC. Defaults to true
+    // (RA's recommended default); cores read this at load time and on mid-session toggles.
+    var _hardcoreEnabled: Bool = true
+
     // Observer for achievement unlock notifications posted by the active core plugin.
     var _achievementObserver: Any?
 
@@ -500,7 +504,16 @@ extension OSLog {
             userInfo: userInfo
         )
     }
-    
+
+    public func setHardcoreEnabled(_ enabled: Bool) {
+        _hardcoreEnabled = enabled
+        NotificationCenter.default.post(
+            name: .OEHardcoreModeDidChange,
+            object: nil,
+            userInfo: [OEHardcoreEnabledKey: enabled]
+        )
+    }
+
     public func saveStateToFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void) {
         gameCore.perform {
             self.gameCore.saveStateToFile(at: fileURL, completionHandler: block)

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -283,6 +283,7 @@ extension OSLog {
         gameCore.romMD5             = info.romMD5
         gameCore.romHeader          = info.romHeader
         gameCore.romSerial          = info.romSerial
+        gameCore.hardcoreEnabled    = _hardcoreEnabled
         
         _systemResponder.client                 = gameCore
         _systemResponder.globalEventsHandler    = self
@@ -507,6 +508,9 @@ extension OSLog {
 
     public func setHardcoreEnabled(_ enabled: Bool) {
         _hardcoreEnabled = enabled
+        // Gate rewind / fast-forward / frame-step at the core level. The OESystemResponder
+        // calls those directly on the OEGameCore client, bypassing our host-side gates.
+        gameCore?.hardcoreEnabled = enabled
         NotificationCenter.default.post(
             name: .OEHardcoreModeDidChange,
             object: nil,
@@ -839,23 +843,27 @@ extension OSLog {
     }
     
     public func fastForwardGameplay(_ enable: Bool) {
+        if _hardcoreEnabled { return }
         // Required so that _videoLayer.nextDrawable() vends frames faster than the display refresh rate
         // Fixes: https://github.com/OpenEmu/OpenEmu/issues/4780
         _videoLayer.displaySyncEnabled = !enable
         gameCoreOwner.fastForwardGameplay(enable)
     }
-    
+
     public func rewindGameplay(_ enable: Bool) {
+        if _hardcoreEnabled { return }
         // TODO: technically a data race, but it is only updating a single NSInteger
         _filterChain.frameDirection = enable ? -1 : 1
         gameCoreOwner.rewindGameplay(enable)
     }
-    
+
     public func stepGameplayFrameForward(_ sender: Any) {
+        if _hardcoreEnabled { return }
         gameCoreOwner.stepGameplayFrameForward()
     }
-    
+
     public func stepGameplayFrameBackward(_ sender: Any) {
+        if _hardcoreEnabled { return }
         gameCoreOwner.stepGameplayFrameBackward()
     }
     

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -65,6 +65,8 @@
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
 }
 
 - (void)finalizeAudioSamples;
@@ -716,7 +718,8 @@ static __weak SNESGameCore *_current;
         if (_rcClient) {
             rc_client_set_userdata(_rcClient, (__bridge void *)self);
             rc_client_set_event_handler(_rcClient, snes9x_rc_event_handler);
-            rc_client_set_hardcore_enabled(_rcClient, 0);
+            _raHardcoreEnabled = YES;
+            rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
             rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, snes9x_rc_log);
 
             __weak SNESGameCore *weakSelf = self;
@@ -737,6 +740,20 @@ static __weak SNESGameCore *_current;
                                                      (__bridge void *)s);
                 } else {
                     rc_client_logout(s->_rcClient);
+                }
+            }];
+
+            _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:OEHardcoreModeDidChangeNotification
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *note) {
+                NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+                if (enabled) {
+                    self->_raHardcoreEnabled = enabled.boolValue;
+                    if (self->_rcClient) {
+                        rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                    }
                 }
             }];
         }
@@ -791,6 +808,10 @@ static __weak SNESGameCore *_current;
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
     if (_rcClient) {
         rc_client_unload_game(_rcClient);

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -65,6 +65,8 @@ const char* projectVersion;
 	NSMutableDictionary *cheatSets;
 	rc_client_t *_rcClient;
     id _raTokenObserver;
+    BOOL _raHardcoreEnabled;
+    id _raHardcoreObserver;
     NSString *_romPath;
 }
 - (struct mCore *)mCore;
@@ -241,7 +243,8 @@ static struct mLogger logger = { .log = _log };
         _romPath = path;
         rc_client_set_userdata(_rcClient, (__bridge void *)self);
         rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
-        rc_client_set_hardcore_enabled(_rcClient, 0);
+        _raHardcoreEnabled = YES;
+        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mGBA_rc_log);
 
         // Register token observer before game identification so we don't miss
@@ -265,6 +268,20 @@ static struct mLogger logger = { .log = _log };
                                                  (__bridge void *)s);
             } else {
                 rc_client_logout(s->_rcClient);
+            }
+        }];
+
+        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:OEHardcoreModeDidChangeNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+            if (enabled) {
+                self->_raHardcoreEnabled = enabled.boolValue;
+                if (self->_rcClient) {
+                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
+                }
             }
         }];
     }
@@ -293,6 +310,10 @@ static struct mLogger logger = { .log = _log };
     if (_raTokenObserver) {
         [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
         _raTokenObserver = nil;
+    }
+    if (_raHardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
+        _raHardcoreObserver = nil;
     }
 	if (_rcClient) {
         rc_client_unload_game(_rcClient);


### PR DESCRIPTION
## What does this PR do?

Adds a user-facing RetroAchievements hardcore mode toggle and enforces RA's auto-fail criteria across all 9 RA-enabled cores plus the host app. This is the precondition for getting OpenEmu-Silicon onto RA's whitelist of approved emulators.

When hardcore is on (default), save state loading, rewind, fast-forward, frame-step, and cheats are all disabled and the running game shows a persistent "HARDCORE" overlay. Toggling soft→hard mid-game requires confirming a reset (per RA spec); hard→soft is silent.

## What did you test?

- Built and launched the debug app via `./Scripts/launch-debug.sh`
- Tested end-to-end on Super Mario Bros. on **Nestopia** and **FCEU**:
  - Default-on hardcore shows the HARDCORE shield overlay at game start
  - Save state load → alert "Save state loading is disabled in hardcore mode"
  - Rewind / fast-forward / step-forward / step-backward (keyboard bindings) are all complete no-ops; lock stays visible
  - Cheats menu greyed out
  - Toggling hardcore off mid-game drops to softcore immediately with no prompt; all features re-enable
  - Toggling hardcore on mid-game prompts "Switching to hardcore mode requires restarting the game" → confirm → game resets
  - Achievement unlock banner still fires (RA hardcore gates the cheating-equivalent features, not achievements themselves)
- Build clean: `./Scripts/verify.sh` (host app), `./Scripts/verify.sh --core <CoreName>` for all 9 cores (Snes9x / mGBA / Mednafen need `--release` per their existing build config)

User to also test on additional systems before merge.

## Which cores or systems are affected?

Host app (preference UI, gates, HUD, XPC plumbing) and all 9 RA-enabled cores: **Nestopia, FCEU, BSNES, Snes9x, Gambatte, GenesisPlus, mGBA, Mupen64Plus, Mednafen**.

Out of scope (separate RA stacks, tracked separately): **Flycast** (#259) has its own `settings.raHardcoreMode`. **Dolphin** (#260) likewise. **Libretro host** (#360) will need the same preference read once libretro RA infra ships.

## Did you use AI tools?

Yes — used Claude (Opus) to draft the implementation against a written plan, including the regex-based core patches, the OEGameCore base-class gate for keyboard-bound rewind/FF/step (which bypasses the host-side gates via `OESystemResponder`), and the verification flow. Reviewed and tested manually before opening this PR.

## Linked issues

Related to #438
Related to #258

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

For per-core testing:

```bash
./Scripts/verify.sh --core Nestopia
./Scripts/launch-debug.sh
```

For Snes9x / mGBA / Mednafen add `--release`. Sign in to RetroAchievements under Preferences ▸ Achievements; the new "Hardcore mode (recommended)" checkbox is below the sign-in section and defaults to **on**. Load any RA-supported ROM and confirm the lock overlay appears, save state load is blocked, and rewind/fast-forward/step keys are no-ops.

---

## Notes

- RA's server currently flags this client with an "Unknown Emulator" notification because OpenEmu-Silicon isn't on their whitelist yet — this PR is the prerequisite for that submission, not a regression.
- Hardcore HUD art is an SF Symbol (`lock.shield.fill`) placeholder; final asset can come in a follow-up.
- The User-Agent on RA traffic now follows their expected `Name/Version (OS)` shape: `OpenEmu/<version> (macOS <os-version>) rcheevos/<...>`.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M-series Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (none added)