### PR TITLE
chore: bump build to 15 for v1.1.2 (PPSSPP entitlement fix)

### DIFF
--- a/OpenEmu/OpenEmu-Info.plist
+++ b/OpenEmu/OpenEmu-Info.plist
@@ -143,7 +143,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Bumps CFBundleVersion 14→15 so Sparkle delivers the rebuilt v1.1.2 DMG (which includes the allow-unsigned-executable-memory entitlement fix for PPSSPP on macOS 26) to users who already installed build 14.