### PR TITLE
feat: expand Sentry instrumentation in helper process and host

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,6 +30,21 @@ if [ ! -x ./Scripts/verify.sh ]; then
   exit 0
 fi
 
+# Skip verify if the exact HEAD being pushed already passed verification and
+# the tree is clean. verify.sh writes this stamp on a successful run. This
+# avoids re-running verify back-to-back, which races on Xcode's build.db lock
+# (SWBBuildService stays alive ~30s after xcodebuild exits and holds the DB).
+STAMP_FILE=$(git rev-parse --git-path verify-passed 2>/dev/null || true)
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+if [ -n "$STAMP_FILE" ] && [ -f "$STAMP_FILE" ] && [ -n "$HEAD_SHA" ]; then
+  STAMPED_SHA=$(cat "$STAMP_FILE" 2>/dev/null || echo "")
+  if [ "$STAMPED_SHA" = "$HEAD_SHA" ] && git diff --quiet && git diff --cached --quiet; then
+    echo "[pre-push] verify.sh PASSED earlier for $HEAD_SHA — skipping"
+    echo "[pre-push] (delete $STAMP_FILE to force a re-run)"
+    exit 0
+  fi
+fi
+
 echo "[pre-push] Running Scripts/verify.sh ..."
 if ./Scripts/verify.sh; then
   echo "[pre-push] verify.sh PASSED — push allowed"

--- a/OpenEmu/OpenEmuHelperApp/main.swift
+++ b/OpenEmu/OpenEmuHelperApp/main.swift
@@ -39,10 +39,41 @@ if (consentValue as? Bool) == true {
     let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
     let build   = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
     SentrySDK.start { options in
-        options.dsn         = "https://387777a8153aae33cb514deea3601946@o4511164820815872.ingest.us.sentry.io/4511164891529216"
-        options.releaseName = "openemu-silicon@\(version)+\(build)"
-        options.environment = "production"
-        options.debug       = false
+        options.dsn              = "https://387777a8153aae33cb514deea3601946@o4511164820815872.ingest.us.sentry.io/4511164891529216"
+        options.releaseName      = "openemu-silicon@\(version)+\(build)"
+        options.environment      = "production"
+        options.debug            = false
+        options.tracesSampleRate = 0.2
+        options.enableLogs       = true
+        options.enableMetricKit  = true
+        options.appHangTimeoutInterval = 1.0
+    }
+
+    // Tag this helper process with the active game/system/core. The host writes
+    // these into its preference domain just before launching the helper, and
+    // CFPreferencesCopyValue reads from the host domain (this helper is not
+    // sandboxed). Without this, every helper crash arrives with no emulation
+    // context — and most crashes happen in the helper, not the host.
+    let domain = "org.openemu.OpenEmu" as CFString
+    func ctx(_ key: String) -> String? {
+        CFPreferencesCopyValue(key as CFString, domain, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? String
+    }
+    let game   = ctx("OESentryActiveGame")
+    let system = ctx("OESentryActiveSystem")
+    let core   = ctx("OESentryActiveCore")
+    if game != nil || system != nil || core != nil {
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: [
+                "game":   game   ?? "Unknown",
+                "system": system ?? "Unknown",
+                "core":   core   ?? "Unknown",
+                "process": "helper",
+            ], key: "emulation")
+        }
+    } else {
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: ["process": "helper"], key: "emulation")
+        }
     }
 }
 

--- a/OpenEmu/SentryService.swift
+++ b/OpenEmu/SentryService.swift
@@ -35,6 +35,12 @@ enum SentryService {
     private static let consentKey    = "OESentryCrashReportingEnabled"
     private static let hasPromptedKey = "OESentryCrashReportingPrompted"
 
+    // Game-context keys mirrored into CFPreferences so the helper process
+    // (which crashes most often) can attach the same context to its events.
+    private static let ctxGameKey   = "OESentryActiveGame"
+    private static let ctxSystemKey = "OESentryActiveSystem"
+    private static let ctxCoreKey   = "OESentryActiveCore"
+
     /// Call once at the top of applicationDidFinishLaunching.
     /// On first launch, shows a consent prompt. On subsequent launches,
     /// starts Sentry automatically if the user previously opted in.
@@ -63,6 +69,14 @@ enum SentryService {
                 "core": coreIdentifier,
             ], key: "emulation")
         }
+        // Mirror into CFPrefs so the helper process picks up the same context
+        // when it starts Sentry. Synchronize forces the write to disk before
+        // the helper launches.
+        let defaults = UserDefaults.standard
+        defaults.set(gameName,         forKey: ctxGameKey)
+        defaults.set(systemIdentifier, forKey: ctxSystemKey)
+        defaults.set(coreIdentifier,   forKey: ctxCoreKey)
+        defaults.synchronize()
     }
 
     /// Clears game context when emulation ends so stale info doesn't attach to future crashes.
@@ -70,6 +84,11 @@ enum SentryService {
         SentrySDK.configureScope { scope in
             scope.removeContext(key: "emulation")
         }
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: ctxGameKey)
+        defaults.removeObject(forKey: ctxSystemKey)
+        defaults.removeObject(forKey: ctxCoreKey)
+        defaults.synchronize()
     }
 
     /// Records a breadcrumb — a timestamped event visible in the crash report trail.
@@ -146,6 +165,12 @@ enum SentryService {
             options.environment      = "production"
             options.tracesSampleRate = 0.2  // sample 20% of sessions for performance tracing
             options.enableLogs       = true
+            // OS-level diagnostics: hangs the in-process detector misses,
+            // CPU exceptions, disk-write spikes. Off by default in the SDK.
+            options.enableMetricKit  = true
+            // Default is 2.0s. UI thread blocks shorter than that — like the
+            // OEAlert runModal hang we fixed in 01456229 — slip through silently.
+            options.appHangTimeoutInterval = 1.0
         }
     }
 }

--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -348,6 +348,22 @@ if [ "$FAILURES" -eq 0 ]; then
   echo "===================="
   echo "verify.sh: ALL PASS"
   echo "===================="
+  # Stamp the current HEAD as verified. The pre-push hook reads this to
+  # skip re-running verify when the exact commit being pushed already
+  # passed — which avoids the build.db lock contention that happens when
+  # two xcodebuild invocations race against the same DerivedData/worktree
+  # build directory in quick succession.
+  # Only stamp when the full app verification ran (no --core, no --release).
+  # Skip stamping for partial/non-default runs so the hook can't be tricked.
+  if [ -z "$CORE" ] && [ "$CONFIG" = "Debug" ]; then
+    STAMP_FILE=$(git rev-parse --git-path verify-passed 2>/dev/null || true)
+    if [ -n "$STAMP_FILE" ]; then
+      HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+      if [ -n "$HEAD_SHA" ]; then
+        echo "$HEAD_SHA" > "$STAMP_FILE"
+      fi
+    fi
+  fi
   exit 0
 else
   echo "===================="


### PR DESCRIPTION
## What does this PR do?

Expands Sentry instrumentation so OpenEmu's helper process (where most emulation crashes happen) is configured at parity with the host: structured logs, performance tracing, OS-level diagnostics via MetricKit, and tighter app-hang detection. Also propagates the active game/system/core context from host to helper via CFPreferences so helper crashes arrive in Sentry tagged instead of bare. As a side fix, the pre-push hook now caches a successful verify run per HEAD to avoid re-running verify back-to-back, which had been racing against Xcode's `build.db` lock and blocking pushes.

## What did you test?

Ran `./Scripts/verify.sh --worktree` to confirm both processes compile cleanly with the new options (Sentry SDK 9.9.0, all options resolved). Manually confirmed the new pre-push stamp file is created, matches HEAD on subsequent push, and the hook skips re-running verify. Have not yet observed a real Sentry event end-to-end with the new helper context — that requires a production build with consent enabled.

## Which cores or systems are affected?

General app change. Affects the host (`OpenEmu`) and the XPC helper process (`OpenEmuHelperApp`). No cores touched.

## Did you use AI tools?

Used Claude Code to research Sentry Cocoa SDK options, draft the helper/host config changes, and diagnose the pre-push lock-contention issue. Reviewed and verified all changes locally.

## Linked issues

Related to Sentry observability work — no specific issue number.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 444 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --worktree`
- [x] Tested on Apple Silicon (M-series Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] No new files added (existing files modified only)
