### PR TITLE
fix: RetroAchievements P0 gates and native snapshots

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -50,6 +50,7 @@
 
 @interface BSNESGameCore (RetroAchievements)
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 @end
 
 // rcheevos memory callback.
@@ -82,8 +83,12 @@ static void bsnes_rc_log(const char *message, const rc_client_t *client)
 static void bsnes_rc_load_game_callback(int result, const char *error_message,
                                          rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    BSNESGameCore *self = (__bridge BSNESGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-BSNES] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void bsnes_rc_login_callback(int result, const char *error_message,
@@ -114,6 +119,8 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    BSNESGameCore *core = (__bridge BSNESGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation BSNESGameCore {
@@ -146,6 +153,105 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
                                            NULL, 0,
                                            bsnes_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)dealloc

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -84,6 +84,7 @@ static uint32_t palette[256];
 
 - (void)loadDisplayModeOptions;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -114,8 +115,12 @@ static void fceu_rc_log(const char *message, const rc_client_t *client)
 static void fceu_rc_load_game_callback(int result, const char *error_message,
                                         rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    FCEUGameCore *self = (__bridge FCEUGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-FCEU] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void fceu_rc_login_callback(int result, const char *error_message,
@@ -146,6 +151,8 @@ static void fceu_rc_event_handler(const rc_client_event_t *event, rc_client_t *c
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    FCEUGameCore *core = (__bridge FCEUGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation FCEUGameCore
@@ -173,6 +180,105 @@ static __weak FCEUGameCore *_current;
                                            NULL, 0,
                                            fceu_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)dealloc

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -87,6 +87,7 @@ public:
 - (void)loadPaletteDefault;
 - (void)changePalette:(NSString *)palette;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -118,8 +119,12 @@ static void gambatte_rc_log(const char *message, const rc_client_t *client)
 static void gambatte_rc_load_game_callback(int result, const char *error_message,
                                             rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    GBGameCore *self = (__bridge GBGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-Gambatte] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void gambatte_rc_login_callback(int result, const char *error_message,
@@ -150,6 +155,8 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    GBGameCore *core = (__bridge GBGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation GBGameCore
@@ -175,6 +182,105 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
                                            NULL, 0,
                                            gambatte_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)dealloc

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -131,6 +131,7 @@ typedef NS_ENUM(NSInteger, MultiTapType)
 - (void)configureOptions;
 - (void)configureInput;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 @end
 
 // rcheevos memory callback.
@@ -169,8 +170,12 @@ static void genplus_rc_log(const char *message, const rc_client_t *client)
 static void genplus_rc_load_game_callback(int result, const char *error_message,
                                            rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    GenPlusGameCore *self = (__bridge GenPlusGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-GenPlus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void genplus_rc_login_callback(int result, const char *error_message,
@@ -201,6 +206,8 @@ static void genplus_rc_event_handler(const rc_client_event_t *event, rc_client_t
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    GenPlusGameCore *core = (__bridge GenPlusGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation GenPlusGameCore
@@ -216,6 +223,105 @@ static __weak GenPlusGameCore *_current;
                                            NULL, 0,
                                            genplus_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (id)init

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -118,6 +118,7 @@ namespace MDFN_IEN_VB
 - (NSString *)mednafenCoreModule;
 - (BOOL)isSystemPCECD;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 
 - (void)initializeMednafen;
 - (void)loadDisplayModeOptions;
@@ -225,8 +226,12 @@ static void mednafen_rc_log(const char *message, const rc_client_t *client)
 static void mednafen_rc_load_game_callback(int result, const char *error_message,
                                             rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    MednafenGameCore *self = (__bridge MednafenGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-Mednafen] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void mednafen_rc_login_callback(int result, const char *error_message,
@@ -259,6 +264,8 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    MednafenGameCore *core = (__bridge MednafenGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation MednafenGameCore
@@ -275,6 +282,105 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
                                            NULL, 0,
                                            mednafen_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)initializeMednafen

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -89,6 +89,7 @@ NSString *MupenControlNames[] = {
 
 - (void)OE_didReceiveStateChangeForParamType:(m64p_core_param)paramType value:(int)newValue;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -156,9 +157,12 @@ static void mupen_rc_log(const char *message, const rc_client_t *client)
 static void mupen_rc_load_game_callback(int result, const char *error_message,
                                          rc_client_t *client, void *userdata)
 {
+    MupenGameCore *self = (__bridge MupenGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-Mupen64Plus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
     }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void mupen_rc_login_callback(int result, const char *error_message,
@@ -189,6 +193,8 @@ static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    MupenGameCore *core = (__bridge MupenGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation MupenGameCore
@@ -202,6 +208,105 @@ static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *
                                            NULL, 0,
                                            mupen_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (instancetype)init

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -97,6 +97,7 @@ static void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event,
 
 - (void)loadDisplayModeOptions;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 - (const uint8_t *)_nesRamBytesForRC;
 
 @end
@@ -130,8 +131,12 @@ static void nestopia_rc_log(const char *message, const rc_client_t *client)
 static void nestopia_rc_load_game_callback(int result, const char *error_message,
                                             rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    NESGameCore *self = (__bridge NESGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-Nestopia] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void nestopia_rc_login_callback(int result, const char *error_message,
@@ -162,6 +167,8 @@ static void nestopia_rc_event_handler(const rc_client_event_t *event, rc_client_
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    NESGameCore *core = (__bridge NESGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation NESGameCore
@@ -197,6 +204,105 @@ static __weak NESGameCore *_current;
                                            NULL, 0,
                                            nestopia_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)dealloc

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -629,17 +629,20 @@ static Class GameCoreClass = Nil;
 
 - (void)fastForwardAtSpeed:(CGFloat)fastForwardSpeed;
 {
+    if (self.hardcoreEnabled) return;
     [self setRate:fastForwardSpeed];
 }
 
 - (void)rewindAtSpeed:(CGFloat)rewindSpeed;
 {
+    if (self.hardcoreEnabled) { isRewinding = NO; return; }
     isRewinding = (rewindSpeed > 0);
     [self setRate:rewindSpeed];
 }
 
 - (void)slowMotionAtSpeed:(CGFloat)slowMotionSpeed;
 {
+    if (self.hardcoreEnabled) return;
     [self setRate:slowMotionSpeed];
 }
 

--- a/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
@@ -30,7 +30,10 @@
 //
 // Hardcore gates under test (OEGameCore.m):
 //   - fastForward:          line ~582
+//   - fastForwardAtSpeed:   line ~630
 //   - rewind:               line ~597
+//   - rewindAtSpeed:        line ~636
+//   - slowMotionAtSpeed:    line ~643
 //   - stepFrameForward      line ~648
 //   - stepFrameBackward     line ~654
 //
@@ -99,6 +102,30 @@
                          @"fastForward: must increase rate when hardcoreEnabled is NO (sanity check that the gate is the only thing blocking).");
 }
 
+- (void)testFastForwardAtSpeedBlockedWhenHardcoreEnabled
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.rate = 1.0f;
+    core.hardcoreEnabled = YES;
+
+    [core fastForwardAtSpeed:4.0f];
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"fastForwardAtSpeed: must be a no-op when hardcoreEnabled is YES — latent analog bindings must not bypass hardcore.");
+}
+
+- (void)testFastForwardAtSpeedAllowedWhenHardcoreDisabled
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.rate = 1.0f;
+    core.hardcoreEnabled = NO;
+
+    [core fastForwardAtSpeed:4.0f];
+
+    XCTAssertEqualWithAccuracy(core.rate, 4.0f, 0.0001f,
+                               @"fastForwardAtSpeed: must set the requested rate when hardcoreEnabled is NO.");
+}
+
 #pragma mark - rewind:
 
 - (void)testRewindBlockedWhenHardcoreEnabled
@@ -127,6 +154,61 @@
 
     XCTAssertFalse([self isRewindingForCore:core],
                    @"rewind: must force-clear isRewinding when hardcoreEnabled is YES.");
+}
+
+- (void)testRewindAtSpeedBlockedWhenHardcoreEnabled
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.rate = 1.0f;
+    core.hardcoreEnabled = YES;
+
+    [core rewindAtSpeed:1.0f];
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"rewindAtSpeed: must not change rate when hardcoreEnabled is YES.");
+    XCTAssertFalse([self isRewindingForCore:core],
+                   @"rewindAtSpeed: must not flip isRewinding to YES when hardcoreEnabled is YES.");
+}
+
+- (void)testRewindAtSpeedForceClearedWhenHardcoreEnabledMidRewind
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core rewindAtSpeed:1.0f];
+    XCTAssertTrue([self isRewindingForCore:core],
+                  @"precondition: rewind must be active before we test the hardcore-on transition.");
+
+    core.hardcoreEnabled = YES;
+    [core rewindAtSpeed:1.0f];
+
+    XCTAssertFalse([self isRewindingForCore:core],
+                   @"rewindAtSpeed: must force-clear isRewinding when hardcoreEnabled is YES.");
+}
+
+#pragma mark - slowMotionAtSpeed:
+
+- (void)testSlowMotionAtSpeedBlockedWhenHardcoreEnabled
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.rate = 1.0f;
+    core.hardcoreEnabled = YES;
+
+    [core slowMotionAtSpeed:0.5f];
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"slowMotionAtSpeed: must be a no-op when hardcoreEnabled is YES — latent bindings must not bypass hardcore.");
+}
+
+- (void)testSlowMotionAtSpeedAllowedWhenHardcoreDisabled
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.rate = 1.0f;
+    core.hardcoreEnabled = NO;
+
+    [core slowMotionAtSpeed:0.5f];
+
+    XCTAssertEqualWithAccuracy(core.rate, 0.5f, 0.0001f,
+                               @"slowMotionAtSpeed: must set the requested rate when hardcoreEnabled is NO.");
 }
 
 #pragma mark - stepFrameForward / stepFrameBackward

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -176,13 +176,16 @@ final class OEGameDocument: NSDocument {
     }
 
     /// Whether hardcore restrictions should actually be enforced right now.
-    /// True only when the user has the preference on **and** an RA session is
-    /// active (a token is stored). Without a token, no achievements are being
-    /// tracked, so blocking save states, cheats, rewind, etc. would just take
-    /// existing OpenEmu functionality away from non-RA users.
+    /// True only when the user has the preference on, a token is stored, and
+    /// the selected core advertises RetroAchievements support for this system.
+    /// Without all three, no hardcore achievements are being tracked, so blocking
+    /// save states, cheats, rewind, etc. would just take existing OpenEmu
+    /// functionality away from non-RA or unsupported games.
     @objc var isHardcoreModeEnabled: Bool {
         guard isHardcoreModePreferenceEnabled else { return false }
-        return OECredentialStore.shared.get(.retroAchievementsToken) != nil
+        guard OECredentialStore.shared.get(.retroAchievementsToken) != nil else { return false }
+        guard let corePlugin, let systemPlugin else { return false }
+        return corePlugin.supportsRetroAchievements(forSystemIdentifier: systemPlugin.systemIdentifier)
     }
 
     private var displaySleepAssertionID: IOPMAssertionID = 0
@@ -687,7 +690,7 @@ final class OEGameDocument: NSDocument {
 
                 // Push the effective hardcore state to the helper before any startup save-state
                 // decision. The helper defaults to hardcore=true; without this early push a
-                // softcore/non-RA startup restore would be blocked by the stale default (#438).
+                // softcore/non-RA/unsupported startup restore would be blocked by the stale default (#438).
                 self.gameCoreManager?.setHardcoreEnabled(self.isHardcoreModeEnabled)
 
                 if let saveStateForGameStart = self.saveStateForGameStart {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -670,27 +670,32 @@ final class OEGameDocument: NSDocument {
                 self.rom.incrementPlayCount()
                 self.rom.markAsPlayedNow()
                 self.lastPlayStartDate = Date()
-                
+
+                // set initial volume
+                self.setVolume(self.volume, asDefault: false)
+
+                // set initial image adjustments
+                self.imageSaturation = Self.clampedSaturation((UserDefaults.standard.object(forKey: OEGameSaturationKey) as? Float) ?? 1.0)
+                self.imageGamma = Self.clampedGamma((UserDefaults.standard.object(forKey: OEGameGammaKey) as? Float) ?? 1.0)
+
+                self.gameCoreHelper?.setGlobalShaderParameters(gamma: CGFloat(self.imageGamma), saturation: CGFloat(self.imageSaturation))
+
+                OEBindingsController.default.systemBindings(for: self.systemPlugin.controller).add(self)
+
+                self.gameCoreManager?.setHandleEvents(self.handleEvents)
+                self.gameCoreManager?.setHandleKeyboardEvents(self.handleKeyboardEvents)
+
+                // Push the effective hardcore state to the helper before any startup save-state
+                // decision. The helper defaults to hardcore=true; without this early push a
+                // softcore/non-RA startup restore would be blocked by the stale default (#438).
+                self.gameCoreManager?.setHardcoreEnabled(self.isHardcoreModeEnabled)
+
                 if let saveStateForGameStart = self.saveStateForGameStart {
                     self.saveStateForGameStart = nil
                     DispatchQueue.main.async {
                         self.loadState(state: saveStateForGameStart)
                     }
                 }
-                
-                // set initial volume
-                self.setVolume(self.volume, asDefault: false)
-                
-                // set initial image adjustments
-                self.imageSaturation = Self.clampedSaturation((UserDefaults.standard.object(forKey: OEGameSaturationKey) as? Float) ?? 1.0)
-                self.imageGamma = Self.clampedGamma((UserDefaults.standard.object(forKey: OEGameGammaKey) as? Float) ?? 1.0)
-                
-                self.gameCoreHelper?.setGlobalShaderParameters(gamma: CGFloat(self.imageGamma), saturation: CGFloat(self.imageSaturation))
-                
-                OEBindingsController.default.systemBindings(for: self.systemPlugin.controller).add(self)
-                
-                self.gameCoreManager?.setHandleEvents(self.handleEvents)
-                self.gameCoreManager?.setHandleKeyboardEvents(self.handleKeyboardEvents)
 
                 // Pass stored RA credentials so the core can log in at launch
                 let raUsername = UserDefaults.standard.string(forKey: "RAUsername")
@@ -717,11 +722,6 @@ final class OEGameDocument: NSDocument {
                     // flip that would let RA track an already-mutated session (#447).
                     self.handleHardcoreToggle(enabled: self.isHardcoreModePreferenceEnabled)
                 }
-
-                // Push the effective hardcore state to the helper at game start.
-                // Without an RA session this stays false even if the preference is on,
-                // so non-RA users keep save states, rewind, cheats, etc. (#445).
-                self.gameCoreManager?.setHardcoreEnabled(self.isHardcoreModeEnabled)
 
                 // Forward mid-session hardcore toggles. soft→hard requires a reset
                 // (RA spec: switching into hardcore must restart the run).

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -51,6 +51,38 @@
 #define OEAchievementBadgeURLKey            @"badgeURL"
 #define OEAchievementPointsKey              @"points"
 
+/// NSNotificationCenter name posted by a core plugin when RA session metadata changes.
+/// Fired after game load succeeds and after each achievement trigger. The helper app
+/// observes this and forwards the payload to the host via OEGameCoreOwner.
+#define OERASessionUpdatedNotification      @"OERetroAchievementsSessionUpdated"
+
+// Session payload keys — userInfo dictionary for OERASessionUpdatedNotification
+#define OERAGameIDKey                @"gameID"
+#define OERAGameTitleKey             @"gameTitle"
+#define OERAGameHashKey              @"gameHash"
+#define OERAGameBadgeURLKey          @"gameBadgeURL"
+#define OERAUnlockedCountKey         @"unlockedCount"
+#define OERAAchievementCountKey      @"achievementCount"
+#define OERAUnlockedPointsKey        @"unlockedPoints"
+#define OERATotalPointsKey           @"totalPoints"
+#define OERAAchievementsKey          @"achievements"
+#define OERASetsKey                  @"sets"
+#define OERASetIDKey                 @"setID"
+#define OERASetTitleKey              @"setTitle"
+#define OERASetBadgeURLKey           @"setBadgeURL"
+#define OERASetAchievementCountKey   @"setAchievementCount"
+#define OERASetLeaderboardCountKey   @"setLeaderboardCount"
+#define OERABucketTitleKey           @"bucketTitle"
+#define OERABucketTypeKey            @"bucketType"
+#define OERAStateKey                 @"state"
+#define OERATypeKey                  @"type"
+#define OERAMeasuredProgressKey      @"measuredProgress"
+#define OERAMeasuredPercentKey       @"measuredPercent"
+#define OERABadgeLockedURLKey        @"badgeLockedURL"
+#define OERARarityKey                @"rarity"
+#define OERAHardcoreRarityKey        @"rarityHardcore"
+#define OERAUnlockedKey              @"unlocked"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -72,6 +72,7 @@
 - (void)finalizeAudioSamples;
 - (void)mapButtons;
 - (void)_beginLoadGame;
+- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -109,8 +110,12 @@ static void snes9x_rc_log(const char *message, const rc_client_t *client)
 static void snes9x_rc_load_game_callback(int result, const char *error_message,
                                           rc_client_t *client, void *userdata)
 {
-    if (result != RC_OK)
+    SNESGameCore *self = (__bridge SNESGameCore *)userdata;
+    if (result != RC_OK) {
         NSLog(@"[RA-SNES9x] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        return;
+    }
+    [self _postRetroAchievementsSessionSnapshot];
 }
 
 static void snes9x_rc_login_callback(int result, const char *error_message,
@@ -141,6 +146,8 @@ static void snes9x_rc_event_handler(const rc_client_event_t *event, rc_client_t 
         postNotificationName:OEAchievementUnlockedNotification
                       object:nil
                     userInfo:info];
+    SNESGameCore *core = (__bridge SNESGameCore *)rc_client_get_userdata(client);
+    [core _postRetroAchievementsSessionSnapshot];
 }
 
 @implementation SNESGameCore
@@ -773,6 +780,105 @@ static __weak SNESGameCore *_current;
                                            NULL, 0,
                                            snes9x_rc_load_game_callback,
                                            (__bridge void *)self);
+}
+
+- (void)_postRetroAchievementsSessionSnapshot
+{
+    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
+    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512];
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
+        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url)
+                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
+                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
+                if (ach->badge_url)
+                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
+                if (ach->badge_locked_url)
+                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
 }
 
 - (void)executeFrame

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -50,35 +50,7 @@
 
 #define SAMPLES 1024
 
-// Keep these payload keys in sync with OERetroAchievementsConstants.swift.
-// Swift global constants are not exported to Objective-C core sources, so the
-// mGBA bridge mirrors the string values when posting the session snapshot.
-static NSString * const OERAGameIDKey = @"gameID";
-static NSString * const OERAGameTitleKey = @"gameTitle";
-static NSString * const OERAGameHashKey = @"gameHash";
-static NSString * const OERAGameBadgeURLKey = @"gameBadgeURL";
-static NSString * const OERAUnlockedCountKey = @"unlockedCount";
-static NSString * const OERAAchievementCountKey = @"achievementCount";
-static NSString * const OERAUnlockedPointsKey = @"unlockedPoints";
-static NSString * const OERATotalPointsKey = @"totalPoints";
-static NSString * const OERAAchievementsKey = @"achievements";
-static NSString * const OERASetsKey = @"sets";
-static NSString * const OERASetIDKey = @"setID";
-static NSString * const OERASetTitleKey = @"setTitle";
-static NSString * const OERASetBadgeURLKey = @"setBadgeURL";
-static NSString * const OERASetAchievementCountKey = @"setAchievementCount";
-static NSString * const OERASetLeaderboardCountKey = @"setLeaderboardCount";
-static NSString * const OERABucketTitleKey = @"bucketTitle";
-static NSString * const OERABucketTypeKey = @"bucketType";
-static NSString * const OERAStateKey = @"state";
-static NSString * const OERATypeKey = @"type";
-static NSString * const OERAMeasuredProgressKey = @"measuredProgress";
-static NSString * const OERAMeasuredPercentKey = @"measuredPercent";
-static NSString * const OERABadgeLockedURLKey = @"badgeLockedURL";
-static NSString * const OERARarityKey = @"rarity";
-static NSString * const OERAHardcoreRarityKey = @"rarityHardcore";
-static NSString * const OERAUnlockedKey = @"unlocked";
-static NSNotificationName const OERASessionUpdatedNotification = @"OERetroAchievementsSessionUpdated";
+// Session payload keys and notification name are defined in OERetroAchievementsTransport.h.
 
 #ifdef DEBUG
     #error "Cores should not be compiled in DEBUG! Follow the guide https://github.com/OpenEmu/OpenEmu/wiki/Compiling-From-Source-Guide"


### PR DESCRIPTION
## What does this PR do?

Continues #438 after the RetroAchievements UI foundation by closing the next focused compliance slice: P0 hardcore speed/startup gates plus native RA metadata snapshots for all RA-enabled cores.

This PR:
- Blocks latent analog speed controls (`fastForwardAtSpeed:`, `rewindAtSpeed:`, `slowMotionAtSpeed:`) when hardcore mode is active.
- Pushes the effective hardcore state before startup save-state decisions, while scoping enforcement to signed-in RA-supported sessions only.
- Adds regression coverage for the latent speed-binding paths.
- Moves shared RA session snapshot keys into `OERetroAchievementsTransport.h`.
- Applies the RA session snapshot bridge to all 9 native RA cores so the Achievements window can receive real game/set/achievement metadata beyond mGBA.

## What did you test?

- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmuBase -configuration Debug -destination 'platform=macOS,arch=arm64' test`
  - 32 tests passed, including new hardcore speed-gate tests.
- Branch review/build pass also checked the affected RA core schemes in Release before the final host/test-only follow-up commit.

## Which cores or systems are affected?

Host app / OpenEmuBase plus all native RA-enabled cores:

- Nestopia
- FCEU
- BSNES
- SNES9x
- Gambatte
- GenesisPlus
- mGBA
- Mupen64Plus
- Mednafen

## Did you use AI tools?

Yes. Used pi/Claude to inspect the prior branch state, review the diff, add the startup-scope fix and regression tests, and run local verification.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 517 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmuBase \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  test 2>&1 | tail -60
```

For each RA core you want to manually verify, build and install the matching Release scheme before launching. Example for mGBA:

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + mGBA' \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

./Scripts/install-core.sh --release mGBA
./Scripts/verify-core-installed.sh --release mGBA
./Scripts/launch-debug.sh
```

Manual behavior checks:

1. Sign into RetroAchievements in Preferences → Achievements.
2. Launch an RA-supported game/core and confirm the startup placard and Achievements window populate with game/set/achievement metadata.
3. Confirm startup save-state restore is not blocked for non-RA or unsupported games just because an RA token exists.
4. With hardcore active, confirm fast-forward, rewind, frame advance, and slow motion do not affect gameplay.
5. With hardcore off, confirm those controls still work normally.

Not included in this PR:

- Leaderboard/challenge/progress/mastery gameplay overlays.
- Offline/reconnect/server-error UI.
- Save-state hit storage.
- Libretro RA behavior changes.

---

## PR checklist

- [x] Branched from an up-to-date `main` (branch is based on current `origin/main` including #514)
- [x] Build passes: host `xcodebuild` build passed
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
