### PR TITLE
fix: pre-release hardening — security, backup correctness, and RA core fixes

### DIFF
--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -378,6 +378,11 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
 - (void)loadStateFromFileAtPath:(NSString *)fileName completionHandler:(void (^)(BOOL, NSError *))block
 {
     int success = gb.loadState(fileName.fileSystemRepresentation);
+    // Notify the rcheevos client that emulator state has been externally replaced.
+    // Without this, the RA library keeps evaluating achievement conditions against
+    // stale pre-load state. Matches the reset already present in deserializeState:.
+    if (success == 1 && _rcClient)
+        rc_client_reset(_rcClient);
     if(block) block(success==1, nil);
 }
 

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -625,6 +625,11 @@ static __weak NESGameCore *_current;
         return;
     }
 
+    // Notify the rcheevos client that emulator state has been externally replaced.
+    // Without this, the RA library keeps evaluating achievement conditions against
+    // stale pre-load state. Matches the reset already present in deserializeState:.
+    if (_rcClient)
+        rc_client_reset(_rcClient);
     block(YES, nil);
 }
 

--- a/OpenEmu/GameInfoHelper.swift
+++ b/OpenEmu/GameInfoHelper.swift
@@ -29,13 +29,18 @@ final class GameInfoHelper {
 
     static let shared = GameInfoHelper()
 
+    /// Shared serial queue for all ROM info lookups.
+    /// Previously a new queue was created per call, which allocates a kernel thread
+    /// resource per ROM and can stall the thread pool during large library scans.
+    private let lookupQueue = DispatchQueue(label: "org.openemu.OpenEmu.GameInfoHelper", qos: .userInitiated)
+
     var database: OpenVGDB? {
         return OpenVGDB.shared.isAvailable ? OpenVGDB.shared : nil
     }
 
     func gameInfo(withDictionary gameInfo: [String : Any]) -> [String : Any] {
 
-        DispatchQueue(label: "org.openemu.OpenEmu.GameInfoHelper").sync {
+        lookupQueue.sync {
 
             lazy var resultDict: [String : Any] = [:]
 

--- a/OpenEmu/OECredentialStore.swift
+++ b/OpenEmu/OECredentialStore.swift
@@ -223,6 +223,13 @@ final class OECredentialStore {
             // .atomic writes to a temp file first then renames, preventing a partial write
             // from corrupting the store if the app quits mid-write.
             try combined.write(to: url, options: .atomic)
+            // Restrict to owner-read/write only (0600). The key is derived from the hardware
+            // UUID so any local user who can read the file could also derive the key — 0600
+            // closes that gap and matches what the Keychain enforced for us automatically.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: url.path
+            )
             os_log(.info, log: log, "Credential store persisted (%d entries).", cache.count)
         } catch {
             os_log(.error, log: log,

--- a/OpenEmu/OEFolderBackupManager.swift
+++ b/OpenEmu/OEFolderBackupManager.swift
@@ -87,8 +87,14 @@ extension Notification.Name {
     // MARK: - Private
 
     private var eventStream: FSEventStreamRef?
+    /// Dedicated serial queue for all backup copy operations.
+    /// Serialising writes prevents I/O saturation on slow external/NAS destinations
+    /// when several FSEvents fire simultaneously (e.g. auto-save + screenshot + Info.plist).
+    private let copyQueue = DispatchQueue(label: "org.openemu.OpenEmu.FolderBackup.copy", qos: .utility)
 
     private override init() { super.init() }
+
+    deinit { stopFSEventStream() }
 
     // MARK: - Lifecycle
 
@@ -128,6 +134,18 @@ extension Notification.Name {
         panel.beginSheetModal(for: window) { [weak self] response in
             guard response == .OK, let url = panel.url else {
                 completion(false)
+                return
+            }
+            // Reject a folder that lives inside the OpenEmu support directory.
+            // If the user picks a subfolder of Save States as the destination,
+            // every copy would trigger another FSEvent → infinite copy loop.
+            let supportPath = URL.oeApplicationSupportDirectory.standardized.path
+            if url.standardized.path.hasPrefix(supportPath) {
+                let alert = NSAlert()
+                alert.messageText = "Invalid Backup Folder"
+                alert.informativeText = "The backup folder cannot be inside the OpenEmu data folder. Please choose a different location, such as a folder on an external drive or inside iCloud Drive."
+                alert.alertStyle = .warning
+                alert.beginSheetModal(for: window) { _ in completion(false) }
                 return
             }
             self?.stop()
@@ -213,7 +231,7 @@ extension Notification.Name {
         }
         for localURL in roots {
             guard let dest = backupURL(for: localURL, backupFolder: backupFolder) else { continue }
-            DispatchQueue.global(qos: .utility).async { [weak self] in
+            copyQueue.async { [weak self] in
                 self?.copyToBackupIfNewer(from: localURL, to: dest)
             }
         }
@@ -274,7 +292,19 @@ extension Notification.Name {
         copyFile(from: localURL, to: destURL, direction: "→")
     }
 
-    private func copyFile(from src: URL, to dest: URL, direction: String) {
+    // MARK: - Name sanitisation
+
+    /// Returns a filesystem-safe version of a game name.
+    /// Replaces `/` (path separator) and `..` (parent-directory traversal) so a
+    /// crafted game name cannot write outside the backup folder.
+    private func sanitizedName(_ name: String) -> String {
+        name
+            .replacingOccurrences(of: "/",  with: "_")
+            .replacingOccurrences(of: "..", with: "__")
+    }
+
+    @discardableResult
+    private func copyFile(from src: URL, to dest: URL, direction: String) -> Bool {
         let fm = FileManager.default
         try? fm.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
         let temp = dest.deletingLastPathComponent().appendingPathComponent("." + UUID().uuidString)
@@ -291,7 +321,9 @@ extension Notification.Name {
             try? fm.removeItem(at: temp)
             os_log(.error, log: log, "Copy failed (%@ %@): %@", direction, src.lastPathComponent, error.localizedDescription)
             DispatchQueue.main.async { [weak self] in self?.status = .failed }
+            return false
         }
+        return true
     }
 
     // MARK: - Pre-launch check
@@ -330,11 +362,12 @@ extension Notification.Name {
     ) {
         guard let backupFolder = backupFolderURL else { completion(false); return }
         let systemShort = systemIdentifier.replacingOccurrences(of: "openemu.system.", with: "")
-        let safeName    = gameName.replacingOccurrences(of: "/", with: "_")
+        let safeName    = sanitizedName(gameName)
         let fm = FileManager.default
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { completion(false); return }
+            var allSucceeded = true
 
             // Save states
             let backupStateDir = backupFolder
@@ -344,7 +377,7 @@ extension Notification.Name {
             if let states = try? fm.contentsOfDirectory(at: backupStateDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles) {
                 for f in states where f.pathExtension.lowercased() == "oesavestate" {
                     if let local = self.localURL(for: f, backupFolder: backupFolder) {
-                        self.copyFile(from: f, to: local, direction: "←")
+                        if !self.copyFile(from: f, to: local, direction: "←") { allSucceeded = false }
                     }
                 }
             }
@@ -360,13 +393,13 @@ extension Notification.Name {
                           let files = try? fm.contentsOfDirectory(at: bsDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles) else { continue }
                     for f in files where f.deletingPathExtension().lastPathComponent == safeName {
                         if let local = self.localURL(for: f, backupFolder: backupFolder) {
-                            self.copyFile(from: f, to: local, direction: "←")
+                            if !self.copyFile(from: f, to: local, direction: "←") { allSucceeded = false }
                         }
                     }
                 }
             }
 
-            DispatchQueue.main.async { completion(true) }
+            DispatchQueue.main.async { completion(allSucceeded) }
         }
     }
 
@@ -408,7 +441,7 @@ extension Notification.Name {
 
     private func newestBackupDate(backupFolder: URL, systemIdentifier: String, gameName: String) -> Date? {
         let systemShort = systemIdentifier.replacingOccurrences(of: "openemu.system.", with: "")
-        let safeName    = gameName.replacingOccurrences(of: "/", with: "_")
+        let safeName    = sanitizedName(gameName)
         let fm = FileManager.default
         var dates: [Date] = []
 
@@ -442,7 +475,7 @@ extension Notification.Name {
 
     private func newestLocalDate(systemIdentifier: String, gameName: String) -> Date? {
         let systemShort = systemIdentifier.replacingOccurrences(of: "openemu.system.", with: "")
-        let safeName    = gameName.replacingOccurrences(of: "/", with: "_")
+        let safeName    = sanitizedName(gameName)
         let supportDir  = URL.oeApplicationSupportDirectory
         let fm = FileManager.default
         var dates: [Date] = []

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -487,7 +487,7 @@ private enum RetroAchievementsAPI {
                 DispatchQueue.main.async { completion(.failure(.networkError(error))) }
                 return
             }
-            if let raw = data { NSLog("[RA] Raw response: %@", String(data: raw, encoding: .utf8) ?? "<non-utf8>") }
+
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else {

--- a/OpenEmu/SentryService.swift
+++ b/OpenEmu/SentryService.swift
@@ -133,7 +133,7 @@ enum SentryService {
     private static func showConsentPrompt() {
         let alert = NSAlert()
         alert.messageText = "Help Improve OpenEmu"
-        alert.informativeText = "Would you like to automatically send crash reports when OpenEmu crashes? This helps the team find and fix bugs faster.\n\nNo personal data, game files, or save data is ever included."
+        alert.informativeText = "Would you like to automatically send crash reports when OpenEmu crashes? This helps the team find and fix bugs faster.\n\nReports include the game title, system, and core in use at the time of the crash. No game files, save data, or passwords are ever included."
         alert.addButton(withTitle: "Send Crash Reports")
         alert.addButton(withTitle: "Don't Send")
         alert.alertStyle = .informational


### PR DESCRIPTION
## What does this PR do?

Addresses findings from an adversarial pre-release code review covering all commits since `v2.4.2-ARM64-CloudSync`. Seven files touched across three areas: security, folder backup correctness, and RetroAchievements core compliance.

## What did you test?

- Main app scheme builds clean (`verify.sh`)
- Gambatte and Nestopia core schemes build clean
- Credential store file permissions verified with `ls -la ~/Library/Application\ Support/OpenEmu/.oe_credentials` after launch (should show `-rw-------`)
- Backup folder inside Save States correctly rejected with error sheet
- Backup restore failure path now returns `false` when a copy fails

## Which cores or systems are affected?

- **Gambatte** (Game Boy / GBC) — rc_client_reset fix affects RetroAchievements state tracking after save state load
- **Nestopia** (NES) — same fix
- All systems using folder backup (save state restore completion reporting)
- All users with RetroAchievements or ScreenScraper credentials (credential file permissions)

## Did you use AI tools?

Yes — adversarial review and fixes generated with Claude Code, reviewed and committed by maintainer.

## Linked issues

Related to the pre-release review process for the next app release.

---

## Changes in detail

### Security
- **Remove RA token from system log** — `NSLog("[RA] Raw response: …")` in `PrefRetroAchievementsController.swift` was logging the full RA login response body, which contains the session token as plain JSON. Deleted the line entirely.
- **Credential file permissions** — `OECredentialStore.swift` now sets `0600` permissions on `.oe_credentials` after the atomic write. The AES-GCM key is derived from the hardware UUID (readable by any local process), so a world-readable file meant any local user could decrypt all stored credentials. This closes the gap the Keychain enforced automatically.

### Folder backup
- **Restore reports real outcome** — `restoreFromBackup` tracked a local `allSucceeded` flag and passes the real result to `completion` instead of always calling `completion(true)`.
- **Reject backup-inside-support-dir** — `chooseFolder` now validates the selected URL against the OpenEmu support directory before accepting it. Picking a subfolder of Save States as the backup destination would cause every copy to trigger another FSEvent → infinite copy loop filling the disk. Now rejected with a clear error sheet.
- **Path traversal sanitisation** — `sanitizedName()` helper added, strips both `/` and `..` from game names used in backup folder paths. Replaces the three inline `.replacingOccurrences(of: "/", with: "_")` calls.
- **Serial copy queue** — `handleFSEvents` now dispatches to a dedicated serial `copyQueue` instead of `DispatchQueue.global().async`. Saves that write multiple files simultaneously (auto-save + screenshot + Info.plist) no longer launch unbounded parallel I/O that can saturate slow external/NAS destinations. Also adds `deinit { stopFSEventStream() }` for correctness.

### Sentry consent text
Updated the one-sentence claim from *"No personal data, game files, or save data is ever included"* to accurately state that game title, system, and core are included in crash reports.

### RetroAchievements — Gambatte and Nestopia
`rc_client_reset` was called in `deserializeState:` (in-memory state load) but missing from `loadStateFromFileAtPath:` (file-based load — the path OE's normal save state UI uses). Without this reset, the RA library continues evaluating achievement conditions against pre-load state after a save state is restored, causing achievements to fire incorrectly or not at all. Added the matching call to both cores.

### GameInfoHelper queue
Moved `DispatchQueue(label:)` from inside `gameInfo(withDictionary:)` to a stored property on the class. Previously a new kernel-backed queue was allocated per ROM during library scans — on a library of thousands of ROMs this creates thousands of abandoned queue objects.

---

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

# 2. Build and verify
./Scripts/verify.sh

# 3. Launch
./Scripts/launch-debug.sh
```

**Test credential file permissions** (after first launch post-update):
```bash
ls -la ~/Library/Application\ Support/OpenEmu/.oe_credentials
# Should show: -rw------- (0600, owner only)
```

**Test backup folder rejection:**
1. Open Preferences → Library → Backup
2. Click Choose Folder and navigate inside `~/Library/Application Support/OpenEmu/`
3. Should present an error sheet and not save the folder

**Test RA core fixes** (requires RA account + Gambatte or Nestopia game with achievements):
1. Load a save state from file (not quickload) mid-game
2. Achievements should fire correctly from the loaded state, not from pre-load state

**Install and verify cores after build:**
```bash
./Scripts/install-core.sh Gambatte
./Scripts/verify-core-installed.sh Gambatte
./Scripts/install-core.sh Nestopia
./Scripts/verify-core-installed.sh Nestopia
```

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `xcodebuild -scheme OpenEmu`, `OpenEmu + Gambatte`, `OpenEmu + Nestopia` all succeed
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files