### PR TITLE
fix: clamp negative buffer sizes in OEDiffQueueTests helper

### DIFF
--- a/OpenEmu-SDK/OpenEmuBaseTests/OEDiffQueueTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEDiffQueueTests.m
@@ -47,8 +47,8 @@
 - (NSData *)dataByMutatingData:(NSData *)orig withFrequency:(double)freq sizeDifference:(NSInteger)diff
 {
     NSInteger oldsize = orig.length;
-    NSInteger newsize = oldsize + diff;
-    NSInteger commonsize = MIN(newsize, oldsize);
+    NSInteger newsize = MAX(oldsize + diff, (NSInteger)0);
+    NSInteger commonsize = MAX(MIN(newsize, oldsize), (NSInteger)0);
     
     char *newbuf = malloc(newsize);
     memcpy(newbuf, orig.bytes, commonsize);


### PR DESCRIPTION
## What does this PR do?

Clamps buffer sizes to >= 0 in the `dataByMutatingData:withFrequency:sizeDifference:` test helper. When `testBigDeltas` ran 100 random size-delta mutations in a row, a run of negative-leaning rolls could drive the cumulative size below zero — which then cast to a huge `size_t` in `malloc()` and `memcpy()`, reliably crashing on the GitHub Actions arm64 runner and intermittently elsewhere. This was blocking CI on every unrelated open PR.

## What did you test?

All 26 tests in the OpenEmuBaseTests scheme pass locally after the change. No app behavior is affected — this is test-only code.

## Which cores or systems are affected?

None — test helper only, no production code changed.

## Did you use AI tools?

Used Claude to identify the root cause and draft the fix, reviewed the change manually.

## Linked issues

Fixes #

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 449 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header