### PR TITLE
fix: avoid duplicate core list startup error

### DIFF
--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -46,6 +46,7 @@ final class CoreUpdater: NSObject {
     private var coresDict: [String : CoreDownload] = [:]
     private var autoInstall = false
     private var lastCoreListURLTask: URLSessionDataTask?
+    private var pendingCoreListCompletionHandlers: [(_ error: Error?) -> Void] = []
     private var pendingUserInitiatedDownloads: Set<CoreDownload> = []
     private var oeKnownCoreIDs: Set<String> = []
     
@@ -160,8 +161,15 @@ final class CoreUpdater: NSObject {
     }
     
     func checkForNewCores(completionHandler handler: ((_ error: Error?) -> Void)? = nil) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.checkForNewCores(completionHandler: handler) }
+            return
+        }
+        
         guard lastCoreListURLTask == nil else {
-            DispatchQueue.main.async { handler?(Errors.newCoreCheckAlreadyPendingError) }
+            if let handler {
+                pendingCoreListCompletionHandlers.append(handler)
+            }
             return
         }
         
@@ -176,9 +184,14 @@ final class CoreUpdater: NSObject {
                         self.updateCoreList()
                     }
                     
-                    handler?(error)
-                    
+                    let pendingHandlers = self.pendingCoreListCompletionHandlers
+                    self.pendingCoreListCompletionHandlers.removeAll()
                     self.lastCoreListURLTask = nil
+                    
+                    handler?(error)
+                    for pendingHandler in pendingHandlers {
+                        pendingHandler(error)
+                    }
                 }
             }
             


### PR DESCRIPTION
## What does this PR do?

Prevents the first-run setup assistant from showing a misleading internet/download error when the startup core-list update is already in progress.

`CoreUpdater.checkForNewCores()` now joins an in-flight core-list request by queueing completion handlers instead of returning `newCoreCheckAlreadyPendingError` to the second caller.

## What did you test?

Built the main app successfully with:

```bash
xcodebuild   -workspace OpenEmu-metal.xcworkspace   -scheme OpenEmu   -configuration Debug   -destination 'platform=macOS,arch=arm64'   build
```

## Which cores or systems are affected?

General app startup/setup flow. No specific emulator core is affected.

## Did you use AI tools?

Used Claude Code to diagnose and implement the fix; reviewed the diff and built locally.

## Linked issues

None.

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 512 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

To specifically verify this fix, test a fresh first-run setup flow and confirm the setup assistant does not show `OpenEmu.CoreUpdater.Errors error 1` when the app performs its startup core-list check.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main` / verified `origin/main...HEAD`)
- [x] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
