### PR TITLE
fix: GLideN64 v4.0 upgrade — verify build, clean up compat shim

### DIFF
--- a/Mupen64Plus/Compatibility/GLideN64.cpp
+++ b/Mupen64Plus/Compatibility/GLideN64.cpp
@@ -1,7 +1,4 @@
-//#include "Revision.h"
 char pluginName[] = "GLideN64";
-// uhh, what?
-//char pluginNameWithRevision[] = "GLideN64 rev." PLUGIN_REVISION;
 char pluginNameWithRevision[] = "GLideN64";
 wchar_t pluginNameW[] = L"GLideN64";
 void (*CheckInterrupts)( void );


### PR DESCRIPTION
## What does this PR do?

Closes out the GLideN64 v4.0 upgrade (issue #487). The v4.0 source tree was already vendored in a prior commit (`f7cf6142`) with all required directories and files wired into the Xcode project. This PR verifies the full workspace build passes cleanly and removes dead commented-out code from the Compatibility shim.

Specific changes:
- `Compatibility/GLideN64.cpp`: removed dead commented-out lines (`#include "Revision.h"`, disabled `pluginNameWithRevision` override, stale `// uhh, what?` comment). The static string definitions it kept are correct — `Revision.h` is generated by CMake's `getRevision.sh` at build time and does not exist as a static file in the Xcode build.
- No changes to `Compatibility/OpenGL/FrameBuffer.cpp` — its one intentional delta from upstream (initialising `m_copyFBO` with `ObjectHandle::null` instead of `ObjectHandle::defaultFramebuffer`) is correct for OpenEmu's off-screen rendering pipeline.

## What did you test?

Built via `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + Mupen64Plus" -configuration Debug -destination 'platform=macOS,arch=arm64' build` — BUILD SUCCEEDED with one pre-existing warning (deployment target 10.11 below SDK minimum; not introduced by this change).

Ran `./Scripts/verify.sh --core Mupen64Plus`:
- PASS: build
- PASS: plist
- PASS: codesign (DerivedData artifact)
- PASS: install-core.sh
- PASS: verify-core-installed.sh (hash match confirmed)
- FAIL: codesign installed plugin — pre-existing Debug-signing condition, not introduced by this change

## Which cores or systems are affected?

N64 — Mupen64Plus core (GLideN64 video renderer)

## Did you use AI tools?

Yes — Claude assisted with the investigation and verification. The cleanup change was reviewed manually.

## Linked issues

Fixes #487

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh --core Mupen64Plus
./Scripts/install-core.sh Mupen64Plus
./Scripts/launch-debug.sh
```

Load a standard N64 ROM (Super Mario 64) and confirm it renders. For the rendering improvement that motivated the upgrade, test Super Mario 64 Last Impact or another title with documented GLideN64 v2.0.0 rendering bugs.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh --core Mupen64Plus`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header