### PR TITLE
fix: three pre-release regressions — credential loss, quicksave crash, nested modal

### DIFF
--- a/OpenEmu/OECredentialStore.swift
+++ b/OpenEmu/OECredentialStore.swift
@@ -267,8 +267,7 @@ final class OECredentialStore {
         if migrated > 0 {
             os_log(.info, log: log,
                    "Migrated %d credential(s) from keychain to encrypted file store.", migrated)
-            // persist() is called by the caller (ensureLoaded → persist via set) after
-            // migrateFromKeychain returns, so we don't need to call it here.
+            persist()
         }
     }
 

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1185,31 +1185,41 @@ final class OEGameDocument: NSDocument {
             alert.informativeText = NSLocalizedString("Save states, rewind, frame advance, and cheats will be disabled.", comment: "")
             alert.defaultButtonTitle = NSLocalizedString("Restart Game", comment: "")
             alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
-            if alert.runModal() == .alertFirstButtonReturn {
-                // Flush active cheats from the core before engaging hardcore.
-                // setHardcoreEnabled(true) blocks the document's setCheat guard,
-                // but core cheat lists persist across a reset — they must be
-                // cleared first so the restarted session is clean (#447).
-                cheats.filter(\.isEnabled).forEach {
-                    gameCoreManager?.setCheat($0.code, withType: $0.type, enabled: false)
+
+            let handleResponse: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+                guard let self else { return }
+                if response == .alertFirstButtonReturn {
+                    // Flush active cheats from the core before engaging hardcore.
+                    // setHardcoreEnabled(true) blocks the document's setCheat guard,
+                    // but core cheat lists persist across a reset — they must be
+                    // cleared first so the restarted session is clean (#447).
+                    self.cheats.filter(\.isEnabled).forEach {
+                        self.gameCoreManager?.setCheat($0.code, withType: $0.type, enabled: false)
+                    }
+                    self.gameCoreManager?.setHardcoreEnabled(true)
+                    self.gameCoreManager?.resetEmulation { [weak self] in
+                        self?.isEmulationPaused = false
+                    }
+                    self.gameViewController.showHardcoreNotification(true)
+                } else {
+                    // User cancelled — revert the preference so UI and state agree.
+                    // Post the change so the prefs checkbox can resync (#446); if we
+                    // only write UserDefaults, the imperatively-set checkbox stays
+                    // visually checked until the pane is rebuilt.
+                    UserDefaults.standard.set(false, forKey: RAHardcoreEnabledKey)
+                    NotificationCenter.default.post(
+                        name: .OERAHardcoreDidChange,
+                        object: nil,
+                        userInfo: [OEHardcoreEnabledKey: false]
+                    )
+                    self.isEmulationPaused = false
                 }
-                gameCoreManager?.setHardcoreEnabled(true)
-                gameCoreManager?.resetEmulation { [weak self] in
-                    self?.isEmulationPaused = false
-                }
-                gameViewController.showHardcoreNotification(true)
+            }
+
+            if let win = gameWindowController?.window {
+                alert.beginSheetModal(for: win, completionHandler: handleResponse)
             } else {
-                // User cancelled — revert the preference so UI and state agree.
-                // Post the change so the prefs checkbox can resync (#446); if we
-                // only write UserDefaults, the imperatively-set checkbox stays
-                // visually checked until the pane is rebuilt.
-                UserDefaults.standard.set(false, forKey: RAHardcoreEnabledKey)
-                NotificationCenter.default.post(
-                    name: .OERAHardcoreDidChange,
-                    object: nil,
-                    userInfo: [OEHardcoreEnabledKey: false]
-                )
-                isEmulationPaused = false
+                handleResponse(alert.runModal())
             }
         } else if !enabled && HardcoreModePolicy.requiresResetWhenDisabling {
             // Reserved branch for future spec changes — currently unreachable.

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1879,19 +1879,22 @@ final class OEGameDocument: NSDocument {
                 return
             }
             
+            // Re-fetch rom in mainThreadContext for both branches — self.rom may be from a
+            // different NSManagedObjectContext, and calling saveState(withName:) on a
+            // cross-context object crashes (#453 fixed the else branch; this closes the gap
+            // for quicksave/autosave which use the specialNamePrefix branch).
+            let context = OELibraryDatabase.default!.mainThreadContext
+            let romInContext = context.object(with: rom.objectID) as! OEDBRom
+
             var saveState: OEDBSaveState?
             if stateName.hasPrefix(OEDBSaveState.specialNamePrefix),
-               let state = rom.saveState(withName: stateName) {
+               let state = romInContext.saveState(withName: stateName) {
                 state.coreIdentifier = core.bundleIdentifier
                 state.coreVersion = core.version
                 state.replaceStateFileWithFile(at: temporaryStateFileURL)
                 state.timestamp = Date()
                 saveState = state
             } else {
-                let context = OELibraryDatabase.default!.mainThreadContext
-                // Re-fetch rom in the target context to avoid a cross-context relationship crash.
-                // self.rom may have been fetched in a different NSManagedObjectContext.
-                let romInContext = context.object(with: rom.objectID) as! OEDBRom
                 saveState = OEDBSaveState.createSaveState(named: stateName, for: romInContext, core: core, withFile: temporaryStateFileURL, in: context)
             }
             


### PR DESCRIPTION
## What does this PR do?

Fixes three regressions found in adversarial review of changes since v1.1.1. Two are data-loss or crash-risk bugs; one is a subtle modal session issue.

**Fix 1 — Credential store silently deletes all credentials on first read after upgrade** (`OECredentialStore.swift`): `migrateFromKeychain()` was deleting keychain items and populating `cache[]` but never calling `persist()`. A false comment claimed the caller would persist, but `ensureLoaded()` (the only caller) does not. Any read operation (`get`/`has`) on first launch after upgrade would wipe all three credentials (ScreenScraper password, RA token, Google Drive token) with nothing written to disk.

**Fix 2 — Quicksave/autosave crash: incomplete #453 fix** (`OEGameDocument.swift`): The fix for #453 only re-fetched `rom` in `mainThreadContext` for the user-named-save branch. The `specialNamePrefix` branch (quicksave + autosave — the most frequent save path) still called `rom.saveState(withName:)` on a potentially cross-context object. Hoists `context`/`romInContext` above the `if`, shared by both branches.

**Fix 3 — Hardcore mode alert can nest modal sessions** (`OEGameDocument.swift`): `handleHardcoreToggle` called `alert.runModal()` on the main queue. With 20+ `runModal()` call sites in this file, any already-blocking alert would cause a nested `NSApp.runModal` session that could return the wrong response. Converts to `beginSheetModal(for:)` following the existing pattern (lines 2007-2015), falling back to `runModal()` only when no game window is present.

## What did you test?

`./Scripts/verify.sh --launch` — all checks pass, no new warnings introduced by this branch.

Manual checks:
- **Fix 1:** Verified `persist()` is called inside `migrateFromKeychain()` after migrated items are in `cache[]` and `isLoaded` is already `true` — correct ordering confirmed by code inspection.
- **Fix 2:** Context/romInContext hoisted above `if`; both branches use `romInContext`. Quicksave and autosave paths now safe.
- **Fix 3:** Sheet attaches to game window. Cancel path re-entry via `OERAHardcoreDidChange` is safe: observer uses block-based API with `queue: .main` (async delivery), so `isEmulationPaused = false` runs in the same synchronous pass before the observer fires.

## Which cores or systems are affected?

General app change — affects all cores and systems.

## Did you use AI tools?

Used Claude to draft all three fixes, run adversarial review, and verify. Rebuttals to both block findings were verified with code inspection and confirmed false alarms before pushing.

## Linked issues

Related to #438 (hardcore mode compliance)

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 459 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## Adversarial review

Diff reviewed by adversarial-reviewer agent. Two `block` findings raised, both rebutted:

**Block 1 (re-entrancy / stuck `isEmulationPaused`):** `raHardcoreObserver` uses the block-based `addObserver(forName:object:queue:using:)` API with `queue: .main`. Delivery with a non-nil queue is dispatched (async), not run inline. `isEmulationPaused = false` at line 1215 runs in the same synchronous pass before the observer fires. Even under synchronous delivery, the re-entrant call hits `enabled=false → else` branch which never touches `isEmulationPaused`, returns, then line 1215 runs. False alarm.

**Block 2 (document closed while sheet open):** `gameCoreManager` is a strong reference owned by `OEGameDocument`. If `self` is deallocated (document torn down), `gameCoreManager` is released with it — there is no surviving paused emulation core. Additionally macOS prevents Cmd-W while a sheet is attached. False alarm.

**Note:** `gameViewController` accessed without nil check in the confirm path — pre-existing in both old and new code. No fix required; surfaced for future cleanup.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header