### PR TITLE
fix: prevent verify.sh from leaving orphan xcodebuild on pipe close

### DIFF
--- a/Scripts/verify.sh
+++ b/Scripts/verify.sh
@@ -41,6 +41,25 @@
 
 set -uo pipefail
 
+# Ignore SIGPIPE. A truncated consumer (e.g. `verify.sh | head -30`,
+# `... | grep ... | head`) closes its stdin partway through; without this trap,
+# the next echo from verify.sh receives SIGPIPE and terminates the script
+# mid-run. The currently running xcodebuild child then gets orphaned and keeps
+# holding the build.db lock, which causes the *next* verify invocation to fail
+# with a "database is locked" build error — the symptom that's been showing up
+# across worktrees today.
+trap '' PIPE
+
+# On any exit, terminate child processes so xcodebuild cannot outlive the
+# script. xcodebuild handles SIGTERM cleanly and propagates to its own
+# children (swift-frontend, clang, ld, etc.), which releases the build.db
+# lock for the next verify run. Errors are suppressed because there may be
+# no children to kill on a clean exit.
+verify_cleanup_children() {
+  pkill -TERM -P $$ 2>/dev/null || true
+}
+trap verify_cleanup_children EXIT
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"


### PR DESCRIPTION
## What does this PR do?

Two-line hardening to `Scripts/verify.sh` so it survives a truncated stdout consumer (`verify.sh | tail -N`, `... | grep ... | head`, etc.) and cleans up its xcodebuild child on exit. This eliminates the "every PR I push hits a stale build.db lock" loop that's been showing up across worktrees today.

**Root cause.** When verify.sh's stdout pipe closes early, the next echo from the script receives SIGPIPE and the script terminates. The xcodebuild it spawned is then orphaned and keeps holding build.db locked for ~30s. The next verify run in the same worktree's ~/Builds/openemu/<branch>/ path then fails with cryptic build errors (manifesting today as exit 144 / "database is locked"). AI sessions in particular trip this constantly because they reflexively pipe verify.sh through grep/head/tail.

**Fix.**

1. `trap '' PIPE` near the top of the script — ignore SIGPIPE so a truncated consumer no longer aborts the run. Output to a closed pipe is silently dropped; the script runs to completion. This is the load-bearing change.
2. `trap verify_cleanup_children EXIT` — defensive: if verify.sh exits for any other reason (Ctrl+C, parent kill), `pkill -TERM -P $$` reaps direct children so xcodebuild cannot outlive the script.

Companion to f25c488f on `feat/sentry-updates` (stamp-file caching that skips re-verify on push when HEAD already passed). That commit addresses the manual-verify-then-push lock contention case; this PR addresses the truncated-output case. Together they should knock out both flavors of the failure mode.

## What did you test?

Isolated reproducer with a fake long-running child mimicking xcodebuild:

- **Test A** — `trap-test.sh | head -2` (forces early pipe close). With `trap '' PIPE`, the script runs to completion instead of dying on its 3rd echo. Zero orphan children left behind.
- **Test B** — Spawn the script, SIGTERM the parent mid-run. The EXIT trap fires and `pkill -P $$` reaps the child. Confirmed via `kill -0 $CHILD` returning non-zero.

Both confirmed in under 3 seconds, no full-app build required.

End-to-end: this branch's own `git push` exercised the pre-push hook → ran `verify.sh` → ALL PASS → push allowed.

## Which cores or systems are affected?

None. Tooling-only change. No core or app code modified.

## Did you use AI tools?

Yes. Claude Code drafted the trap design and the isolated reproducer; I reviewed, ran the tests, and committed. Diagnosis went through one wrong turn (initially blamed concurrent xcodebuilds across worktrees, was actually SIGPIPE + orphan) so the eventual fix is narrower and more surgical than the first instinct.

## Linked issues

Related to #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

To confirm the fix specifically: run `./Scripts/verify.sh | head -2` and check that no orphan xcodebuild process is left behind (`pgrep -lf 'xcodebuild.*OpenEmu'`).

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (gated by the pre-push hook on this very push)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
