### PR TITLE
fix: PPSSPP JIT on macOS 26 — allow-unsigned-executable-memory entitlement

### DIFF
--- a/OpenEmu/OpenEmuHelperApp/OpenEmuHelperApp.entitlements
+++ b/OpenEmu/OpenEmuHelperApp/OpenEmuHelperApp.entitlements
@@ -8,11 +8,15 @@
 	     launch and produce "The <core> core has quit unexpectedly". -->
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
-	<!-- Allow JIT compilation. Dynarec emulation cores (Mupen64Plus, mGBA,
-	     PPSSPP, and others) write and execute code at runtime. Without this,
-	     hardened runtime blocks mmap(MAP_JIT) and the core crashes immediately
-	     on any platform that uses the recompiler. -->
+	<!-- Allow JIT compilation via MAP_JIT. Used by dynarec cores (Mupen64Plus,
+	     mGBA, Dolphin, Flycast, etc.) that explicitly opt into MAP_JIT. -->
 	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<!-- Allow executing anonymous pages made executable via mprotect, without
+	     MAP_JIT. Required for PPSSPP on macOS 26, where MAP_JIT + W^X enforcement
+	     causes the Emu thread to stall. PPSSPP uses plain mmap + mprotect, which
+	     works on all macOS versions and avoids MAP_JIT complexity entirely. -->
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 </dict>
 </plist>

--- a/PPSSPP/PPSSPP-Core/ppsspp/Common/MemoryUtil.cpp
+++ b/PPSSPP/PPSSPP-Core/ppsspp/Common/MemoryUtil.cpp
@@ -38,6 +38,7 @@
 #include <sys/mman.h>
 #include <mach/vm_param.h>
 #include <unistd.h>
+#include <pthread.h>   // pthread_jit_write_protect_np (macOS 11+)
 // csops is a stable BSD syscall; the header is private/SDK-unavailable in some targets.
 extern "C" int csops(pid_t pid, unsigned int ops, void *useraddr, size_t usersize);
 #define CS_OPS_STATUS  0
@@ -183,17 +184,11 @@ void *AllocateExecutableMemory(size_t size) {
 
 	int mmap_flags = MAP_ANON | MAP_PRIVATE;
 #if defined(__APPLE__) && PPSSPP_ARCH(ARM64)
-	// On Apple Silicon, the code signature validator rejects execution of any
-	// anonymous page not allocated with MAP_JIT when running under hardened
-	// runtime (CS_RUNTIME). Debug builds work with plain mmap + mprotect.
-	// Release builds need MAP_JIT + RWX; macOS (unlike iOS) does not
-	// hardware-enforce W^X so no pthread_jit_write_protect_np is required.
-	uint32_t cs_flags = 0;
-	if (csops(getpid(), CS_OPS_STATUS, &cs_flags, sizeof(cs_flags)) == 0 &&
-		(cs_flags & CS_RUNTIME)) {
-		mmap_flags |= MAP_JIT;
-		prot = PROT_READ | PROT_WRITE | PROT_EXEC;
-	}
+	// On Apple Silicon, the plain mmap + mprotect path works on macOS 26 with
+	// the com.apple.security.cs.allow-jit entitlement — even under Hardened
+	// Runtime. MAP_JIT + RWX is no longer used because macOS 26 enforces
+	// hardware W^X on MAP_JIT pages and the mode-switching complexity it
+	// introduces causes the Emu thread to stall.
 #endif
 	void* ptr = mmap(map_hint, size, prot, mmap_flags, -1, 0);
 #endif /* defined(_WIN32) */
@@ -338,12 +333,7 @@ bool ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
 	return true;
 #else
 #if defined(__APPLE__) && PPSSPP_ARCH(ARM64)
-	// Under hardened runtime, JIT pages are MAP_JIT + RWX — mprotect is a no-op.
-	uint32_t cs_flags = 0;
-	if (csops(getpid(), CS_OPS_STATUS, &cs_flags, sizeof(cs_flags)) == 0 &&
-		(cs_flags & CS_RUNTIME)) {
-		return true;
-	}
+	// No special handling needed — mprotect works for both debug and production.
 #endif
 	uint32_t protect = ConvertProtFlagsUnix(memProtFlags);
 	uintptr_t page_size = GetMemoryProtectPageSize();


### PR DESCRIPTION
## Summary

macOS 26 blocks `mprotect(PROT_EXEC)` on anonymous pages under Hardened Runtime unless the process has the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement. The existing `allow-jit` entitlement only covers `MAP_JIT` pages — plain mmap + mprotect requires this separate entitlement.

### Root cause

PPSSPP uses `PlatformIsWXExclusive() = true` on macOS ARM64:
1. `AllocateExecutableMemory`: `mmap` with `PROT_READ|PROT_WRITE` (no EXEC)
2. JIT writes compiled ARM64 code into the buffer
3. `ProtectMemoryPages(EXEC)`: `mprotect → PROT_READ|EXEC` before executing

Under Hardened Runtime **without** `allow-unsigned-executable-memory`, step 3 silently fails — the Emu thread stalls waiting for a VBLANK that never fires → permanent black screen → hang on quit (force-quit required).

MAP_JIT was investigated as an alternative but macOS 26 now enforces hardware W^X on MAP_JIT pages (like iOS always has), requiring `pthread_jit_write_protect_np` mode-switching at every compile/execute boundary. The complexity caused the Emu thread to stall in write mode.

### Changes

- **`OpenEmuHelperApp.entitlements`**: add `com.apple.security.cs.allow-unsigned-executable-memory` — enables `mprotect(PROT_EXEC)` on anonymous pages under Hardened Runtime
- **`MemoryUtil.cpp`**: remove the `CS_RUNTIME → MAP_JIT + RWX` branch; plain mmap + mprotect now works identically in Debug and Release builds on macOS 26

### Verified

Final Fantasy Tactics: The War of the Lions boots and renders correctly on macOS 26.4.1 (25E253) in both Debug and Release (Hardened Runtime) configurations.

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout 471 --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + PPSSPP' \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -5

# 3. Install core
./Scripts/install-core.sh PPSSPP

# 4. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Launch any PSP game. Before this fix: black screen, hang on quit. After: game renders correctly.