### PR TITLE
fix: 4DO video garbled in Release builds — move Get_Frame_Bitmap to executeFrame

### DIFF
--- a/4DO/FreeDOGameCore.mm
+++ b/4DO/FreeDOGameCore.mm
@@ -388,7 +388,21 @@ static void writeSaveFile(const char* path)
 
 - (void)executeFrame
 {
-    _freedo_Interface(FDP_DO_EXECFRAME, frame); // FDP_DO_EXECFRAME_MT ?
+    _freedo_Interface(FDP_DO_EXECFRAME, frame);
+
+    // Copy the VDL frame into the video buffer every frame.
+    // getVideoBufferWithHint: only stores the hint pointer; the actual pixel
+    // copy must happen here so it runs in both Debug and Release builds.
+    // (In Debug, the MTLGameRenderer assert was accidentally calling
+    // getVideoBufferWithHint: every frame — that side-effect is gone in Release.)
+    if (isSwapFrameSignaled && videoBuffer) {
+        isSwapFrameSignaled = NO;
+        struct BitmapCrop bmpcrop;
+        ScalingAlgorithm sca;
+        int rw, rh;
+        Get_Frame_Bitmap((VDLFrame *)frame, videoBuffer, 0, &bmpcrop,
+                         videoWidth, videoHeight, false, true, false, sca, &rw, &rh);
+    }
 }
 
 - (void)resetEmulation
@@ -438,20 +452,14 @@ static void writeSaveFile(const char* path)
 #pragma mark Video
 - (const void *)getVideoBufferWithHint:(void *)hint
 {
-    if(!hint) {
-        if (!videoBuffer) videoBuffer = (uint32_t*)malloc(videoWidth * videoHeight * 4);
-        hint = videoBuffer;
+    // Store the hint as our video buffer so executeFrame writes directly into
+    // OpenEmu's backing store. Fall back to our own allocation if no hint.
+    if (hint) {
+        videoBuffer = (uint32_t *)hint;
+    } else {
+        if (!videoBuffer) videoBuffer = (uint32_t *)malloc(videoWidth * videoHeight * 4);
     }
-
-    if(isSwapFrameSignaled)
-    {
-        isSwapFrameSignaled = NO;
-        struct BitmapCrop bmpcrop;
-        ScalingAlgorithm sca;
-        int rw, rh;
-        Get_Frame_Bitmap((VDLFrame *)frame, hint, 0, &bmpcrop, videoWidth, videoHeight, false, true, false, sca, &rw, &rh);
-    }
-    return hint;
+    return videoBuffer;
 }
 
 - (OEIntRect)screenRect

--- a/4DO/Info.plist
+++ b/4DO/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.4</string>
+	<string>2.3.5</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>


### PR DESCRIPTION
## Summary

4DO rendered correctly in Debug but showed garbled pixels in Release builds.

### Root cause

`Get_Frame_Bitmap` was called inside `getVideoBufferWithHint:` instead of `executeFrame`. `MTLGameRenderer.willExecuteFrame()` contains an `assert` that calls `getVideoBuffer(withHint:)` every frame — in Debug this accidentally triggered the pixel copy each frame. In Release, Swift `assert` is a no-op, so `Get_Frame_Bitmap` only ran once at setup and the buffer stayed stale.

### Fix

Move `Get_Frame_Bitmap` into `executeFrame`, and make `getVideoBufferWithHint:` just store the hint pointer — the same pattern used by Gambatte, SNES9x, and every other bitmap core.

## How to test locally

```bash
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon
xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme 'OpenEmu + 4DO' \
  -configuration Release -destination 'platform=macOS,arch=arm64' build 2>&1 | tail -3
./Scripts/install-core.sh 4DO --release
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Release/OpenEmu.app
```
Launch any 3DO game. Before: garbled pixels in Release. After: correct video.