### PR TITLE
chore: cores-v1.3.2 appcasts — PPSSPP 1.14.7 + 4DO 2.3.4

### DIFF
--- a/Appcasts/4do.xml
+++ b/Appcasts/4do.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>4DO</title>
-            <item>
+                <item>
+      <title>4DO 2.3.4</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.2/4DO.oecoreplugin.zip"
+        sparkle:version="2.3.4"
+        sparkle:shortVersionString="2.3.4"
+        length="154776"
+        sparkle:edSignature="uTPCtL7HkAFz8ZJtg018aPHIbT70rlw4uuLMFM4sUH303DS9Ra6mva+AxGuHnrU1S0NetkyF+srYq1s4kOV6Cw=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>4DO 2.3.3</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/ppsspp.xml
+++ b/Appcasts/ppsspp.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>PPSSPP</title>
-            <item>
+                <item>
+      <title>PPSSPP 1.14.7</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.2/PPSSPP.oecoreplugin.zip"
+        sparkle:version="1.14.7"
+        sparkle:shortVersionString="1.14.7"
+        length="12709175"
+        sparkle:edSignature="bdW9WC+VrIF+ikREMO01PX6kXILPUsiKwfZIaahTzWAqjAPdBjfvn0g0XdId6we+WzPqvv7diGmOpGoyTiWhDg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>PPSSPP 1.14.6</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure


### PR DESCRIPTION
Updates appcasts for the two cores refreshed in the existing cores-v1.3.2 pre-release.

- **PPSSPP 1.14.7** — macOS 26 JIT fix (allow-unsigned-executable-memory + plain mmap path)
- **4DO 2.3.4** — audio stereo unpack + video buffer return fixes

Assets already uploaded to cores-v1.3.2 release via `package-core.sh`. No new release tag needed.