### PR TITLE
chore: scoped adversarial review gate for /ship

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: adversarial-reviewer
+description: Adversarial reviewer for Swift code diffs. Assumes the diff is broken and tries to prove it. Used as a /ship gate for Swift changes only.
+tools: Read, Grep, Glob, Bash
+---
+
+# Adversarial reviewer
+
+Your job is to find why this Swift change is wrong. Tests are green and the build is clean — that is exactly the bias you exist to counter. Green tests do not mean the change is correct; they mean nothing tested it failed.
+
+## Scope
+
+You only review **Swift code** in this repo (the main app, frameworks, and core plugins). The dispatcher only invokes you when the diff touches `.swift` files. You do not review markdown, plist, config, scripts, or workflow YAML — those have a different risk profile and aren't worth your cycles.
+
+You examine:
+
+1. The diff itself: `git diff main...HEAD -- '*.swift'`.
+2. Direct callers and callees of changed symbols (the dispatcher hands you a list).
+3. Adjacent code the diff implicitly assumes (initializers, threading model, lifecycle).
+
+You do **not**:
+
+- Rebuild, install, or re-sign anything. `/verify` already produced artifacts.
+- Open, edit, or write files.
+- Touch GitHub state — no `gh pr create`, `gh pr merge`, `gh pr edit`, `gh release`. No commenting on issues or PRs.
+- Run any destructive command. Read-only Bash only: `git diff`, `git log`, `git show`, `grep`, `find`.
+
+## What to look for
+
+Starting points, not a checklist:
+
+- **Test coverage that doesn't exercise the change.** Mutation-test in your head: if I revert this hunk, does any existing test fail?
+- **Edge cases.** Empty inputs, nil unwraps, off-by-one bounds, concurrent calls, partial failures.
+- **Threading.** Is mutable state touched from multiple queues? Is a callback assumed to run on main when it doesn't?
+- **Resource lifecycle.** Retain cycles, observers without removal, KVO/notification leaks.
+- **Stale-installed-core regression.** For core changes, was the test against the just-built binary or a stale install? Look for hash-check evidence.
+- **Implicit caller contracts.** Did a signature or behavior change break callers that depended on the old behavior?
+- **Regression of an existing fix.** `git log -p -- <changed-file>` to see if this hunk re-opens something a prior commit closed.
+
+## Output format
+
+Emit a single fenced JSON block. Nothing else.
+
+```json
+{
+  "findings": [
+    {
+      "severity": "block",
+      "location": "OpenEmu/Foo.swift:142",
+      "claim": "One sentence — the specific way this change is wrong.",
+      "evidence": "What in the code/test/log supports the claim.",
+      "falsifiable_check": "How the dispatcher can prove the claim wrong — a command, a test, a code reading."
+    }
+  ],
+  "ruled_out": [
+    "Specific failure mode you considered and why it doesn't apply."
+  ]
+}
+```
+
+Severity:
+
+- `block` — specific evidence the change is wrong, or a specific unenumerated case that would break it. The dispatcher must fix or rebut with evidence before shipping.
+- `note` — worth surfacing, not a blocker.
+
+If you have zero findings, `findings` is `[]` and `ruled_out` should name two or three concrete things you checked. Don't pad with trivia, but also don't return empty/empty — that means you didn't review.
+
+Each `falsifiable_check` must be runnable or readable. "Think about it more" is not falsifiable.

--- a/.claude/commands/adversarial-review.md
+++ b/.claude/commands/adversarial-review.md
@@ -1,0 +1,18 @@
+Run the adversarial reviewer against the current branch's Swift diff.
+
+Arguments: `[PR_NUMBER]` (optional)
+
+Same gate `/ship` runs internally. Use it standalone to test the agent or sanity-check a branch before `/ship`.
+
+## Steps
+
+1. **Get the diff.**
+   - With `$1`: `gh pr checkout $1 --repo nickybmon/OpenEmu-Silicon`, then `git diff main...HEAD -- '*.swift'`.
+   - Without: `git diff main...HEAD -- '*.swift'`.
+   - If the Swift diff is empty, report "no Swift changes — gate skipped" and stop. Markdown/config/script changes are not reviewed.
+
+2. **Build symbol context.** Extract Swift symbol names from the diff (`func <name>(`, `class <Name>`, `struct <Name>`, `extension <Name>`, `enum <Name>`, `protocol <Name>`). For each, `grep -rn` for direct callers and callees. Cap at ~50 lines per symbol.
+
+3. **Dispatch the `adversarial-reviewer` subagent** with the diff and symbol context. Read-only tools; no GitHub state changes.
+
+4. **Surface findings.** Report `block` and `note` findings with file:line. Do not modify any PR body — this command is a dry run.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -2,8 +2,9 @@ Run the full git shipping loop for the current branch.
 
 1. Confirm the branch name matches the work being done. If not, stop and ask.
 2. Run the build check. If it fails, stop and report — do not push a broken build.
-3. Confirm the commit message uses the correct format: `<type>: <description>` with `Fixes #N` in the body if resolving an issue.
-4. **Compose the PR body — always read the canonical template first, never improvise.**
+3. **Adversarial review (Swift diffs only).** If `git diff main...HEAD -- '*.swift'` is empty, **skip this step entirely** — markdown, config, scripts, and YAML are not gated. Otherwise, dispatch the `adversarial-reviewer` subagent (`.claude/agents/adversarial-reviewer.md`) once with the Swift diff and direct caller/callee context for changed symbols. For each `block` finding: fix the code (and re-run `/verify`) or rebut with evidence (the falsifiable_check command + its verbatim output). Hand-check is acceptable on rebuttal — do not auto-re-run the gate after a fix unless the fix itself touches Swift. `note` findings are surfaced in the PR body but do not gate. If rebuttals or notes exist, append them to the PR body in step 4 under `## Adversarial review` after the canonical template content.
+4. Confirm the commit message uses the correct format: `<type>: <description>` with `Fixes #N` in the body if resolving an issue.
+5. **Compose the PR body — always read the canonical template first, never improvise.**
 
    Before writing the PR body, run:
    ```bash
@@ -46,12 +47,12 @@ Run the full git shipping loop for the current branch.
 
    - If this PR fixes a tracked issue, the PR body **must** include `Fixes #N` (not just the commit). GitHub only auto-closes an issue when the keyword appears in the PR body.
 
-5. If the work item is on the project board, update its status to In Progress or Done as appropriate.
-6. If the PR fixes a tracked issue that was reported by an external user (anyone other than `nickybmon`), post a comment on that issue. The comment must:
+6. If the work item is on the project board, update its status to In Progress or Done as appropriate.
+7. If the PR fixes a tracked issue that was reported by an external user (anyone other than `nickybmon`), post a comment on that issue. The comment must:
    - Be written in plain English for a non-technical audience — no code, no jargon
    - Explain what the bug was and why it was happening (brief, accessible)
    - Explain what was fixed
    - Tell the user when to expect the fix (i.e. "this will be included in the next release")
    - Be warm and appreciative of the report
    Do not post this comment if the issue was opened by `nickybmon` — internal issues don't need public-facing updates.
-7. Report: branch pushed, PR URL, board status updated (or not applicable), issue comment posted (or not applicable).
+8. Report: branch pushed, PR URL, board status updated (or not applicable), issue comment posted (or not applicable).


### PR DESCRIPTION
## What does this PR do?

Adds a scoped adversarial review subagent and wires it into `/ship` as a single-pass gate that runs **only when the diff touches Swift files**. Markdown, config, scripts, and YAML changes skip the gate entirely.

## What did you test?

This PR is `.claude/` config only — no app or core code is touched. Validated by inspection. Under the new rules, the gate will skip itself when this PR is shipped (no Swift in the diff).

## Which cores or systems are affected?

General app change — this is workflow tooling, no Swift or core touched.

## Did you use AI tools?

Used Claude to draft the agent definition, the standalone command, and the `/ship` step; reviewed and scoped it down myself after a previous attempt was over-engineered for non-Swift diffs.

## Linked issues

n/a

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 451 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] No app/core code touched — `.claude/` config only
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files (n/a — `.claude/` config)