### PR TITLE
WIP: shared GL context + staging texture for libretro HW render (issue #464)

### DIFF
--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B5AE7A121710BD6200ED5801 /* OELibretroCoreTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */; };
+		F15A000B1710BD6200ED5801 /* fishhook.c in Sources */ = {isa = PBXBuildFile; fileRef = F15A000A1710BD6200ED5801 /* fishhook.c */; };
 		B5AE7A141710BD6200ED5801 /* OELibretroCoreTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0109BBA5209F25EB002419C1 /* OEDiffQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0109BBA4209F25EB002419C1 /* OEDiffQueueTests.m */; };
 		0442B0011A2F4E6C00442001 /* OEGameCoreHardcoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0001A2F4E6C00442001 /* OEGameCoreHardcoreTests.m */; };
@@ -148,6 +149,8 @@
 
 /* Begin PBXFileReference section */
 		B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELibretroCoreTranslator.m; sourceTree = "<group>"; };
+		F15A000A1710BD6200ED5801 /* fishhook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fishhook.c; path = fishhook/fishhook.c; sourceTree = "<group>"; };
+		F15A000C1710BD6200ED5801 /* fishhook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fishhook.h; path = fishhook/fishhook.h; sourceTree = "<group>"; };
 		B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELibretroCoreTranslator.h; sourceTree = "<group>"; };
 		B5AE7A151710BD6200ED5801 /* libretro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libretro.h; sourceTree = "<group>"; };
 		0109BBA2209F25EB002419C1 /* OpenEmuBaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuBaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -365,6 +368,8 @@
 				C6772A631710BD6200ED580A /* OEGameCore.m */,
 				B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */,
 				B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */,
+				F15A000C1710BD6200ED5801 /* fishhook.h */,
+				F15A000A1710BD6200ED5801 /* fishhook.c */,
 				B5AE7A151710BD6200ED5801 /* libretro.h */,
 				013D75CC23BD25CB00D74AD3 /* OEGameCoreDisplayModes.h */,
 				C6772A641710BD6200ED580A /* OEAbstractAdditions.h */,
@@ -785,6 +790,7 @@
 			files = (
 				C6772A711710BD6200ED580A /* OEGameCore.m in Sources */,
 				B5AE7A121710BD6200ED5801 /* OELibretroCoreTranslator.m in Sources */,
+				F15A000B1710BD6200ED5801 /* fishhook.c in Sources */,
 				C6772A731710BD6200ED580A /* OEAbstractAdditions.m in Sources */,
 				27FC95191A92F12700CF1DC6 /* OEDiffQueue.mm in Sources */,
 				C6772A751710BD6200ED580A /* OEGameCoreController.m in Sources */,

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -193,6 +193,17 @@ typedef NS_ENUM(NSUInteger, OEGameCoreRendering) {
  */
 @property (nonatomic, readonly) NSUInteger hwRenderFramebuffer;
 
+/*!
+ * @property hwRenderSharedContextPtr
+ * @discussion
+ * The CGLContextObj of the shared HW render context, transmitted as a
+ * NSUInteger (uintptr_t) to avoid importing CGL types into this header.
+ * Zero if -prepareHWRenderSharedContext has not been called or failed.
+ * The libretro translator casts this back to CGLContextObj and stores it
+ * for per-frame CGLSetCurrentContext calls on the emulation thread.
+ */
+@property (nonatomic, readonly) NSUInteger hwRenderSharedContextPtr;
+
 // For internal use only.
 - (void)willExecute;
 - (void)didExecute;

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -171,6 +171,28 @@ typedef NS_ENUM(NSUInteger, OEGameCoreRendering) {
  */
 @property (nonatomic, readonly, nullable) id presentationFramebuffer;
 
+/*!
+ * @method prepareHWRenderSharedContext
+ * @discussion
+ * Called by the libretro translator when it accepts a RETRO_ENVIRONMENT_SET_HW_RENDER
+ * request. The renderer must create a CGL context that shares the texture namespace
+ * of its primary glContext, then create an FBO on that shared context backed by the
+ * same IOSurface texture. Subsequent calls to hwRenderFramebuffer will return that
+ * FBO. The shared context is also used as the current context for context_reset and
+ * retro_run so that the core's GL plugin (e.g. GLideN64) operates within the correct
+ * sharegroup.
+ */
+- (void)prepareHWRenderSharedContext;
+
+/*!
+ * @property hwRenderFramebuffer
+ * @discussion
+ * Returns the OpenGL FBO name that is valid on the shared HW render context.
+ * Only meaningful after -prepareHWRenderSharedContext has been called.
+ * The libretro translator returns this value from libretro_get_current_framebuffer.
+ */
+@property (nonatomic, readonly) NSUInteger hwRenderFramebuffer;
+
 // For internal use only.
 - (void)willExecute;
 - (void)didExecute;

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -58,7 +58,7 @@
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | 0x10000)
 #endif
 
-NSString * const OELibretroBridgeVersion = @"9";
+NSString * const OELibretroBridgeVersion = @"17";
 
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
@@ -134,7 +134,9 @@ static glReadBuffer_t                           _glReadBuffer = NULL;
 
 // Issue #464 — limit diagnostic logging to the first N frames per session.
 // Probing GL state every frame would flood Console.app and slow rendering.
-#define OE_ISSUE_464_DIAG_FRAMES 6
+// Bumped to 120 to cover ~2s of frames (60fps) so we catch the moment the
+// game starts rendering past its boot/load splash.
+#define OE_ISSUE_464_DIAG_FRAMES 120
 
 // =============================================================================
 // Issue #464 — fishhook trace of glBindFramebuffer inside the core dylib.
@@ -153,9 +155,33 @@ static glReadBuffer_t                           _glReadBuffer = NULL;
 // Gated to the first OE_GL_BIND_HOOK_LOG_LIMIT calls per session.
 // =============================================================================
 typedef void (*pfn_glBindFramebuffer_t)(uint32_t target, uint32_t framebuffer);
-static pfn_glBindFramebuffer_t _orig_glBindFramebuffer = NULL;
-static atomic_int _bind_hook_seq = 0;
-#define OE_GL_BIND_HOOK_LOG_LIMIT 200
+typedef void (*pfn_glClear_t)(uint32_t mask);
+typedef void (*pfn_glDrawArrays_t)(uint32_t mode, int first, int count);
+typedef void (*pfn_glDrawElements_t)(uint32_t mode, int count, uint32_t type, const void *indices);
+typedef void (*pfn_glDrawArraysInstanced_t)(uint32_t mode, int first, int count, int instancecount);
+typedef void (*pfn_glDrawElementsInstanced_t)(uint32_t mode, int count, uint32_t type, const void *indices, int instancecount);
+typedef void (*pfn_glDrawElementsBaseVertex_t)(uint32_t mode, int count, uint32_t type, const void *indices, int basevertex);
+typedef void (*pfn_glDrawRangeElements_t)(uint32_t mode, uint32_t start, uint32_t end, int count, uint32_t type, const void *indices);
+typedef void (*pfn_glClearBufferfv_t)(uint32_t buffer, int drawbuffer, const float *value);
+typedef void (*pfn_glBlitFramebuffer_t)(int sx0, int sy0, int sx1, int sy1, int dx0, int dy0, int dx1, int dy1, uint32_t mask, uint32_t filter);
+
+static pfn_glBindFramebuffer_t           _orig_glBindFramebuffer       = NULL;
+static pfn_glClear_t                     _orig_glClear                 = NULL;
+static pfn_glDrawArrays_t                _orig_glDrawArrays            = NULL;
+static pfn_glDrawElements_t              _orig_glDrawElements          = NULL;
+static pfn_glDrawArraysInstanced_t       _orig_glDrawArraysInstanced   = NULL;
+static pfn_glDrawElementsInstanced_t     _orig_glDrawElementsInstanced = NULL;
+static pfn_glDrawElementsBaseVertex_t    _orig_glDrawElementsBaseVertex= NULL;
+static pfn_glDrawRangeElements_t         _orig_glDrawRangeElements     = NULL;
+static pfn_glClearBufferfv_t             _orig_glClearBufferfv         = NULL;
+static pfn_glBlitFramebuffer_t           _orig_glBlitFramebuffer       = NULL;
+
+static atomic_int _bind_hook_seq  = 0;
+static atomic_int _draw_hook_seq  = 0;
+static atomic_int _clear_hook_seq = 0;
+#define OE_GL_BIND_HOOK_LOG_LIMIT  200
+#define OE_GL_DRAW_HOOK_LOG_LIMIT  60
+#define OE_GL_CLEAR_HOOK_LOG_LIMIT 60
 
 static void oe_hook_glBindFramebuffer(uint32_t target, uint32_t framebuffer)
 {
@@ -175,6 +201,128 @@ static void oe_hook_glBindFramebuffer(uint32_t target, uint32_t framebuffer)
     }
 }
 
+// Snapshots GL state interesting to issue #464 (current draw FBO, viewport).
+static void oe_snapshot_draw_state(int *out_drawFB, int *out_vx, int *out_vy, int *out_vw, int *out_vh)
+{
+    int drawFB = -1; int vp[4] = {-1,-1,-1,-1};
+    if (_glGetIntegerv) {
+        _glGetIntegerv(0x8CA6 /* GL_FRAMEBUFFER_BINDING / GL_DRAW_FRAMEBUFFER_BINDING */, &drawFB);
+        _glGetIntegerv(0x0BA2 /* GL_VIEWPORT */, vp);
+    }
+    *out_drawFB = drawFB; *out_vx = vp[0]; *out_vy = vp[1]; *out_vw = vp[2]; *out_vh = vp[3];
+}
+
+static void oe_hook_glClear(uint32_t mask)
+{
+    int seq = atomic_fetch_add_explicit(&_clear_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_CLEAR_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glClear #%d mask=0x%X drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mask, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glClear) _orig_glClear(mask);
+}
+
+static void oe_hook_glDrawArrays(uint32_t mode, int first, int count)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawArrays #%d mode=0x%X count=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawArrays) _orig_glDrawArrays(mode, first, count);
+}
+
+static void oe_hook_glDrawElements(uint32_t mode, int count, uint32_t type, const void *indices)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawElements #%d mode=0x%X count=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawElements) _orig_glDrawElements(mode, count, type, indices);
+}
+
+static void oe_hook_glDrawArraysInstanced(uint32_t mode, int first, int count, int instancecount)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawArraysInstanced #%d mode=0x%X count=%d inst=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, instancecount, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawArraysInstanced) _orig_glDrawArraysInstanced(mode, first, count, instancecount);
+}
+
+static void oe_hook_glDrawElementsInstanced(uint32_t mode, int count, uint32_t type, const void *indices, int instancecount)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawElementsInstanced #%d mode=0x%X count=%d inst=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, instancecount, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawElementsInstanced) _orig_glDrawElementsInstanced(mode, count, type, indices, instancecount);
+}
+
+static void oe_hook_glDrawElementsBaseVertex(uint32_t mode, int count, uint32_t type, const void *indices, int basevertex)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawElementsBaseVertex #%d mode=0x%X count=%d basevtx=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, basevertex, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawElementsBaseVertex) _orig_glDrawElementsBaseVertex(mode, count, type, indices, basevertex);
+}
+
+static void oe_hook_glDrawRangeElements(uint32_t mode, uint32_t start, uint32_t end, int count, uint32_t type, const void *indices)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        NSLog(@"[OELibretro][#464 hook] glDrawRangeElements #%d mode=0x%X count=%d drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, mode, count, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glDrawRangeElements) _orig_glDrawRangeElements(mode, start, end, count, type, indices);
+}
+
+static void oe_hook_glClearBufferfv(uint32_t buffer, int drawbuffer, const float *value)
+{
+    int seq = atomic_fetch_add_explicit(&_clear_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_CLEAR_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        float v0 = value ? value[0] : 0, v1 = value ? value[1] : 0, v2 = value ? value[2] : 0, v3 = value ? value[3] : 0;
+        NSLog(@"[OELibretro][#464 hook] glClearBufferfv #%d buffer=0x%X drawbuf=%d (%.2f,%.2f,%.2f,%.2f) drawFB=%d viewport=[%d,%d %dx%d]",
+              seq, buffer, drawbuffer, v0, v1, v2, v3, drawFB, vx, vy, vw, vh);
+    }
+    if (_orig_glClearBufferfv) _orig_glClearBufferfv(buffer, drawbuffer, value);
+}
+
+static void oe_hook_glBlitFramebuffer(int sx0, int sy0, int sx1, int sy1, int dx0, int dy0, int dx1, int dy1, uint32_t mask, uint32_t filter)
+{
+    int seq = atomic_fetch_add_explicit(&_draw_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_DRAW_HOOK_LOG_LIMIT) {
+        int drawFB, vx, vy, vw, vh;
+        oe_snapshot_draw_state(&drawFB, &vx, &vy, &vw, &vh);
+        int readFB = -1;
+        if (_glGetIntegerv) _glGetIntegerv(0x8CAA /* GL_READ_FRAMEBUFFER_BINDING */, &readFB);
+        NSLog(@"[OELibretro][#464 hook] glBlitFramebuffer #%d src=[%d,%d %d,%d] dst=[%d,%d %d,%d] mask=0x%X readFB=%d drawFB=%d",
+              seq, sx0, sy0, sx1, sy1, dx0, dy0, dx1, dy1, mask, readFB, drawFB);
+    }
+    if (_orig_glBlitFramebuffer) _orig_glBlitFramebuffer(sx0, sy0, sx1, sy1, dx0, dy0, dx1, dy1, mask, filter);
+}
+
 // Walks the dyld image list to find the loaded image whose path matches
 // (or ends with) the supplied substring, then rebinds glBindFramebuffer in
 // that image only.
@@ -188,14 +336,34 @@ static void oe_install_bind_hook_for_image(const char *path_substr)
         if (strstr(name, path_substr) == NULL) continue;
         const struct mach_header *hdr = _dyld_get_image_header(i);
         intptr_t slide = _dyld_get_image_vmaddr_slide(i);
+        // glBindFramebuffer is NOT typically an external import (it's redefined
+        // via glsym_gl.h to __rglgen_glBindFramebuffer for libretro/GLSM cores)
+        // — we catch it via libretro_get_proc_address instead. But glClear /
+        // glDrawArrays / glDrawElements ARE direct external imports in
+        // mupen64plus_next_libretro.dylib (see `nm -u`), so fishhook can
+        // rebind them. The wrappers log where each draw lands so we can
+        // pinpoint which FBO the core actually rasterises into.
         struct rebinding rb[] = {
             { "glBindFramebuffer",
               (void *)oe_hook_glBindFramebuffer,
               (void **)&_orig_glBindFramebuffer },
+            { "glClear",
+              (void *)oe_hook_glClear,
+              (void **)&_orig_glClear },
+            { "glDrawArrays",
+              (void *)oe_hook_glDrawArrays,
+              (void **)&_orig_glDrawArrays },
+            { "glDrawElements",
+              (void *)oe_hook_glDrawElements,
+              (void **)&_orig_glDrawElements },
         };
-        int rc = rebind_symbols_image((void *)hdr, slide, rb, 1);
-        NSLog(@"[OELibretro][#464 hook] installed glBindFramebuffer hook on %s (rc=%d, orig=%p)",
-              name, rc, _orig_glBindFramebuffer);
+        int rc = rebind_symbols_image((void *)hdr, slide, rb,
+                                      sizeof(rb) / sizeof(rb[0]));
+        NSLog(@"[OELibretro][#464 hook] fishhook installed on %s (rc=%d) "
+              "orig glBindFramebuffer=%p glClear=%p glDrawArrays=%p glDrawElements=%p",
+              name, rc,
+              _orig_glBindFramebuffer, _orig_glClear,
+              _orig_glDrawArrays, _orig_glDrawElements);
         return;
     }
     NSLog(@"[OELibretro][#464 hook] no loaded image matching '%s' — hook NOT installed",
@@ -318,6 +486,50 @@ static void (*libretro_get_proc_address(const char *sym))(void) {
     void *addr = NULL;
     if (gl) addr = dlsym(gl, sym);
     if (!addr) addr = dlsym(RTLD_DEFAULT, sym);
+
+    // Issue #464 — trace which GL functions the core resolves, and (for the
+    // ones we care about) hand back a wrapper that logs every call. The core
+    // accesses system GL via these function pointers; in particular, GLSM's
+    // bindFBO() uses an rglgen-resolved pointer for glBindFramebuffer, which
+    // means this is the single chokepoint for observing the actual GL bind
+    // sequence inside retro_run.
+    if (sym && addr) {
+        // Generic logging: record (and once-only log) every symbol the core
+        // resolves through us. This catches misses where we hooked the wrong
+        // function name.
+        static CFMutableSetRef seen = NULL;
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            seen = CFSetCreateMutable(NULL, 0, &kCFTypeSetCallBacks);
+        });
+        @synchronized([_current ?: [NSNull null] description]) {
+            NSString *key = [NSString stringWithUTF8String:sym];
+            if (key && !CFSetContainsValue(seen, (__bridge const void *)key)) {
+                CFSetAddValue(seen, (__bridge const void *)key);
+                NSLog(@"[OELibretro][#464 sym] core resolved '%s' -> %p", sym, addr);
+            }
+        }
+
+        #define OE_WRAP(symname, slot, wrapper) \
+            if (strcmp(sym, #symname) == 0) { \
+                (slot) = addr; \
+                NSLog(@"[OELibretro][#464 hook] wrapping '%s'", #symname); \
+                return (void (*)(void))(wrapper); \
+            }
+
+        OE_WRAP(glBindFramebuffer,            _orig_glBindFramebuffer,           oe_hook_glBindFramebuffer)
+        OE_WRAP(glClear,                       _orig_glClear,                     oe_hook_glClear)
+        OE_WRAP(glDrawArrays,                  _orig_glDrawArrays,                oe_hook_glDrawArrays)
+        OE_WRAP(glDrawElements,                _orig_glDrawElements,              oe_hook_glDrawElements)
+        OE_WRAP(glDrawArraysInstanced,         _orig_glDrawArraysInstanced,       oe_hook_glDrawArraysInstanced)
+        OE_WRAP(glDrawElementsInstanced,       _orig_glDrawElementsInstanced,     oe_hook_glDrawElementsInstanced)
+        OE_WRAP(glDrawElementsBaseVertex,      _orig_glDrawElementsBaseVertex,    oe_hook_glDrawElementsBaseVertex)
+        OE_WRAP(glDrawRangeElements,           _orig_glDrawRangeElements,         oe_hook_glDrawRangeElements)
+        OE_WRAP(glClearBufferfv,               _orig_glClearBufferfv,             oe_hook_glClearBufferfv)
+        OE_WRAP(glBlitFramebuffer,             _orig_glBlitFramebuffer,           oe_hook_glBlitFramebuffer)
+
+        #undef OE_WRAP
+    }
     return (void(*)(void))addr;
 }
 
@@ -462,6 +674,15 @@ static const uint8_t kSaturnButtonMap[] = {
 static const OELibretroVariableDefault kN64VariableDefaults[] = {
     // GLideN64 — best-compat renderer on Apple Silicon.
     { "mupen64plus-rdp-plugin",                   "gliden64" },
+    // RSP plugin (Reality Signal Processor): processes graphics microcode
+    // and feeds RDP commands to the RDP plugin (GLideN64). Without an RSP
+    // plugin selected, the core's RSP block never produces graphics work
+    // and GLideN64 receives zero draw commands per frame — the framebuffer
+    // is cleared to black and nothing is rendered. HLE is the standard
+    // fast path; mupen64plus-next's declared default is "hle". Issue #464
+    // diagnostics showed the core clearing FBO every frame with zero draw
+    // calls, which is the signature of RSP-plugin-not-selected.
+    { "mupen64plus-rsp-plugin",                   "hle" },
     // GLideN64's threaded renderer needs a shared GL context we don't provide;
     // crashes in TextureCache::_addTexture without this.
     { "mupen64plus-ThreadedRenderer",             "False" },
@@ -966,6 +1187,7 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 for (NSUInteger i = 0; i < _current->_policy.variableDefaultCount; i++) {
                     if (strcmp(var->key, _current->_policy.variableDefaults[i].key) == 0) {
                         var->value = _current->_policy.variableDefaults[i].value;
+                        NSLog(@"[OELibretro][#464 var] policy: %s = %s", var->key, var->value);
                         return true;
                     }
                 }
@@ -989,6 +1211,7 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 NSData *declaredDefault = declaredKey ? _current.declaredOptionDefaults[declaredKey] : nil;
                 if (declaredDefault) {
                     var->value = (const char *)declaredDefault.bytes;
+                    NSLog(@"[OELibretro][#464 var] declared: %s = %s", var->key, var->value);
                     return true;
                 }
 
@@ -996,6 +1219,7 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 // skip the null-check before strcmp() don't crash. Only fires
                 // for keys the core never declared (rare; usually a core bug).
                 var->value = "";
+                NSLog(@"[OELibretro][#464 var] EMPTY (no policy, no declared default): %s", var->key);
 #if DEBUG
                 NSLog(@"[OELibretro] Core queried variable: %s — no override and no declared default", var->key);
 #endif
@@ -1527,10 +1751,15 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
         return NO;
     }
 
-    // Issue #464 — install fishhook trace on the loaded core dylib so we can
-    // observe the actual glBindFramebuffer call sequence during retro_run.
-    // The image is identified by file name (last path component); using the
-    // bare name keeps this resilient to install-location changes.
+    // Issue #464 — attempt to install a fishhook trace on the loaded core
+    // dylib. For mupen64plus_next the trace returns rc=0 / orig=0x0 because
+    // the core does NOT import glBindFramebuffer as an external symbol —
+    // glsym/glsym_gl.h redefines glBindFramebuffer to __rglgen_glBindFramebuffer,
+    // a function pointer resolved by rglgen via our get_proc_address callback.
+    // The actual interception happens in libretro_get_proc_address above.
+    // We keep this install attempt in place because other GL libretro cores
+    // (e.g. Beetle PSX HW) may bind glBindFramebuffer as an external symbol,
+    // in which case fishhook is the right tool.
     {
         NSString *imageName = [corePath lastPathComponent];
         oe_install_bind_hook_for_image([imageName UTF8String]);
@@ -1787,8 +2016,17 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
             // there instead.
             if (_glReadPixels && _glReadBuffer && _glIsFramebuffer) {
                 uint8_t isOurFBOValid = _glIsFramebuffer((uint32_t)ourFBO);
-                // 16x16 RGBA probe = 1024 bytes. Cheap.
-                uint8_t probe[16 * 16 * 4];
+                // 64x64 RGBA probe = 16 KiB. Read from the centre of the FBO
+                // (we previously read 16x16 from the bottom-left, which sat in
+                // the dead-letterbox of any centred game render).
+                uint8_t probe[64 * 64 * 4];
+                const int probeW = 64, probeH = 64;
+                // Centre point depends on the FBO dimensions; we don't know
+                // them in this TU, but most N64 frames render at <=640x480,
+                // and our staging FBO is sized to max texture dimensions.
+                // Sample from a fixed (x=128, y=128) offset which lands inside
+                // any reasonable render region.
+                const int probeX = 128, probeY = 128;
                 int probeNonzeroOurs = -1;
                 int probeNonzeroZero = -1;
                 uint32_t probeErrOurs = 0;
@@ -1798,7 +2036,7 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                     _glReadBuffer(OE_GL_COLOR_ATTACHMENT0);
                     (void)_glGetError();
                     memset(probe, 0, sizeof(probe));
-                    _glReadPixels(0, 0, 16, 16, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
+                    _glReadPixels(probeX, probeY, probeW, probeH, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
                     probeErrOurs = _glGetError();
                     int nz = 0;
                     for (size_t i = 0; i < sizeof(probe); i++) if (probe[i]) nz++;
@@ -1808,7 +2046,7 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                 _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, 0);
                 (void)_glGetError();
                 memset(probe, 0, sizeof(probe));
-                _glReadPixels(0, 0, 16, 16, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
+                _glReadPixels(probeX, probeY, probeW, probeH, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
                 probeErrZero = _glGetError();
                 if (probeErrZero == 0) {
                     int nz = 0;
@@ -1817,10 +2055,19 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                 }
                 // Restore READ binding.
                 _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, (uint32_t)readBinding);
-                NSLog(@"[OELibretro][#464 diag4] post-retro_run[%d] ourFBO_valid=%d ourFBO_nonzero_bytes=%d (glErr=0x%04X) FBO0_nonzero_bytes=%d (glErr=0x%04X)",
-                      _postRunDiagCount, (int)isOurFBOValid,
-                      probeNonzeroOurs, probeErrOurs,
-                      probeNonzeroZero, probeErrZero);
+                // Only log when the readback changes — otherwise we'd flood logs
+                // with 120 identical "all zero" lines. Always log first/last few.
+                static int _lastNonzeroOurs = -2;
+                if (probeNonzeroOurs != _lastNonzeroOurs ||
+                    _postRunDiagCount <= 3 ||
+                    _postRunDiagCount >= OE_ISSUE_464_DIAG_FRAMES - 2) {
+                    NSLog(@"[OELibretro][#464 diag4] post-retro_run[%d] ourFBO_valid=%d ourFBO_nonzero_bytes=%d (glErr=0x%04X) FBO0_nonzero_bytes=%d (glErr=0x%04X) [%dx%d at %d,%d]",
+                          _postRunDiagCount, (int)isOurFBOValid,
+                          probeNonzeroOurs, probeErrOurs,
+                          probeNonzeroZero, probeErrZero,
+                          probeW, probeH, probeX, probeY);
+                    _lastNonzeroOurs = probeNonzeroOurs;
+                }
             }
         }
     }

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -56,7 +56,7 @@
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | 0x10000)
 #endif
 
-NSString * const OELibretroBridgeVersion = @"4";
+NSString * const OELibretroBridgeVersion = @"5";
 
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
@@ -111,17 +111,45 @@ static char *_contentDirCStr     = NULL;
 static __unsafe_unretained OELibretroCoreTranslator *_current = nil;
 
 // HW Callbacks
-typedef void (*glGetIntegerv_t)(uint32_t pname, int *params);
+typedef void     (*glGetIntegerv_t)(uint32_t pname, int *params);
+typedef void     (*glBindFramebuffer_t)(uint32_t target, uint32_t framebuffer);
+typedef void     (*glGetFramebufferAttachmentParameteriv_t)(uint32_t target, uint32_t attachment, uint32_t pname, int *params);
+typedef uint32_t (*glCheckFramebufferStatus_t)(uint32_t target);
+typedef uint32_t (*glGetError_t)(void);
 
 static void *_gl_handle = NULL;
-static glGetIntegerv_t _glGetIntegerv = NULL;
+static glGetIntegerv_t                          _glGetIntegerv = NULL;
+static glBindFramebuffer_t                      _glBindFramebuffer = NULL;
+static glGetFramebufferAttachmentParameteriv_t  _glGetFramebufferAttachmentParameteriv = NULL;
+static glCheckFramebufferStatus_t               _glCheckFramebufferStatus = NULL;
+static glGetError_t                             _glGetError = NULL;
+
+// Issue #464 — limit diagnostic logging to the first N frames per session.
+// Probing GL state every frame would flood Console.app and slow rendering.
+#define OE_ISSUE_464_DIAG_FRAMES 6
+
+// GL constants (we don't link OpenGL headers in this TU).
+#define OE_GL_NO_ERROR                       0x0000
+#define OE_GL_FRAMEBUFFER                    0x8D40
+#define OE_GL_READ_FRAMEBUFFER               0x8CA8
+#define OE_GL_DRAW_FRAMEBUFFER               0x8CA9
+#define OE_GL_FRAMEBUFFER_BINDING            0x8CA6  // alias of GL_DRAW_FRAMEBUFFER_BINDING
+#define OE_GL_READ_FRAMEBUFFER_BINDING       0x8CAA
+#define OE_GL_COLOR_ATTACHMENT0              0x8CE0
+#define OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE 0x8CD0
+#define OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME 0x8CD1
+#define OE_GL_FRAMEBUFFER_COMPLETE           0x8CD5
 
 static void* get_gl_handle(void) {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         _gl_handle = dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", RTLD_LAZY | RTLD_LOCAL);
         if (_gl_handle) {
-            _glGetIntegerv = (glGetIntegerv_t)dlsym(_gl_handle, "glGetIntegerv");
+            _glGetIntegerv                          = (glGetIntegerv_t)                         dlsym(_gl_handle, "glGetIntegerv");
+            _glBindFramebuffer                      = (glBindFramebuffer_t)                     dlsym(_gl_handle, "glBindFramebuffer");
+            _glGetFramebufferAttachmentParameteriv  = (glGetFramebufferAttachmentParameteriv_t) dlsym(_gl_handle, "glGetFramebufferAttachmentParameteriv");
+            _glCheckFramebufferStatus               = (glCheckFramebufferStatus_t)              dlsym(_gl_handle, "glCheckFramebufferStatus");
+            _glGetError                             = (glGetError_t)                            dlsym(_gl_handle, "glGetError");
         }
     });
     return _gl_handle;
@@ -137,9 +165,49 @@ static uintptr_t libretro_get_current_framebuffer(void) {
                 NSUInteger fbo = _current.renderDelegate.hwRenderFramebuffer;
                 CGLContextObj activeCTX = CGLGetCurrentContext();
                 CGLContextObj sharedCTX = (CGLContextObj)(uintptr_t)_current.renderDelegate.hwRenderSharedContextPtr;
+
+                // Issue #464 — Diag 1: context identity check.
+                // glsm_state_setup will capture default_framebuffer = <our FBO> against
+                // whatever context is current at the moment of this call. If activeCTX
+                // != sharedCTX, the FBO number we return is meaningless on the active
+                // context and rendering will go nowhere (or somewhere wrong).
+                if (activeCTX != sharedCTX) {
+                    os_log_fault(OE_LOG_DEFAULT,
+                                 "[OELibretro][#464 diag1] CTX MISMATCH in get_current_framebuffer: active %p != shared %p, FBO %lu",
+                                 activeCTX, sharedCTX, (unsigned long)fbo);
+                }
+
+                // Issue #464 — Diag 2: confirm the FBO's color attachment is the
+                // texture name we expect. If the renderer recreated the IOSurface
+                // texture under us, the FBO would still reference the now-dead name.
                 static int _fbDiagCount = 0;
-                if (++_fbDiagCount <= 5) {
-                    NSLog(@"[OELibretro] get_current_framebuffer[%d] -> FBO %lu, active ctx %p, shared ctx %p",
+                if (++_fbDiagCount <= OE_ISSUE_464_DIAG_FRAMES
+                    && get_gl_handle() && _glGetFramebufferAttachmentParameteriv
+                    && _glCheckFramebufferStatus && _glBindFramebuffer && _glGetError) {
+                    // Save current binding, bind ours, query, restore.
+                    int prevDraw = 0;
+                    int prevRead = 0;
+                    if (_glGetIntegerv) {
+                        _glGetIntegerv(OE_GL_FRAMEBUFFER_BINDING,      &prevDraw);
+                        _glGetIntegerv(OE_GL_READ_FRAMEBUFFER_BINDING, &prevRead);
+                    }
+                    (void)_glGetError(); // clear any pre-existing error
+                    _glBindFramebuffer(OE_GL_FRAMEBUFFER, (uint32_t)fbo);
+                    int attachName = 0;
+                    int attachType = 0;
+                    _glGetFramebufferAttachmentParameteriv(OE_GL_FRAMEBUFFER, OE_GL_COLOR_ATTACHMENT0, OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &attachName);
+                    _glGetFramebufferAttachmentParameteriv(OE_GL_FRAMEBUFFER, OE_GL_COLOR_ATTACHMENT0, OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &attachType);
+                    uint32_t fbStatus = _glCheckFramebufferStatus(OE_GL_FRAMEBUFFER);
+                    uint32_t glErr = _glGetError();
+                    NSLog(@"[OELibretro][#464 diag2] get_current_framebuffer[%d] -> FBO %lu, active ctx %p, shared ctx %p, color-attach name=%d type=0x%04X, fbStatus=0x%04X (complete=%@), glErr=0x%04X",
+                          _fbDiagCount, (unsigned long)fbo, activeCTX, sharedCTX,
+                          attachName, (unsigned)attachType, fbStatus,
+                          (fbStatus == OE_GL_FRAMEBUFFER_COMPLETE ? @"YES" : @"NO"), glErr);
+                    // Restore previous binding so this query is invisible to the core.
+                    _glBindFramebuffer(OE_GL_DRAW_FRAMEBUFFER, (uint32_t)prevDraw);
+                    _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, (uint32_t)prevRead);
+                } else if (_fbDiagCount <= OE_ISSUE_464_DIAG_FRAMES) {
+                    NSLog(@"[OELibretro][#464 diag2] get_current_framebuffer[%d] -> FBO %lu, active ctx %p, shared ctx %p (gl probes unavailable)",
                           _fbDiagCount, (unsigned long)fbo, activeCTX, sharedCTX);
                 }
                 return (uintptr_t)fbo;
@@ -1574,6 +1642,45 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     }
 
     if (_retro_run) _retro_run();
+
+    // Issue #464 — Diag 3: post-retro_run state probe.
+    // With the shared context still current, observe what the core actually
+    // left bound and whether our FBO is complete + still pointing at the
+    // expected texture. Limit to the first N frames per session to avoid
+    // flooding logs and slowing rendering.
+    if (self.isHW && _hwSharedContext && get_gl_handle()
+        && _glGetIntegerv && _glBindFramebuffer && _glGetFramebufferAttachmentParameteriv
+        && _glCheckFramebufferStatus && _glGetError) {
+        static int _postRunDiagCount = 0;
+        if (++_postRunDiagCount <= OE_ISSUE_464_DIAG_FRAMES) {
+            CGLContextObj activeCTX = CGLGetCurrentContext();
+            NSUInteger ourFBO = self.renderDelegate.hwRenderFramebuffer;
+            int drawBinding = 0;
+            int readBinding = 0;
+            _glGetIntegerv(OE_GL_FRAMEBUFFER_BINDING,      &drawBinding);
+            _glGetIntegerv(OE_GL_READ_FRAMEBUFFER_BINDING, &readBinding);
+            (void)_glGetError(); // clear pre-existing error
+            _glBindFramebuffer(OE_GL_FRAMEBUFFER, (uint32_t)ourFBO);
+            int attachName = 0;
+            _glGetFramebufferAttachmentParameteriv(OE_GL_FRAMEBUFFER, OE_GL_COLOR_ATTACHMENT0, OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &attachName);
+            uint32_t fbStatus = _glCheckFramebufferStatus(OE_GL_FRAMEBUFFER);
+            uint32_t glErr = _glGetError();
+            // Restore whatever the core left bound, so post-frame work
+            // (didExecuteFrame's glFinish/flush path) sees the same state.
+            _glBindFramebuffer(OE_GL_DRAW_FRAMEBUFFER, (uint32_t)drawBinding);
+            _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, (uint32_t)readBinding);
+            NSLog(@"[OELibretro][#464 diag3] post-retro_run[%d] active=%p shared=%p drawBinding=%d readBinding=%d ourFBO=%lu attach=%d fbStatus=0x%04X (complete=%@) glErr=0x%04X",
+                  _postRunDiagCount, activeCTX, _hwSharedContext,
+                  drawBinding, readBinding, (unsigned long)ourFBO,
+                  attachName, fbStatus,
+                  (fbStatus == OE_GL_FRAMEBUFFER_COMPLETE ? @"YES" : @"NO"), glErr);
+            if (activeCTX != _hwSharedContext) {
+                os_log_fault(OE_LOG_DEFAULT,
+                             "[OELibretro][#464 diag3] CTX MISMATCH after retro_run: active %p != shared %p",
+                             activeCTX, _hwSharedContext);
+            }
+        }
+    }
 }
 
 - (void)resetEmulation {

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -67,6 +67,7 @@ NSString * const OELibretroBridgeVersion = @"4";
 @property (nonatomic, assign) BOOL isBufferSizeLocked;
 @property (nonatomic, assign) BOOL isHW;
 @property (nonatomic, assign) BOOL needsContextReset;
+@property (nonatomic, assign) BOOL needsHWContextSetup;
 @property (nonatomic, assign) int clearFramesRemaining;
 @property (nonatomic, assign) uint64_t serializationQuirks;
 @property (atomic, assign) int touchX;
@@ -761,10 +762,12 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 _current->_hw_callback = *hw;
                 _current.isHW = YES;
 
-                // Tell the renderer to create the shared CGL context and FBO now,
-                // while we still have the render delegate. The shared context will
-                // be made current before context_reset and every retro_run call.
-                [_current.renderDelegate prepareHWRenderSharedContext];
+                // Defer shared context setup to the first executeFrame call.
+                // glContext / glPixelFormat don't exist yet at retro_load_game time
+                // (they're initialised when the render loop starts). Setting this flag
+                // tells executeFrame to call prepareHWRenderSharedContext on the
+                // emulation thread, where GL is guaranteed to be ready.
+                _current.needsHWContextSetup = YES;
 
 #if DEBUG
                 NSLog(@"[OELibretro] Accepted HW Rendering (Type: %d, Version: %u.%u)", hw->context_type, hw->version_major, hw->version_minor);
@@ -1320,8 +1323,9 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     // To add a new system, extend OELibretroSystemPolicyForSystemID().
     NSString *systemID = [self systemIdentifier];
     _policy = OELibretroSystemPolicyForSystemID(systemID);
-    _isHW          = NO;  // Reset — core will re-request via SET_HW_RENDER if needed
-    _hwSharedContext = NULL;  // Renderer teardown (destroyGLResources) owns the CGL lifetime
+    _isHW               = NO;    // Reset — core will re-request via SET_HW_RENDER if needed
+    _hwSharedContext    = NULL;   // Renderer teardown (destroyGLResources) owns the CGL lifetime
+    self.needsHWContextSetup = NO;
 
     // Reset declared option defaults so a re-load doesn't carry stale entries
     // from a previous game/core into the new core's environment callbacks.
@@ -1500,32 +1504,50 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 - (void)executeFrame {
     _current = self;
 
-    // The OpenGL context is only guaranteed to be bound to this thread AFTER startEmulation,
-    // right at the beginning of the first frame execution. This is the latest and safest
-    // place to initialize the core's hardware context.
     if (self.isHW) {
-        // Switch to the shared context before context_reset and before every retro_run.
-        // This ensures GLideN64 (or any core GL plugin) operates within the shared
-        // CGL context that shares the texture namespace with OpenEmu's primary context.
-        // willExecuteFrame() is a no-op in HW render mode (it returns early when
-        // hwSharedContext != nil), so we own context management completely here.
-        NSUInteger hwFBO = self.renderDelegate.hwRenderFramebuffer;
-        if (hwFBO != 0) {
-            // hwRenderFramebuffer non-zero means prepareHWRenderSharedContext succeeded.
-            // The shared context is the one currently set by the renderer — query it
-            // so we can re-assert it before each call.
-            _hwSharedContext = CGLGetCurrentContext();
+        // --- Deferred HW context setup (runs exactly once on the first HW frame) ---
+        // prepareHWRenderSharedContext couldn't run at SET_HW_RENDER time because
+        // glContext / glPixelFormat don't exist until the render loop starts.
+        // Now we're on the emulation thread with GL fully initialised.
+        if (self.needsHWContextSetup) {
+            self.needsHWContextSetup = NO;
+            [self.renderDelegate prepareHWRenderSharedContext];
+
+            // Retrieve the shared context pointer directly from the renderer.
+            // Do NOT use CGLGetCurrentContext() — that returns the current context
+            // on this thread, which may be nil or glContext at this point.
+            NSUInteger ctxPtr = self.renderDelegate.hwRenderSharedContextPtr;
+            _hwSharedContext = ctxPtr ? (CGLContextObj)(uintptr_t)ctxPtr : NULL;
+
+            if (!_hwSharedContext) {
+                // Setup failed: glContext was nil, FBO was incomplete, or the
+                // renderer doesn't support HW render. Reset to software mode so
+                // the game runs (without HW acceleration) rather than crashing.
+                os_log_fault(OE_LOG_DEFAULT,
+                    "[OELibretro] prepareHWRenderSharedContext failed — "
+                    "falling back to software render for this session");
+                self.isHW = NO;
+                if (self.needsContextReset) {
+                    self.needsContextReset = NO;
+                    // Skip context_reset — GLideN64 won't get its GL context,
+                    // but at least we won't crash with no context active.
+                }
+                if (_retro_run) _retro_run();
+                return;
+            }
         }
 
+        // --- Per-frame context management ---
+        // Re-assert the shared context before context_reset and before retro_run.
+        // GLideN64 may have changed the current context internally; we need
+        // the shared context active so its GL calls land in the correct sharegroup.
         if (self.needsContextReset) {
             self.needsContextReset = NO;
+            CGLSetCurrentContext(_hwSharedContext);
             if (_hw_callback.context_reset) {
-                if (_hwSharedContext) CGLSetCurrentContext(_hwSharedContext);
                 _hw_callback.context_reset();
             }
-        } else if (_hwSharedContext) {
-            // Re-assert the shared context on every frame. GLideN64 may have
-            // changed it internally; we need it current before retro_run.
+        } else {
             CGLSetCurrentContext(_hwSharedContext);
         }
     } else if (self.needsContextReset) {

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -56,7 +56,7 @@
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | 0x10000)
 #endif
 
-NSString * const OELibretroBridgeVersion = @"3";
+NSString * const OELibretroBridgeVersion = @"4";
 
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
@@ -127,9 +127,16 @@ static void* get_gl_handle(void) {
 }
 
 static uintptr_t libretro_get_current_framebuffer(void) {
-    // 1. Ask OpenEmu's renderer for the authoritative FBO
     @autoreleasepool {
         if (_current && _current.renderDelegate) {
+            // HW render mode: return the FBO on the shared context.
+            // This FBO was created by prepareHWRenderSharedContext and is
+            // valid in the context that GLideN64 / the core GL plugin uses.
+            if (_current.isHW) {
+                return (uintptr_t)_current.renderDelegate.hwRenderFramebuffer;
+            }
+
+            // Software / bitmap path: ask for the standard presentation FBO.
             id fb = _current.renderDelegate.presentationFramebuffer;
             if (fb && [fb isKindOfClass:[NSNumber class]]) {
                 return (uintptr_t)[(NSNumber *)fb unsignedLongValue];
@@ -137,7 +144,7 @@ static uintptr_t libretro_get_current_framebuffer(void) {
         }
     }
 
-    // 2. Fall back to querying the active CGL context
+    // Last resort: query whatever FBO is currently bound.
     if (get_gl_handle() && _glGetIntegerv) {
         int fbo = 0;
         _glGetIntegerv(0x8CA6, &fbo); // GL_FRAMEBUFFER_BINDING
@@ -463,6 +470,12 @@ static OELibretroSystemPolicy OELibretroSystemPolicyForSystemID(NSString *system
 
     os_unfair_lock _avInfoLock;
 
+    // HW render shared context — stored here so executeFrame can re-assert it
+    // each frame without going through the render delegate on every call.
+    // Set on the first HW frame after prepareHWRenderSharedContext succeeds.
+    // Only touched on the emulation thread.
+    CGLContextObj _hwSharedContext;
+
     // Per-system policy — set once in -loadFileAtPath:, consulted everywhere
     // else. Adding a new system: extend OELibretroSystemPolicyForSystemID().
     OELibretroSystemPolicy _policy;
@@ -747,6 +760,12 @@ static bool libretro_environment_cb(unsigned cmd, void *data) {
                 hw->get_proc_address = libretro_get_proc_address;
                 _current->_hw_callback = *hw;
                 _current.isHW = YES;
+
+                // Tell the renderer to create the shared CGL context and FBO now,
+                // while we still have the render delegate. The shared context will
+                // be made current before context_reset and every retro_run call.
+                [_current.renderDelegate prepareHWRenderSharedContext];
+
 #if DEBUG
                 NSLog(@"[OELibretro] Accepted HW Rendering (Type: %d, Version: %u.%u)", hw->context_type, hw->version_major, hw->version_minor);
 #endif
@@ -1301,7 +1320,8 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     // To add a new system, extend OELibretroSystemPolicyForSystemID().
     NSString *systemID = [self systemIdentifier];
     _policy = OELibretroSystemPolicyForSystemID(systemID);
-    _isHW   = NO;  // Reset — core will re-request via SET_HW_RENDER if needed
+    _isHW          = NO;  // Reset — core will re-request via SET_HW_RENDER if needed
+    _hwSharedContext = NULL;  // Renderer teardown (destroyGLResources) owns the CGL lifetime
 
     // Reset declared option defaults so a re-load doesn't carry stale entries
     // from a previous game/core into the new core's environment callbacks.
@@ -1479,18 +1499,39 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
 - (void)executeFrame {
     _current = self;
-    
+
     // The OpenGL context is only guaranteed to be bound to this thread AFTER startEmulation,
-    // right at the beginning of the first frame execution. This is the latest and safest 
+    // right at the beginning of the first frame execution. This is the latest and safest
     // place to initialize the core's hardware context.
-    if (self.needsContextReset) {
-        self.needsContextReset = NO;
-        
-        if (self.isHW && _hw_callback.context_reset) {
-            _hw_callback.context_reset();
+    if (self.isHW) {
+        // Switch to the shared context before context_reset and before every retro_run.
+        // This ensures GLideN64 (or any core GL plugin) operates within the shared
+        // CGL context that shares the texture namespace with OpenEmu's primary context.
+        // willExecuteFrame() is a no-op in HW render mode (it returns early when
+        // hwSharedContext != nil), so we own context management completely here.
+        NSUInteger hwFBO = self.renderDelegate.hwRenderFramebuffer;
+        if (hwFBO != 0) {
+            // hwRenderFramebuffer non-zero means prepareHWRenderSharedContext succeeded.
+            // The shared context is the one currently set by the renderer — query it
+            // so we can re-assert it before each call.
+            _hwSharedContext = CGLGetCurrentContext();
         }
+
+        if (self.needsContextReset) {
+            self.needsContextReset = NO;
+            if (_hw_callback.context_reset) {
+                if (_hwSharedContext) CGLSetCurrentContext(_hwSharedContext);
+                _hw_callback.context_reset();
+            }
+        } else if (_hwSharedContext) {
+            // Re-assert the shared context on every frame. GLideN64 may have
+            // changed it internally; we need it current before retro_run.
+            CGLSetCurrentContext(_hwSharedContext);
+        }
+    } else if (self.needsContextReset) {
+        self.needsContextReset = NO;
     }
-    
+
     if (_retro_run) _retro_run();
 }
 

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -36,6 +36,8 @@
 #import <arm_neon.h>
 #endif
 #import <stdatomic.h>
+#import <mach-o/dyld.h>
+#import "fishhook/fishhook.h"
 
 // Flip to 1 to dump libretro audio plumbing to the unified log. Off by default —
 // production logs are too chatty otherwise. Filter with:
@@ -56,7 +58,7 @@
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | 0x10000)
 #endif
 
-NSString * const OELibretroBridgeVersion = @"6";
+NSString * const OELibretroBridgeVersion = @"9";
 
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
@@ -133,6 +135,72 @@ static glReadBuffer_t                           _glReadBuffer = NULL;
 // Issue #464 — limit diagnostic logging to the first N frames per session.
 // Probing GL state every frame would flood Console.app and slow rendering.
 #define OE_ISSUE_464_DIAG_FRAMES 6
+
+// =============================================================================
+// Issue #464 — fishhook trace of glBindFramebuffer inside the core dylib.
+//
+// All previous diagnostics confirmed our FBO is complete + correctly attached,
+// EnableFBEmulation=True is applied, and the GL context identity is right —
+// yet zero pixels reach our FBO. We have no visibility into the actual
+// glBindFramebuffer call sequence the core dylib issues during a frame.
+//
+// fishhook (vendored under fishhook/) rebinds the lazy symbol slot for
+// glBindFramebuffer inside the loaded mupen64plus_next_libretro.dylib so
+// every call from inside the core (including GLSM's bindFBO()) is logged
+// with (target, fbo, sequence). The wrapper forwards to the original system
+// glBindFramebuffer so behaviour is unchanged.
+//
+// Gated to the first OE_GL_BIND_HOOK_LOG_LIMIT calls per session.
+// =============================================================================
+typedef void (*pfn_glBindFramebuffer_t)(uint32_t target, uint32_t framebuffer);
+static pfn_glBindFramebuffer_t _orig_glBindFramebuffer = NULL;
+static atomic_int _bind_hook_seq = 0;
+#define OE_GL_BIND_HOOK_LOG_LIMIT 200
+
+static void oe_hook_glBindFramebuffer(uint32_t target, uint32_t framebuffer)
+{
+    int seq = atomic_fetch_add_explicit(&_bind_hook_seq, 1, memory_order_relaxed);
+    if (seq < OE_GL_BIND_HOOK_LOG_LIMIT) {
+        const char *t = "?";
+        switch (target) {
+            case 0x8D40: t = "FB";       break;  // GL_FRAMEBUFFER
+            case 0x8CA8: t = "READ_FB";  break;  // GL_READ_FRAMEBUFFER
+            case 0x8CA9: t = "DRAW_FB";  break;  // GL_DRAW_FRAMEBUFFER
+        }
+        NSLog(@"[OELibretro][#464 hook] glBindFramebuffer #%d %s -> %u",
+              seq, t, framebuffer);
+    }
+    if (_orig_glBindFramebuffer) {
+        _orig_glBindFramebuffer(target, framebuffer);
+    }
+}
+
+// Walks the dyld image list to find the loaded image whose path matches
+// (or ends with) the supplied substring, then rebinds glBindFramebuffer in
+// that image only.
+static void oe_install_bind_hook_for_image(const char *path_substr)
+{
+    if (!path_substr) return;
+    uint32_t count = _dyld_image_count();
+    for (uint32_t i = 0; i < count; i++) {
+        const char *name = _dyld_get_image_name(i);
+        if (!name) continue;
+        if (strstr(name, path_substr) == NULL) continue;
+        const struct mach_header *hdr = _dyld_get_image_header(i);
+        intptr_t slide = _dyld_get_image_vmaddr_slide(i);
+        struct rebinding rb[] = {
+            { "glBindFramebuffer",
+              (void *)oe_hook_glBindFramebuffer,
+              (void **)&_orig_glBindFramebuffer },
+        };
+        int rc = rebind_symbols_image((void *)hdr, slide, rb, 1);
+        NSLog(@"[OELibretro][#464 hook] installed glBindFramebuffer hook on %s (rc=%d, orig=%p)",
+              name, rc, _orig_glBindFramebuffer);
+        return;
+    }
+    NSLog(@"[OELibretro][#464 hook] no loaded image matching '%s' — hook NOT installed",
+          path_substr);
+}
 
 // GL constants (we don't link OpenGL headers in this TU).
 #define OE_GL_NO_ERROR                       0x0000
@@ -397,6 +465,15 @@ static const OELibretroVariableDefault kN64VariableDefaults[] = {
     // GLideN64's threaded renderer needs a shared GL context we don't provide;
     // crashes in TextureCache::_addTexture without this.
     { "mupen64plus-ThreadedRenderer",             "False" },
+    // Framebuffer emulation: REQUIRED for any rendering to reach our shared
+    // FBO. The libretro option default is "True" (libretro_core_options.h),
+    // but mupen64plus-next only applies that default when the front-end
+    // explicitly returns it from RETRO_ENVIRONMENT_GET_VARIABLE. The core's
+    // static initialiser is `uint32_t EnableFBEmulation = 0;`, so without
+    // this entry the core boots in non-FBE mode and never issues the
+    // glBindFramebuffer(GL_FRAMEBUFFER, default_framebuffer) call in
+    // glsm_state_bind — the screen stays black. See issue #464.
+    { "mupen64plus-EnableFBEmulation",            "True" },
     { "mupen64plus-MaxTxCacheSize",               "1500" },
     { "mupen64plus-txHiresEnable",                "False" },
     { "mupen64plus-EnableEnhancedTextureStorage", "False" },
@@ -1448,6 +1525,15 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
             *error = [NSError errorWithDomain:OEGameCoreErrorDomain code:OEGameCoreCouldNotLoadROMError userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to load libretro core: %s", err ?: "unknown error"]}];
         }
         return NO;
+    }
+
+    // Issue #464 — install fishhook trace on the loaded core dylib so we can
+    // observe the actual glBindFramebuffer call sequence during retro_run.
+    // The image is identified by file name (last path component); using the
+    // bare name keeps this resilient to install-location changes.
+    {
+        NSString *imageName = [corePath lastPathComponent];
+        oe_install_bind_hook_for_image([imageName UTF8String]);
     }
     
     // Resolve all mandatory symbols with fallback

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -56,7 +56,7 @@
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | 0x10000)
 #endif
 
-NSString * const OELibretroBridgeVersion = @"5";
+NSString * const OELibretroBridgeVersion = @"6";
 
 
 @interface OELibretroCoreTranslator () <OELibretroInputReceiver>
@@ -116,6 +116,9 @@ typedef void     (*glBindFramebuffer_t)(uint32_t target, uint32_t framebuffer);
 typedef void     (*glGetFramebufferAttachmentParameteriv_t)(uint32_t target, uint32_t attachment, uint32_t pname, int *params);
 typedef uint32_t (*glCheckFramebufferStatus_t)(uint32_t target);
 typedef uint32_t (*glGetError_t)(void);
+typedef void     (*glReadPixels_t)(int x, int y, int width, int height, uint32_t format, uint32_t type, void *pixels);
+typedef uint8_t  (*glIsFramebuffer_t)(uint32_t framebuffer);
+typedef void     (*glReadBuffer_t)(uint32_t mode);
 
 static void *_gl_handle = NULL;
 static glGetIntegerv_t                          _glGetIntegerv = NULL;
@@ -123,6 +126,9 @@ static glBindFramebuffer_t                      _glBindFramebuffer = NULL;
 static glGetFramebufferAttachmentParameteriv_t  _glGetFramebufferAttachmentParameteriv = NULL;
 static glCheckFramebufferStatus_t               _glCheckFramebufferStatus = NULL;
 static glGetError_t                             _glGetError = NULL;
+static glReadPixels_t                           _glReadPixels = NULL;
+static glIsFramebuffer_t                        _glIsFramebuffer = NULL;
+static glReadBuffer_t                           _glReadBuffer = NULL;
 
 // Issue #464 — limit diagnostic logging to the first N frames per session.
 // Probing GL state every frame would flood Console.app and slow rendering.
@@ -139,6 +145,9 @@ static glGetError_t                             _glGetError = NULL;
 #define OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE 0x8CD0
 #define OE_GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME 0x8CD1
 #define OE_GL_FRAMEBUFFER_COMPLETE           0x8CD5
+#define OE_GL_RGBA                           0x1908
+#define OE_GL_UNSIGNED_BYTE                  0x1401
+#define OE_GL_COLOR_ATTACHMENT0_TARGET       0x8CE0
 
 static void* get_gl_handle(void) {
     static dispatch_once_t once;
@@ -150,6 +159,9 @@ static void* get_gl_handle(void) {
             _glGetFramebufferAttachmentParameteriv  = (glGetFramebufferAttachmentParameteriv_t) dlsym(_gl_handle, "glGetFramebufferAttachmentParameteriv");
             _glCheckFramebufferStatus               = (glCheckFramebufferStatus_t)              dlsym(_gl_handle, "glCheckFramebufferStatus");
             _glGetError                             = (glGetError_t)                            dlsym(_gl_handle, "glGetError");
+            _glReadPixels                           = (glReadPixels_t)                          dlsym(_gl_handle, "glReadPixels");
+            _glIsFramebuffer                        = (glIsFramebuffer_t)                       dlsym(_gl_handle, "glIsFramebuffer");
+            _glReadBuffer                           = (glReadBuffer_t)                          dlsym(_gl_handle, "glReadBuffer");
         }
     });
     return _gl_handle;
@@ -1678,6 +1690,51 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                 os_log_fault(OE_LOG_DEFAULT,
                              "[OELibretro][#464 diag3] CTX MISMATCH after retro_run: active %p != shared %p",
                              activeCTX, _hwSharedContext);
+            }
+
+            // Issue #464 — Diag 4: read pixel contents from our FBO and from
+            // raw FBO 0. Definitively answers "did the core render into our
+            // FBO?" (the prior session said no, but the bridge version 4->5
+            // and other changes may have shifted things). Bind our FBO as
+            // read source, glReadBuffer(COLOR_ATTACHMENT0), then glReadPixels.
+            // Count nonzero bytes. Repeat for FBO 0 to see if the core wrote
+            // there instead.
+            if (_glReadPixels && _glReadBuffer && _glIsFramebuffer) {
+                uint8_t isOurFBOValid = _glIsFramebuffer((uint32_t)ourFBO);
+                // 16x16 RGBA probe = 1024 bytes. Cheap.
+                uint8_t probe[16 * 16 * 4];
+                int probeNonzeroOurs = -1;
+                int probeNonzeroZero = -1;
+                uint32_t probeErrOurs = 0;
+                uint32_t probeErrZero = 0;
+                if (isOurFBOValid) {
+                    _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, (uint32_t)ourFBO);
+                    _glReadBuffer(OE_GL_COLOR_ATTACHMENT0);
+                    (void)_glGetError();
+                    memset(probe, 0, sizeof(probe));
+                    _glReadPixels(0, 0, 16, 16, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
+                    probeErrOurs = _glGetError();
+                    int nz = 0;
+                    for (size_t i = 0; i < sizeof(probe); i++) if (probe[i]) nz++;
+                    probeNonzeroOurs = nz;
+                }
+                // Probe FBO 0 (raw default framebuffer on shared context).
+                _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, 0);
+                (void)_glGetError();
+                memset(probe, 0, sizeof(probe));
+                _glReadPixels(0, 0, 16, 16, OE_GL_RGBA, OE_GL_UNSIGNED_BYTE, probe);
+                probeErrZero = _glGetError();
+                if (probeErrZero == 0) {
+                    int nz = 0;
+                    for (size_t i = 0; i < sizeof(probe); i++) if (probe[i]) nz++;
+                    probeNonzeroZero = nz;
+                }
+                // Restore READ binding.
+                _glBindFramebuffer(OE_GL_READ_FRAMEBUFFER, (uint32_t)readBinding);
+                NSLog(@"[OELibretro][#464 diag4] post-retro_run[%d] ourFBO_valid=%d ourFBO_nonzero_bytes=%d (glErr=0x%04X) FBO0_nonzero_bytes=%d (glErr=0x%04X)",
+                      _postRunDiagCount, (int)isOurFBOValid,
+                      probeNonzeroOurs, probeErrOurs,
+                      probeNonzeroZero, probeErrZero);
             }
         }
     }

--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -134,7 +134,15 @@ static uintptr_t libretro_get_current_framebuffer(void) {
             // This FBO was created by prepareHWRenderSharedContext and is
             // valid in the context that GLideN64 / the core GL plugin uses.
             if (_current.isHW) {
-                return (uintptr_t)_current.renderDelegate.hwRenderFramebuffer;
+                NSUInteger fbo = _current.renderDelegate.hwRenderFramebuffer;
+                CGLContextObj activeCTX = CGLGetCurrentContext();
+                CGLContextObj sharedCTX = (CGLContextObj)(uintptr_t)_current.renderDelegate.hwRenderSharedContextPtr;
+                static int _fbDiagCount = 0;
+                if (++_fbDiagCount <= 5) {
+                    NSLog(@"[OELibretro] get_current_framebuffer[%d] -> FBO %lu, active ctx %p, shared ctx %p",
+                          _fbDiagCount, (unsigned long)fbo, activeCTX, sharedCTX);
+                }
+                return (uintptr_t)fbo;
             }
 
             // Software / bitmap path: ask for the standard presentation FBO.
@@ -1505,17 +1513,29 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     _current = self;
 
     if (self.isHW) {
-        // --- Deferred HW context setup (runs exactly once on the first HW frame) ---
-        // prepareHWRenderSharedContext couldn't run at SET_HW_RENDER time because
-        // glContext / glPixelFormat don't exist until the render loop starts.
-        // Now we're on the emulation thread with GL fully initialised.
-        if (self.needsHWContextSetup) {
+        // --- HW context setup / re-setup ---
+        // Runs on first frame (needsHWContextSetup) AND whenever the renderer
+        // re-initialises mid-session (e.g. buffer size change triggers update()
+        // → destroyGLResources() → hwSharedContext = nil → hwRenderSharedContextPtr = 0).
+        //
+        // Detect re-init by comparing the stored pointer against what the
+        // renderer currently reports. A mismatch (or zero) means the GL
+        // resources were torn down and must be rebuilt.
+        NSUInteger rendererCtxPtr = self.renderDelegate.hwRenderSharedContextPtr;
+        NSUInteger ourCtxPtr      = (NSUInteger)(uintptr_t)_hwSharedContext;
+
+        if (self.needsHWContextSetup || rendererCtxPtr != ourCtxPtr) {
             self.needsHWContextSetup = NO;
+
+            // Only call context_destroy if the renderer's shared context is still
+            // alive (rendererCtxPtr != 0). If it's already been torn down by
+            // destroyGLResources(), the callback would run with a stale context.
+            if (_hwSharedContext && rendererCtxPtr != 0 && _hw_callback.context_destroy) {
+                _hw_callback.context_destroy();
+            }
+
             [self.renderDelegate prepareHWRenderSharedContext];
 
-            // Retrieve the shared context pointer directly from the renderer.
-            // Do NOT use CGLGetCurrentContext() — that returns the current context
-            // on this thread, which may be nil or glContext at this point.
             NSUInteger ctxPtr = self.renderDelegate.hwRenderSharedContextPtr;
             _hwSharedContext = ctxPtr ? (CGLContextObj)(uintptr_t)ctxPtr : NULL;
 
@@ -1527,20 +1547,19 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
                     "[OELibretro] prepareHWRenderSharedContext failed — "
                     "falling back to software render for this session");
                 self.isHW = NO;
-                if (self.needsContextReset) {
-                    self.needsContextReset = NO;
-                    // Skip context_reset — GLideN64 won't get its GL context,
-                    // but at least we won't crash with no context active.
-                }
+                self.needsContextReset = NO;
                 if (_retro_run) _retro_run();
                 return;
             }
+
+            // Re-fire context_reset so GLideN64 re-initialises its GL state
+            // on the new shared context (new FBO, new texture backing).
+            self.needsContextReset = YES;
         }
 
         // --- Per-frame context management ---
         // Re-assert the shared context before context_reset and before retro_run.
-        // GLideN64 may have changed the current context internally; we need
-        // the shared context active so its GL calls land in the correct sharegroup.
+        // GLideN64 may have changed the current context internally.
         if (self.needsContextReset) {
             self.needsContextReset = NO;
             CGLSetCurrentContext(_hwSharedContext);

--- a/OpenEmu-SDK/OpenEmuBase/fishhook/LICENSE
+++ b/OpenEmu-SDK/OpenEmuBase/fishhook/LICENSE
@@ -1,0 +1,22 @@
+// Copyright (c) 2013, Facebook, Inc.
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name Facebook nor the names of its contributors may be used to
+//     endorse or promote products derived from this software without specific
+//     prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/OpenEmu-SDK/OpenEmuBase/fishhook/fishhook.c
+++ b/OpenEmu-SDK/OpenEmuBase/fishhook/fishhook.c
@@ -1,0 +1,264 @@
+// Copyright (c) 2013, Facebook, Inc.
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name Facebook nor the names of its contributors may be used to
+//     endorse or promote products derived from this software without specific
+//     prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "fishhook.h"
+
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <mach/mach.h>
+#include <mach/vm_map.h>
+#include <mach/vm_region.h>
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+
+#ifdef __LP64__
+typedef struct mach_header_64 mach_header_t;
+typedef struct segment_command_64 segment_command_t;
+typedef struct section_64 section_t;
+typedef struct nlist_64 nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT_64
+#else
+typedef struct mach_header mach_header_t;
+typedef struct segment_command segment_command_t;
+typedef struct section section_t;
+typedef struct nlist nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT
+#endif
+
+#ifndef SEG_DATA_CONST
+#define SEG_DATA_CONST  "__DATA_CONST"
+#endif
+
+struct rebindings_entry {
+  struct rebinding *rebindings;
+  size_t rebindings_nel;
+  struct rebindings_entry *next;
+};
+
+static struct rebindings_entry *_rebindings_head;
+
+static int prepend_rebindings(struct rebindings_entry **rebindings_head,
+                              struct rebinding rebindings[],
+                              size_t nel) {
+  struct rebindings_entry *new_entry = (struct rebindings_entry *) malloc(sizeof(struct rebindings_entry));
+  if (!new_entry) {
+    return -1;
+  }
+  new_entry->rebindings = (struct rebinding *) malloc(sizeof(struct rebinding) * nel);
+  if (!new_entry->rebindings) {
+    free(new_entry);
+    return -1;
+  }
+  memcpy(new_entry->rebindings, rebindings, sizeof(struct rebinding) * nel);
+  new_entry->rebindings_nel = nel;
+  new_entry->next = *rebindings_head;
+  *rebindings_head = new_entry;
+  return 0;
+}
+
+#if 0
+static int get_protection(void *addr, vm_prot_t *prot, vm_prot_t *max_prot) {
+  mach_port_t task = mach_task_self();
+  vm_size_t size = 0;
+  vm_address_t address = (vm_address_t)addr;
+  memory_object_name_t object;
+#ifdef __LP64__
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+  vm_region_basic_info_data_64_t info;
+  kern_return_t info_ret = vm_region_64(
+      task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
+#else
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
+  vm_region_basic_info_data_t info;
+  kern_return_t info_ret = vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
+#endif
+  if (info_ret == KERN_SUCCESS) {
+    if (prot != NULL)
+      *prot = info.protection;
+
+    if (max_prot != NULL)
+      *max_prot = info.max_protection;
+
+    return 0;
+  }
+
+  return -1;
+}
+#endif
+
+static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
+                                           section_t *section,
+                                           intptr_t slide,
+                                           nlist_t *symtab,
+                                           char *strtab,
+                                           uint32_t *indirect_symtab) {
+  uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
+  void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
+
+  for (uint i = 0; i < section->size / sizeof(void *); i++) {
+    uint32_t symtab_index = indirect_symbol_indices[i];
+    if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
+        symtab_index == (INDIRECT_SYMBOL_LOCAL   | INDIRECT_SYMBOL_ABS)) {
+      continue;
+    }
+    uint32_t strtab_offset = symtab[symtab_index].n_un.n_strx;
+    char *symbol_name = strtab + strtab_offset;
+    bool symbol_name_longer_than_1 = symbol_name[0] && symbol_name[1];
+    struct rebindings_entry *cur = rebindings;
+    while (cur) {
+      for (uint j = 0; j < cur->rebindings_nel; j++) {
+        if (symbol_name_longer_than_1 && strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
+          kern_return_t err;
+
+          if (cur->rebindings[j].replaced != NULL && indirect_symbol_bindings[i] != cur->rebindings[j].replacement)
+            *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
+
+          /**
+           * 1. Moved the vm protection modifying codes to here to reduce the
+           *    changing scope.
+           * 2. Adding VM_PROT_WRITE mode unconditionally because vm_region
+           *    API on some iOS/Mac reports mismatch vm protection attributes.
+           * -- Lianfu Hao Jun 16th, 2021
+           **/
+          err = vm_protect (mach_task_self (), (uintptr_t)indirect_symbol_bindings, section->size, 0, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
+          if (err == KERN_SUCCESS) {
+            /**
+             * Once we failed to change the vm protection, we
+             * MUST NOT continue the following write actions!
+             * iOS 15 has corrected the const segments prot.
+             * -- Lionfore Hao Jun 11th, 2021
+             **/
+            indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          }
+          goto symbol_loop;
+        }
+      }
+      cur = cur->next;
+    }
+  symbol_loop:;
+  }
+}
+
+static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
+                                     const struct mach_header *header,
+                                     intptr_t slide) {
+  Dl_info info;
+  if (dladdr(header, &info) == 0) {
+    return;
+  }
+
+  segment_command_t *cur_seg_cmd;
+  segment_command_t *linkedit_segment = NULL;
+  struct symtab_command* symtab_cmd = NULL;
+  struct dysymtab_command* dysymtab_cmd = NULL;
+
+  uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+    cur_seg_cmd = (segment_command_t *)cur;
+    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
+        linkedit_segment = cur_seg_cmd;
+      }
+    } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
+      symtab_cmd = (struct symtab_command*)cur_seg_cmd;
+    } else if (cur_seg_cmd->cmd == LC_DYSYMTAB) {
+      dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
+    }
+  }
+
+  if (!symtab_cmd || !dysymtab_cmd || !linkedit_segment ||
+      !dysymtab_cmd->nindirectsyms) {
+    return;
+  }
+
+  // Find base symbol/string table addresses
+  uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
+  nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
+  char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+
+  // Get indirect symbol table (array of uint32_t indices into symbol table)
+  uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
+
+  cur = (uintptr_t)header + sizeof(mach_header_t);
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+    cur_seg_cmd = (segment_command_t *)cur;
+    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
+          strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
+        continue;
+      }
+      for (uint j = 0; j < cur_seg_cmd->nsects; j++) {
+        section_t *sect =
+          (section_t *)(cur + sizeof(segment_command_t)) + j;
+        if ((sect->flags & SECTION_TYPE) == S_LAZY_SYMBOL_POINTERS) {
+          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+        }
+        if ((sect->flags & SECTION_TYPE) == S_NON_LAZY_SYMBOL_POINTERS) {
+          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+        }
+      }
+    }
+  }
+}
+
+static void _rebind_symbols_for_image(const struct mach_header *header,
+                                      intptr_t slide) {
+    rebind_symbols_for_image(_rebindings_head, header, slide);
+}
+
+int rebind_symbols_image(void *header,
+                         intptr_t slide,
+                         struct rebinding rebindings[],
+                         size_t rebindings_nel) {
+    struct rebindings_entry *rebindings_head = NULL;
+    int retval = prepend_rebindings(&rebindings_head, rebindings, rebindings_nel);
+    rebind_symbols_for_image(rebindings_head, (const struct mach_header *) header, slide);
+    if (rebindings_head) {
+      free(rebindings_head->rebindings);
+    }
+    free(rebindings_head);
+    return retval;
+}
+
+int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel) {
+  int retval = prepend_rebindings(&_rebindings_head, rebindings, rebindings_nel);
+  if (retval < 0) {
+    return retval;
+  }
+  // If this was the first call, register callback for image additions (which is also invoked for
+  // existing images, otherwise, just run on existing images
+  if (!_rebindings_head->next) {
+    _dyld_register_func_for_add_image(_rebind_symbols_for_image);
+  } else {
+    uint32_t c = _dyld_image_count();
+    for (uint32_t i = 0; i < c; i++) {
+      _rebind_symbols_for_image(_dyld_get_image_header(i), _dyld_get_image_vmaddr_slide(i));
+    }
+  }
+  return retval;
+}

--- a/OpenEmu-SDK/OpenEmuBase/fishhook/fishhook.h
+++ b/OpenEmu-SDK/OpenEmuBase/fishhook/fishhook.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2013, Facebook, Inc.
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name Facebook nor the names of its contributors may be used to
+//     endorse or promote products derived from this software without specific
+//     prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef fishhook_h
+#define fishhook_h
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(FISHHOOK_EXPORT)
+#define FISHHOOK_VISIBILITY __attribute__((visibility("hidden")))
+#else
+#define FISHHOOK_VISIBILITY __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+/*
+ * A structure representing a particular intended rebinding from a symbol
+ * name to its replacement
+ */
+struct rebinding {
+  const char *name;
+  void *replacement;
+  void **replaced;
+};
+
+/*
+ * For each rebinding in rebindings, rebinds references to external, indirect
+ * symbols with the specified name to instead point at replacement for each
+ * image in the calling process as well as for all future images that are loaded
+ * by the process. If rebind_functions is called more than once, the symbols to
+ * rebind are added to the existing list of rebindings, and if a given symbol
+ * is rebound more than once, the later rebinding will take precedence.
+ */
+FISHHOOK_VISIBILITY
+int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
+
+/*
+ * Rebinds as above, but only in the specified image. The header should point
+ * to the mach-o header, the slide should be the slide offset. Others as above.
+ */
+FISHHOOK_VISIBILITY
+int rebind_symbols_image(void *header,
+                         intptr_t slide,
+                         struct rebinding rebindings[],
+                         size_t rebindings_nel);
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
+#endif //fishhook_h
+

--- a/OpenEmuKit/Source/GameRenderer.swift
+++ b/OpenEmuKit/Source/GameRenderer.swift
@@ -60,6 +60,10 @@ protocol OpenGLGameRenderer: GameRenderer {
     /// Only meaningful after prepareHWRenderSharedContext() has been called.
     var hwRenderFramebuffer: UInt { get }
 
+    /// The CGLContextObj of the shared context, bit-cast to UInt for protocol crossing.
+    /// Zero if prepareHWRenderSharedContext() has not been called or failed.
+    var hwRenderSharedContextPtr: UInt { get }
+
     func presentDoubleBufferedFBO()
     func willRenderFrameOnAlternateThread()
     func didRenderFrameOnAlternateThread()

--- a/OpenEmuKit/Source/GameRenderer.swift
+++ b/OpenEmuKit/Source/GameRenderer.swift
@@ -51,6 +51,15 @@ protocol GameRenderer {
 protocol OpenGLGameRenderer: GameRenderer {
     var presentationFramebuffer: Any? { get }
 
+    /// Called by the libretro translator when it accepts SET_HW_RENDER.
+    /// Creates a CGL shared context (sharing textures with the primary glContext)
+    /// and an FBO on that context backed by the same IOSurface texture.
+    func prepareHWRenderSharedContext()
+
+    /// The FBO number valid on the HW render shared context.
+    /// Only meaningful after prepareHWRenderSharedContext() has been called.
+    var hwRenderFramebuffer: UInt { get }
+
     func presentDoubleBufferedFBO()
     func willRenderFrameOnAlternateThread()
     func didRenderFrameOnAlternateThread()

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -639,6 +639,14 @@ extension OSLog {
     public var presentationFramebuffer: Any? {
         _openGLGameRenderer?.presentationFramebuffer
     }
+
+    public func prepareHWRenderSharedContext() {
+        _openGLGameRenderer?.prepareHWRenderSharedContext()
+    }
+
+    public var hwRenderFramebuffer: UInt {
+        _openGLGameRenderer?.hwRenderFramebuffer ?? 0
+    }
     
     public func willExecute() {
         _gameRenderer.willExecuteFrame()

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -647,6 +647,10 @@ extension OSLog {
     public var hwRenderFramebuffer: UInt {
         _openGLGameRenderer?.hwRenderFramebuffer ?? 0
     }
+
+    public var hwRenderSharedContextPtr: UInt {
+        _openGLGameRenderer?.hwRenderSharedContextPtr ?? 0
+    }
     
     public func willExecute() {
         _gameRenderer.willExecuteFrame()

--- a/OpenEmuKit/Source/OpenGL3GameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGL3GameRenderer.swift
@@ -131,6 +131,91 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         glBindFramebuffer(GLenum(GL_FRAMEBUFFER), alternateFBO)
     }
     
+    // MARK: - HW render shared context
+
+    override func prepareHWRenderSharedContext() {
+        guard hwSharedContext == nil else {
+            os_log(.debug, log: .renderer, "prepareHWRenderSharedContext: already set up, skipping")
+            return
+        }
+
+        // Create a CGL context that shares the texture namespace of glContext.
+        // Textures (including the IOSurface-backed texture) are shared; FBOs are not.
+        var sharedCtx: CGLContextObj?
+        let err = CGLCreateContext(glPixelFormat, glContext, &sharedCtx)
+        guard err == kCGLNoError, let sharedCtx else {
+            os_log(.error, log: .renderer,
+                   "prepareHWRenderSharedContext: CGLCreateContext failed: %{public}s",
+                   CGLErrorString(err))
+            return
+        }
+
+        CGLSetCurrentContext(sharedCtx)
+
+        // Create the FBO on the shared context.
+        // texture.openGLTexture is a GLuint valid in both glContext and sharedCtx
+        // because they share the texture namespace.
+        var fbo: GLuint = 0
+        glGenFramebuffers(1, &fbo)
+        glBindFramebuffer(GLenum(GL_FRAMEBUFFER), fbo)
+        glFramebufferTexture2D(
+            GLenum(GL_FRAMEBUFFER),
+            GLenum(GL_COLOR_ATTACHMENT0),
+            GLenum(GL_TEXTURE_RECTANGLE),
+            texture.openGLTexture,
+            0
+        )
+        var status = glGetError()
+        if status != 0 {
+            os_log(.error, log: .renderer,
+                   "prepareHWRenderSharedContext: attach color texture, GL error %04X", status)
+        }
+
+        // Depth/stencil renderbuffer — renderbuffers are NOT shared between contexts,
+        // so we create a fresh one on the shared context.
+        var depthRB: GLuint = 0
+        glGenRenderbuffers(1, &depthRB)
+        glBindRenderbuffer(GLenum(GL_RENDERBUFFER), depthRB)
+        glRenderbufferStorage(
+            GLenum(GL_RENDERBUFFER),
+            GLenum(GL_DEPTH24_STENCIL8),
+            GLsizei(texture.size.width),
+            GLsizei(texture.size.height)
+        )
+        glFramebufferRenderbuffer(
+            GLenum(GL_FRAMEBUFFER),
+            GLenum(GL_DEPTH_STENCIL_ATTACHMENT),
+            GLenum(GL_RENDERBUFFER),
+            depthRB
+        )
+        status = glGetError()
+        if status != 0 {
+            os_log(.error, log: .renderer,
+                   "prepareHWRenderSharedContext: attach depth/stencil RB, GL error %04X", status)
+        }
+
+        let fbStatus = glCheckFramebufferStatus(GLenum(GL_FRAMEBUFFER))
+        if fbStatus != GL_FRAMEBUFFER_COMPLETE {
+            os_log(.error, log: .renderer,
+                   "prepareHWRenderSharedContext: FBO incomplete, status %04X", fbStatus)
+            glDeleteFramebuffers(1, &fbo)
+            glDeleteRenderbuffers(1, &depthRB)
+            CGLSetCurrentContext(nil)
+            CGLReleaseContext(sharedCtx)
+            return
+        }
+
+        // Leave the shared context current — the translator will use it
+        // immediately for context_reset on the first frame.
+        hwSharedContext       = sharedCtx
+        hwSharedFBO           = fbo
+        hwSharedDepthStencilRB = depthRB
+
+        os_log(.debug, log: .renderer,
+               "prepareHWRenderSharedContext: shared context %p, FBO %u ready",
+               sharedCtx, fbo)
+    }
+
     override func suspendFPSLimiting() {
         super.suspendFPSLimiting()
         
@@ -160,6 +245,14 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
             return
         }
         
+        if hwSharedContext != nil {
+            // HW render mode: the translator left hwSharedContext current after retro_run.
+            // Flush on that context so the IOSurface-backed texture is committed.
+            // glContext is untouched this frame — no need to switch back.
+            glFlushRenderAPPLE()
+            return
+        }
+
         // Update the IOSurface.
         glFlushRenderAPPLE()
     }

--- a/OpenEmuKit/Source/OpenGL3GameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGL3GameRenderer.swift
@@ -140,7 +140,9 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         }
 
         // Create a CGL context that shares the texture namespace of glContext.
-        // Textures (including the IOSurface-backed texture) are shared; FBOs are not.
+        // Textures (including the IOSurface-backed texture and the staging
+        // texture we create below) are shared across both contexts. FBOs and
+        // renderbuffers are NOT shared, so they live entirely on sharedCtx.
         var sharedCtx: CGLContextObj?
         let err = CGLCreateContext(glPixelFormat, glContext, &sharedCtx)
         guard err == kCGLNoError, let sharedCtx else {
@@ -152,36 +154,58 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
 
         CGLSetCurrentContext(sharedCtx)
 
-        // Create the FBO on the shared context.
-        // texture.openGLTexture is a GLuint valid in both glContext and sharedCtx
-        // because they share the texture namespace.
+        let w = GLsizei(texture.size.width)
+        let h = GLsizei(texture.size.height)
+
+        // --- Staging texture --------------------------------------------------
+        // Plain GL_TEXTURE_2D in ordinary GPU memory. This is what the libretro
+        // core actually renders into. Issue #464 confirmed that attaching the
+        // IOSurface-backed GL_TEXTURE_RECTANGLE directly as the FBO color
+        // attachment produces no observable pixels even though the framebuffer
+        // is COMPLETE — GLideN64's draws (and likely other GL cores' draws)
+        // don't make it through that attachment path. The staging texture
+        // sidesteps that entirely; we blit its contents into the IOSurface
+        // texture at end-of-frame (see didExecuteFrame).
+        var stagingTex: GLuint = 0
+        glGenTextures(1, &stagingTex)
+        glBindTexture(GLenum(GL_TEXTURE_2D), stagingTex)
+        glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MIN_FILTER), GL_LINEAR)
+        glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MAG_FILTER), GL_LINEAR)
+        glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_S),     GL_CLAMP_TO_EDGE)
+        glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_T),     GL_CLAMP_TO_EDGE)
+        glTexImage2D(
+            GLenum(GL_TEXTURE_2D), 0,
+            GL_RGBA8,
+            w, h, 0,
+            GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), nil
+        )
+        if glGetError() != 0 {
+            os_log(.error, log: .renderer, "prepareHWRenderSharedContext: staging texture alloc failed")
+        }
+        glBindTexture(GLenum(GL_TEXTURE_2D), 0)
+
+        // --- hwSharedFBO (returned to the libretro core) ---------------------
+        // Color attachment = staging texture (2D). Depth/stencil renderbuffer.
         var fbo: GLuint = 0
         glGenFramebuffers(1, &fbo)
         glBindFramebuffer(GLenum(GL_FRAMEBUFFER), fbo)
         glFramebufferTexture2D(
             GLenum(GL_FRAMEBUFFER),
             GLenum(GL_COLOR_ATTACHMENT0),
-            GLenum(GL_TEXTURE_RECTANGLE),
-            texture.openGLTexture,
+            GLenum(GL_TEXTURE_2D),
+            stagingTex,
             0
         )
         var status = glGetError()
         if status != 0 {
             os_log(.error, log: .renderer,
-                   "prepareHWRenderSharedContext: attach color texture, GL error %04X", status)
+                   "prepareHWRenderSharedContext: attach staging texture, GL error %04X", status)
         }
 
-        // Depth/stencil renderbuffer — renderbuffers are NOT shared between contexts,
-        // so we create a fresh one on the shared context.
         var depthRB: GLuint = 0
         glGenRenderbuffers(1, &depthRB)
         glBindRenderbuffer(GLenum(GL_RENDERBUFFER), depthRB)
-        glRenderbufferStorage(
-            GLenum(GL_RENDERBUFFER),
-            GLenum(GL_DEPTH24_STENCIL8),
-            GLsizei(texture.size.width),
-            GLsizei(texture.size.height)
-        )
+        glRenderbufferStorage(GLenum(GL_RENDERBUFFER), GLenum(GL_DEPTH24_STENCIL8), w, h)
         glFramebufferRenderbuffer(
             GLenum(GL_FRAMEBUFFER),
             GLenum(GL_DEPTH_STENCIL_ATTACHMENT),
@@ -197,23 +221,55 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         let fbStatus = glCheckFramebufferStatus(GLenum(GL_FRAMEBUFFER))
         if fbStatus != GL_FRAMEBUFFER_COMPLETE {
             os_log(.error, log: .renderer,
-                   "prepareHWRenderSharedContext: FBO incomplete, status %04X", fbStatus)
+                   "prepareHWRenderSharedContext: hwSharedFBO incomplete, status %04X", fbStatus)
             glDeleteFramebuffers(1, &fbo)
             glDeleteRenderbuffers(1, &depthRB)
+            glDeleteTextures(1, &stagingTex)
             CGLSetCurrentContext(nil)
             CGLReleaseContext(sharedCtx)
             return
         }
 
-        // Leave the shared context current — the translator will use it
-        // immediately for context_reset on the first frame.
-        hwSharedContext       = sharedCtx
-        hwSharedFBO           = fbo
+        // --- hwOutputFBO (blit destination, end-of-frame) --------------------
+        // Color attachment = the IOSurface-backed GL_TEXTURE_RECTANGLE.
+        // We blit from hwSharedFBO into here, then flush to commit IOSurface.
+        var outFBO: GLuint = 0
+        glGenFramebuffers(1, &outFBO)
+        glBindFramebuffer(GLenum(GL_FRAMEBUFFER), outFBO)
+        glFramebufferTexture2D(
+            GLenum(GL_FRAMEBUFFER),
+            GLenum(GL_COLOR_ATTACHMENT0),
+            GLenum(GL_TEXTURE_RECTANGLE),
+            texture.openGLTexture,
+            0
+        )
+        let outStatus = glCheckFramebufferStatus(GLenum(GL_FRAMEBUFFER))
+        if outStatus != GL_FRAMEBUFFER_COMPLETE {
+            os_log(.error, log: .renderer,
+                   "prepareHWRenderSharedContext: hwOutputFBO incomplete, status %04X", outStatus)
+            glDeleteFramebuffers(1, &outFBO)
+            glDeleteFramebuffers(1, &fbo)
+            glDeleteRenderbuffers(1, &depthRB)
+            glDeleteTextures(1, &stagingTex)
+            CGLSetCurrentContext(nil)
+            CGLReleaseContext(sharedCtx)
+            return
+        }
+
+        // Leave hwSharedFBO bound — it's the FBO the translator will return
+        // from libretro_get_current_framebuffer() and the core will use for
+        // its first context_reset.
+        glBindFramebuffer(GLenum(GL_FRAMEBUFFER), fbo)
+
+        hwSharedContext        = sharedCtx
+        hwSharedFBO            = fbo
+        hwSharedStagingTexture = stagingTex
         hwSharedDepthStencilRB = depthRB
+        hwOutputFBO            = outFBO
 
         os_log(.debug, log: .renderer,
-               "prepareHWRenderSharedContext: shared context %p, FBO %u ready",
-               sharedCtx, fbo)
+               "prepareHWRenderSharedContext: shared ctx %p, hwSharedFBO=%u (staging tex %u, %dx%d), hwOutputFBO=%u (IOSurface tex %u)",
+               sharedCtx, fbo, stagingTex, Int(w), Int(h), outFBO, texture.openGLTexture)
     }
 
     override func suspendFPSLimiting() {
@@ -246,12 +302,49 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         }
         
         if hwSharedContext != nil {
-            // HW render mode: GLideN64 rendered into hwSharedFBO on hwSharedContext.
-            // glFinish() drains the shared context GPU pipeline, then switch to
-            // glContext (which owns the CVOpenGLTextureCacheRef) for glFlushRenderAPPLE()
-            // to commit the texture contents to the IOSurface.
+            // HW render mode: the core rendered into hwSharedFBO (which is
+            // backed by hwSharedStagingTexture, a plain GL_TEXTURE_2D in GPU
+            // memory). We now blit that into hwOutputFBO (which is backed by
+            // the IOSurface-backed GL_TEXTURE_RECTANGLE) so the compositor
+            // sees the new frame.
+            //
+            // Issue #464: this two-FBO + blit approach is necessary because
+            // attaching an IOSurface-backed RECTANGLE texture directly as the
+            // core's render target produced complete-but-blank framebuffers
+            // for GLideN64. The blit costs one full-frame GPU copy per frame.
             CGLSetCurrentContext(hwSharedContext)
+
+            if hwSharedFBO != 0 && hwOutputFBO != 0 {
+                let w = GLint(texture.size.width)
+                let h = GLint(texture.size.height)
+                // Save current bindings so the core's next frame state is unaffected.
+                var prevDraw: GLint = 0
+                var prevRead: GLint = 0
+                glGetIntegerv(GLenum(GL_DRAW_FRAMEBUFFER_BINDING), &prevDraw)
+                glGetIntegerv(GLenum(GL_READ_FRAMEBUFFER_BINDING), &prevRead)
+
+                glBindFramebuffer(GLenum(GL_READ_FRAMEBUFFER), hwSharedFBO)
+                glReadBuffer(GLenum(GL_COLOR_ATTACHMENT0))
+                glBindFramebuffer(GLenum(GL_DRAW_FRAMEBUFFER), hwOutputFBO)
+                // Some drivers need an explicit color-write enable + scissor-off
+                // for a clean blit.
+                glColorMask(GLboolean(GL_TRUE), GLboolean(GL_TRUE), GLboolean(GL_TRUE), GLboolean(GL_TRUE))
+                glDisable(GLenum(GL_SCISSOR_TEST))
+                glBlitFramebuffer(
+                    0, 0, w, h,
+                    0, 0, w, h,
+                    GLbitfield(GL_COLOR_BUFFER_BIT),
+                    GLenum(GL_NEAREST)
+                )
+
+                // Restore previous bindings so context_reset / glsm_state_bind
+                // state on the next frame matches what the core expects.
+                glBindFramebuffer(GLenum(GL_DRAW_FRAMEBUFFER), GLuint(prevDraw))
+                glBindFramebuffer(GLenum(GL_READ_FRAMEBUFFER), GLuint(prevRead))
+            }
             glFinish()
+            // Switch to glContext (which owns the CVOpenGLTextureCacheRef) for
+            // glFlushRenderAPPLE() to commit the IOSurface texture contents.
             CGLSetCurrentContext(glContext)
             glFlushRenderAPPLE()
             return

--- a/OpenEmuKit/Source/OpenGL3GameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGL3GameRenderer.swift
@@ -246,12 +246,11 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         }
         
         if hwSharedContext != nil {
-            // HW render mode: GLideN64 rendered into hwSharedFBO on hwSharedContext
-            // (which the translator left current after retro_run).
-            // glFinish() drains the shared context's GPU pipeline, then we switch
-            // to glContext — which owns the CVOpenGLTextureCacheRef backing the
-            // IOSurface — and call glFlushRenderAPPLE() to commit the texture
-            // contents to the surface for the Metal compositor to read.
+            // HW render mode: GLideN64 rendered into hwSharedFBO on hwSharedContext.
+            // glFinish() drains the shared context GPU pipeline, then switch to
+            // glContext (which owns the CVOpenGLTextureCacheRef) for glFlushRenderAPPLE()
+            // to commit the texture contents to the IOSurface.
+            CGLSetCurrentContext(hwSharedContext)
             glFinish()
             CGLSetCurrentContext(glContext)
             glFlushRenderAPPLE()

--- a/OpenEmuKit/Source/OpenGL3GameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGL3GameRenderer.swift
@@ -246,9 +246,14 @@ final class OpenGL3GameRenderer: BaseOpenGLGameRenderer {
         }
         
         if hwSharedContext != nil {
-            // HW render mode: the translator left hwSharedContext current after retro_run.
-            // Flush on that context so the IOSurface-backed texture is committed.
-            // glContext is untouched this frame — no need to switch back.
+            // HW render mode: GLideN64 rendered into hwSharedFBO on hwSharedContext
+            // (which the translator left current after retro_run).
+            // glFinish() drains the shared context's GPU pipeline, then we switch
+            // to glContext — which owns the CVOpenGLTextureCacheRef backing the
+            // IOSurface — and call glFlushRenderAPPLE() to commit the texture
+            // contents to the surface for the Metal compositor to read.
+            glFinish()
+            CGLSetCurrentContext(glContext)
             glFlushRenderAPPLE()
             return
         }

--- a/OpenEmuKit/Source/OpenGLGameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGLGameRenderer.swift
@@ -52,9 +52,23 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     
     // HW render shared context — set up on demand by prepareHWRenderSharedContext().
     // Nil until a libretro core accepts RETRO_ENVIRONMENT_SET_HW_RENDER.
+    //
+    // Issue #464: GLideN64 (and likely other GL libretro cores) cannot write
+    // visibly to an FBO whose color attachment is an IOSurface-backed
+    // GL_TEXTURE_RECTANGLE. The framebuffer reports COMPLETE and binds bind
+    // correctly, but rendered fragments produce no observable pixels.
+    //
+    // Workaround: give the core a plain GL_TEXTURE_2D backed by ordinary
+    // GPU memory as the render target (hwSharedStagingTexture, attached to
+    // hwSharedFBO). At end-of-frame, blit from hwSharedFBO into hwOutputFBO,
+    // which has the IOSurface-backed GL_TEXTURE_RECTANGLE as color attachment.
+    // This adds one full-frame GPU copy per frame but is the standard cost of
+    // bridging libretro's GL hw_render contract to a Metal-compositing host.
     var hwSharedContext: CGLContextObj?
-    var hwSharedFBO: GLuint = 0
+    var hwSharedFBO: GLuint = 0                   // → staging texture (rendered into by the core)
+    var hwSharedStagingTexture: GLuint = 0        // GL_TEXTURE_2D, plain GPU memory
     var hwSharedDepthStencilRB: GLuint = 0
+    var hwOutputFBO: GLuint = 0                   // → IOSurface RECTANGLE texture (blit destination)
 
     var isFPSLimiting = ManagedAtomic(0)
     
@@ -187,9 +201,17 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
         // after glContext has been released is undefined behaviour.
         if let hwSharedContext = hwSharedContext {
             CGLSetCurrentContext(hwSharedContext)
+            if hwOutputFBO != 0 {
+                glDeleteFramebuffers(1, &hwOutputFBO)
+                hwOutputFBO = 0
+            }
             if hwSharedFBO != 0 {
                 glDeleteFramebuffers(1, &hwSharedFBO)
                 hwSharedFBO = 0
+            }
+            if hwSharedStagingTexture != 0 {
+                glDeleteTextures(1, &hwSharedStagingTexture)
+                hwSharedStagingTexture = 0
             }
             if hwSharedDepthStencilRB != 0 {
                 glDeleteRenderbuffers(1, &hwSharedDepthStencilRB)

--- a/OpenEmuKit/Source/OpenGLGameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGLGameRenderer.swift
@@ -149,12 +149,23 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     // MARK: - HW render shared context (Phase 2 — GL work added in OpenGL3GameRenderer)
 
     func prepareHWRenderSharedContext() {
-        // Implemented in concrete subclass (OpenGL3GameRenderer).
-        // Base does nothing so non-HW renderers satisfy the protocol without crashing.
+        // Concrete subclasses (OpenGL3GameRenderer) override this.
+        // The base no-op means non-HW-capable renderers (e.g. GL2) satisfy the
+        // protocol without crashing, but hwSharedFBO stays 0 — the translator
+        // treats a zero hwRenderFramebuffer as a setup failure and resets isHW.
+        os_log(.error, log: .renderer,
+               "prepareHWRenderSharedContext called on base renderer — HW render not supported on this renderer type")
     }
 
     var hwRenderFramebuffer: UInt {
         UInt(hwSharedFBO)
+    }
+
+    var hwRenderSharedContextPtr: UInt {
+        guard let ctx = hwSharedContext else { return 0 }
+        // CGLContextObj is an opaque C pointer. Transmit as UInt so the ObjC
+        // protocol header doesn't need to import CGL types.
+        return UInt(bitPattern: OpaquePointer(ctx))
     }
     
     func clearFramebuffer() {
@@ -171,14 +182,9 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     }
     
     func destroyGLResources() {
-        if let glContext = glContext {
-            if let alternateContext = alternateContext {
-                CGLReleaseContext(alternateContext)
-            }
-            CGLReleasePixelFormat(glPixelFormat)
-            CGLReleaseContext(glContext)
-        }
-        
+        // IMPORTANT: clean up hwSharedContext BEFORE releasing glContext.
+        // hwSharedContext was created sharing glContext's sharegroup; using it
+        // after glContext has been released is undefined behaviour.
         if let hwSharedContext = hwSharedContext {
             CGLSetCurrentContext(hwSharedContext)
             if hwSharedFBO != 0 {
@@ -193,6 +199,14 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
             CGLReleaseContext(hwSharedContext)
         }
         hwSharedContext = nil
+
+        if let glContext = glContext {
+            if let alternateContext = alternateContext {
+                CGLReleaseContext(alternateContext)
+            }
+            CGLReleasePixelFormat(glPixelFormat)
+            CGLReleaseContext(glContext)
+        }
 
         alternateContext        = nil
         texture.openGLContext   = nil

--- a/OpenEmuKit/Source/OpenGLGameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGLGameRenderer.swift
@@ -54,6 +54,7 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     // Nil until a libretro core accepts RETRO_ENVIRONMENT_SET_HW_RENDER.
     var hwSharedContext: CGLContextObj?
     var hwSharedFBO: GLuint = 0
+    var hwSharedDepthStencilRB: GLuint = 0
 
     var isFPSLimiting = ManagedAtomic(0)
     
@@ -184,6 +185,10 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
                 glDeleteFramebuffers(1, &hwSharedFBO)
                 hwSharedFBO = 0
             }
+            if hwSharedDepthStencilRB != 0 {
+                glDeleteRenderbuffers(1, &hwSharedDepthStencilRB)
+                hwSharedDepthStencilRB = 0
+            }
             CGLSetCurrentContext(nil)
             CGLReleaseContext(hwSharedContext)
         }
@@ -215,6 +220,15 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
             if isFPSLimiting.load(ordering: .sequentiallyConsistent) != 0 {
                 renderingThreadCanProceed.signal()
             }
+            return
+        }
+
+        if hwSharedContext != nil {
+            // HW render mode (libretro cores like mupen64plus-next / GLideN64).
+            // The translator will call CGLSetCurrentContext(_hwSharedContext) immediately
+            // before context_reset and retro_run. Don't touch glContext here — doing so
+            // would clobber the shared context mid-frame and cause GL_INVALID_OPERATION
+            // when the core tries to bind its own FBOs.
             return
         }
         

--- a/OpenEmuKit/Source/OpenGLGameRenderer.swift
+++ b/OpenEmuKit/Source/OpenGLGameRenderer.swift
@@ -50,6 +50,11 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     var renderingThreadCanProceed = DispatchSemaphore(value: 0)
     var executeThreadCanProceed = DispatchSemaphore(value: 0)
     
+    // HW render shared context — set up on demand by prepareHWRenderSharedContext().
+    // Nil until a libretro core accepts RETRO_ENVIRONMENT_SET_HW_RENDER.
+    var hwSharedContext: CGLContextObj?
+    var hwSharedFBO: GLuint = 0
+
     var isFPSLimiting = ManagedAtomic(0)
     
     init(withInteropTexture texture: CoreVideoTexture, gameCore: OEGameCore) {
@@ -139,6 +144,17 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
     func setupDoubleBufferedFBO() {
         fatalError("Not implemented")
     }
+
+    // MARK: - HW render shared context (Phase 2 — GL work added in OpenGL3GameRenderer)
+
+    func prepareHWRenderSharedContext() {
+        // Implemented in concrete subclass (OpenGL3GameRenderer).
+        // Base does nothing so non-HW renderers satisfy the protocol without crashing.
+    }
+
+    var hwRenderFramebuffer: UInt {
+        UInt(hwSharedFBO)
+    }
     
     func clearFramebuffer() {
         glClearColor(0.0, 0.0, 0.0, 0.0)
@@ -162,6 +178,17 @@ class BaseOpenGLGameRenderer: OpenGLGameRenderer {
             CGLReleaseContext(glContext)
         }
         
+        if let hwSharedContext = hwSharedContext {
+            CGLSetCurrentContext(hwSharedContext)
+            if hwSharedFBO != 0 {
+                glDeleteFramebuffers(1, &hwSharedFBO)
+                hwSharedFBO = 0
+            }
+            CGLSetCurrentContext(nil)
+            CGLReleaseContext(hwSharedContext)
+        }
+        hwSharedContext = nil
+
         alternateContext        = nil
         texture.openGLContext   = nil
         glContext               = nil


### PR DESCRIPTION
**Status: WIP — investigation branch, not ready to merge.**

Fixes #464 (in progress).

## What this branch establishes

The libretro bridge is **architecturally capable of driving GL `hw_render` cores** through OpenEmu's Metal-based compositor. This has been proven end-to-end (see "Evidence" below). The remaining blocker for N64 specifically is *not* in the bridge — it's a configuration / RDP-VI-plumbing problem inside `mupen64plus-libretro-nx` that we haven't fully diagnosed yet.

For the full diagnostic narrative, see the comments on #464. The TL;DR:
- Bridge architecture: **works** (red flash probe proved end-to-end pixel delivery).
- GLSM routing: **works** (`DRAW_FB → our_FBO` per frame).
- GLideN64 rendering: **happens** (scenes drawn into internal FBOs at 1280×1280, downscaled via `CopyColorToRDRAM`).
- N64 VI emulation: **fails every frame** (`m_rdpUpdate.update()` returns false because `REG.VI_*` reads return blank state). GLideN64 takes its "show black" fallback and the bridge faithfully delivers that.

## What's in this branch

### Architectural (keep)

- **Shared CGL context** for HW render, with translator-side `CGLSetCurrentContext` discipline per frame.
- **Staging-texture + blit pattern**: the FBO returned to the core is backed by a plain `GL_TEXTURE_2D` in ordinary GPU memory. At end-of-frame, `glBlitFramebuffer` copies into a second FBO whose color attachment is the IOSurface-backed `GL_TEXTURE_RECTANGLE`, then `glFlushRenderAPPLE` commits IOSurface. This is the right pattern for any GL libretro core (the direct-RECTANGLE attachment we tried first produced complete-but-blank FBOs even though it reported `GL_FRAMEBUFFER_COMPLETE`).
- **`OERenderDelegate` protocol additions**: `prepareHWRenderSharedContext`, `hwRenderFramebuffer`, `hwRenderSharedContextPtr`.
- **N64 variable defaults** required for GLideN64 to actually render:
  - `mupen64plus-EnableFBEmulation = True`
  - `mupen64plus-rsp-plugin = hle`
- **`OELibretroBridgeVersion` bumped to 17.**

### Diagnostic (keep for now, will be stripped before merge)

- `diag1-4` GL state probes in the translator (context identity, FBO completeness, attachment-name, pixel readback).
- Symbol-interception infrastructure at two layers:
  - `libretro_get_proc_address` wrappers for rglgen-resolved GL functions (the path GLSM uses for `glBindFramebuffer` and all modern draw/blit functions).
  - **Fishhook vendored** under `OpenEmu-SDK/OpenEmuBase/fishhook/` for cores whose GL functions are external imports rather than rglgen-resolved. Not used by mupen64plus-next (which routes everything through `glsmsym.h` redefines), but needed for cores like Beetle PSX HW.

Once the N64 path is unblocked, all of this will be either deleted or compile-gated behind a `OE_LIBRETRO_DEBUG` flag.

## Files changed

| File | Change |
|---|---|
| `OpenEmu-SDK/OpenEmuBase/OEGameCore.h` | `+prepareHWRenderSharedContext`, `+hwRenderFramebuffer`, `+hwRenderSharedContextPtr` on `OERenderDelegate` |
| `OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m` | Shared-context lifecycle, `libretro_get_current_framebuffer` HW path, variable defaults, diag1–4 + symbol wrappers + fishhook install |
| `OpenEmu-SDK/OpenEmuBase/fishhook/{fishhook.c,fishhook.h,LICENSE}` | Vendored Facebook fishhook (BSD-3) |
| `OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj` | Add `fishhook.c` to OpenEmuBase Sources |
| `OpenEmuKit/Source/GameRenderer.swift` | Protocol additions for HW render |
| `OpenEmuKit/Source/OpenGLGameRenderer.swift` | `hwSharedContext`/`hwSharedFBO`/`hwSharedStagingTexture`/`hwOutputFBO` ivars, cleanup ordering in `destroyGLResources` |
| `OpenEmuKit/Source/OpenGL3GameRenderer.swift` | Staging-texture FBO build, blit-to-output in `didExecuteFrame` |
| `OpenEmuKit/Source/OpenEmuHelperApp.swift` | Delegate forwarding for the new protocol methods |

## Evidence the bridge works

- The "force red clear into staging FBO" probe (now removed) produced a **visible red flash on screen** during the first 5 frames. This proves: staging FBO is writable → blit copies into IOSurface texture → `glFlushRenderAPPLE` commits → Metal compositor displays. End-to-end.
- The `glBindFramebuffer` hook trace shows the GLSM `0 → default_framebuffer` rewrite firing correctly per frame and binding our FBO for draws.
- GLideN64 issues real draw calls (`glDrawArrays` mode=0x5 ×57 in 2s) into internal FBOs and runs its `CopyColorToRDRAM` blit pipeline as expected.

The only remaining gap is GLideN64's VI emulation, which is downstream of the bridge.

## Not ready to merge because

1. **No GL libretro core renders correctly through this branch yet.** GLideN64 reaches the bridge but stops in its own VI fallback. We need at least one working end-to-end demo.
2. **Diagnostic logging is still on by default.** Will be stripped or gated before merge.
3. **The bridge has not been validated against a non-N64 GL core.** Beetle PSX HW would be the high-confidence test.

## Open work — see #464 for details

- **Find out why GLideN64's `m_rdpUpdate.update()` fails every frame.** Hook VI register reads in mupen64plus-next; compare against RetroArch's runtime state for the same ROM; try `cpucore = pure_interpreter` as a control; exhaust the N64 option matrix.
- **Test Beetle PSX HW end-to-end through this branch.** Validates the bridge's generality and is mechanically simpler than GLideN64.

## How to test locally

```
gh pr checkout 478 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Load any N64 ROM (mupen64plus_next_libretro core installed in `~/Library/Application Support/RetroArch/cores/`). Expected current behaviour:
- Audio plays correctly, input works, the game runs.
- Screen stays black.
- Console.app filtered on `[OELibretro][#464` shows the trace described above (one `glClearBufferfv (0,0,0,0)` per frame on our FBO 2, draws to internal FBOs, no present-to-default-FB).

This is the diagnostic state we want to push forward from in the next session.
