### PR TITLE
fix: flush stale-ROM deletion to disk so NAS/relocated-library re-import works (fixes #344)

### DIFF
--- a/OpenEmu/ImportOperation.swift
+++ b/OpenEmu/ImportOperation.swift
@@ -731,11 +731,29 @@ final class ImportOperation: Operation, NSCopying, @unchecked Sendable {
             self.rom = rom
             romLocation = rom.game?.system?.lastLocalizedName
             
-            let isReachable = (try? romURL?.checkResourceIsReachable()) ?? false
+            // romURL being nil means the library volume (e.g. a NAS) is not mounted.
+            // Treat that as unreachable so we don't silently fall through.
+            let isReachable: Bool
+            if let romURL = romURL {
+                isReachable = (try? romURL.checkResourceIsReachable()) ?? false
+            } else {
+                isReachable = false
+            }
+
             if !isReachable {
                 DLog("rom file not available — removing stale entry and re-importing")
                 context.delete(rom)
+                // Save the child context first, then flush to the parent (main-thread
+                // context) so the deletion reaches the SQLite store on disk.  Without
+                // the parent save the deletion lives only in memory; a fresh context
+                // on the next launch re-reads the stale record and blocks re-import.
+                // (Fixes #344 — NAS / relocated-library users.)
                 try? context.save()
+                if let parent = context.parent {
+                    parent.performAndWait {
+                        try? parent.save()
+                    }
+                }
                 self.rom = nil
                 // fall through: let import proceed normally
             } else {


### PR DESCRIPTION
## Summary

Closes #344.

`performImportStepCheckHash()` already detected unreachable `OEDBRom` records and deleted them, but only saved the **child** import context (`try? context.save()`). That write stays in memory; a fresh context on the next launch re-reads the stale record from the SQLite store and re-blocks the import — which is exactly what the user in #344 kept hitting across multiple releases.

**Root cause for this user specifically:** Their library lives on a NAS volume (`FX_02 > emu > Game Library`). When `romURL` is `nil` (volume not mounted), the previous code fell through the reachability check silently. Even when it did delete, the deletion was never flushed to disk.

## Changes

- After deleting the stale rom, save the child context then flush to its parent (main-thread context) via `performAndWait` so the deletion reaches the SQLite store on disk.
- Treat a `nil` `romURL` (library volume unmounted / NAS not reachable at time of check) as unreachable rather than silently falling through.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout  --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

**Test scenario:**
1. Import a ROM, confirm it appears in the library.
2. Right-click → Delete Game → move to trash.
3. Quit OpenEmu completely.
4. Re-launch and try to re-import the same ROM — it should import cleanly without "already in library" error.

For NAS reproduction: repeat with the library relocated to an external volume; unmount the volume, relaunch, remount, then attempt re-import.