### PR TITLE
fix: close RetroAchievements hardcore P0 audit gaps

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -65,6 +65,7 @@ NSString *const OEGameCoreErrorDomain = @"org.openemu.GameCore.ErrorDomain";
     BOOL                    singleFrameStep;
     BOOL                    isRewinding;
     BOOL                    isPausedExecution;
+    BOOL                    _hardcoreEnabled;
 
     NSTimeInterval          lastRate;
 
@@ -76,6 +77,20 @@ NSString *const OEGameCoreErrorDomain = @"org.openemu.GameCore.ErrorDomain";
 @synthesize nextFrameTime;
 
 static Class GameCoreClass = Nil;
+
+- (BOOL)hardcoreEnabled
+{
+    return _hardcoreEnabled;
+}
+
+- (void)setHardcoreEnabled:(BOOL)hardcoreEnabled
+{
+    _hardcoreEnabled = hardcoreEnabled;
+    if (hardcoreEnabled) {
+        isRewinding = NO;
+        singleFrameStep = NO;
+    }
+}
 
 + (void)initialize
 {

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -89,6 +89,10 @@ static Class GameCoreClass = Nil;
     if (hardcoreEnabled) {
         isRewinding = NO;
         singleFrameStep = NO;
+        lastRate = 1.0;
+        if (_rate != 0) {
+            self.rate = 1.0;
+        }
     }
 }
 

--- a/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
@@ -278,6 +278,50 @@
                    @"setHardcoreEnabled: must clear pending frame-step immediately.");
 }
 
+- (void)testEnablingHardcoreClearsActiveFastForwardRate
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core fastForwardAtSpeed:4.0f];
+    XCTAssertEqualWithAccuracy(core.rate, 4.0f, 0.0001f,
+                               @"precondition: fast-forward rate must be active before hardcore is enabled.");
+
+    core.hardcoreEnabled = YES;
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"setHardcoreEnabled: must return active fast-forward to normal speed immediately.");
+}
+
+- (void)testEnablingHardcoreClearsActiveSlowMotionRate
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core slowMotionAtSpeed:0.5f];
+    XCTAssertEqualWithAccuracy(core.rate, 0.5f, 0.0001f,
+                               @"precondition: slow-motion rate must be active before hardcore is enabled.");
+
+    core.hardcoreEnabled = YES;
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"setHardcoreEnabled: must return active slow motion to normal speed immediately.");
+}
+
+- (void)testEnablingHardcoreClearsPausedFastForwardResumeRate
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core fastForwardAtSpeed:4.0f];
+    [core setPauseEmulation:YES];
+    XCTAssertTrue(core.isEmulationPaused,
+                  @"precondition: core must be paused before testing lastRate normalization.");
+
+    core.hardcoreEnabled = YES;
+    [core setPauseEmulation:NO];
+
+    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
+                               @"setHardcoreEnabled: must clear paused fast-forward resume rate before unpausing.");
+}
+
 - (void)testToggleReEnablesAffordances
 {
     // Hardcore on → block. Hardcore off → allow. Catches regressions where the

--- a/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
@@ -250,6 +250,34 @@
 
 #pragma mark - Toggle behavior
 
+- (void)testEnablingHardcoreClearsActiveRewind
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core rewindAtSpeed:1.0f];
+    XCTAssertTrue([self isRewindingForCore:core],
+                  @"precondition: rewind must be active before hardcore is enabled.");
+
+    core.hardcoreEnabled = YES;
+
+    XCTAssertFalse([self isRewindingForCore:core],
+                   @"setHardcoreEnabled: must clear active rewind immediately, even before the next rewind event arrives.");
+}
+
+- (void)testEnablingHardcoreClearsPendingFrameStep
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    core.hardcoreEnabled = NO;
+    [core stepFrameForward];
+    XCTAssertTrue([self singleFrameStepForCore:core],
+                  @"precondition: frame-step must be pending before hardcore is enabled.");
+
+    core.hardcoreEnabled = YES;
+
+    XCTAssertFalse([self singleFrameStepForCore:core],
+                   @"setHardcoreEnabled: must clear pending frame-step immediately.");
+}
+
 - (void)testToggleReEnablesAffordances
 {
     // Hardcore on → block. Hardcore off → allow. Catches regressions where the

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -184,6 +184,10 @@ final class OEGameDocument: NSDocument {
     @objc var isHardcoreModeEnabled: Bool {
         guard isHardcoreModePreferenceEnabled else { return false }
         guard OECredentialStore.shared.get(.retroAchievementsToken) != nil else { return false }
+        return isRetroAchievementsSessionSupported
+    }
+
+    private var isRetroAchievementsSessionSupported: Bool {
         guard let corePlugin, let systemPlugin else { return false }
         return corePlugin.supportsRetroAchievements(forSystemIdentifier: systemPlugin.systemIdentifier)
     }
@@ -1181,12 +1185,14 @@ final class OEGameDocument: NSDocument {
     }
 
     /// Handle a mid-session hardcore toggle. Soft→hard requires confirming a reset
-    /// (RA spec) — but only when an RA session is actually active; without a
-    /// signed-in session, hardcore wouldn't be enforced anyway, so we skip the
-    /// reset prompt and just record the preference. Hard→soft drops to softcore
-    /// immediately with no prompt.
+    /// (RA spec) — but only when an RA session can actually be active for the
+    /// current core/system; without a signed-in RA-supported session, hardcore
+    /// wouldn't be enforced anyway, so we skip the reset prompt and just record
+    /// the preference. Hard→soft drops to softcore immediately with no prompt.
     private func handleHardcoreToggle(enabled: Bool) {
-        let willEnforce = enabled && OECredentialStore.shared.get(.retroAchievementsToken) != nil
+        let willEnforce = enabled
+            && isRetroAchievementsSessionSupported
+            && OECredentialStore.shared.get(.retroAchievementsToken) != nil
 
         if willEnforce && HardcoreModePolicy.requiresResetWhenEnabling {
             isEmulationPaused = true

--- a/docs/retroachievements-hardcore-p0-audit.md
+++ b/docs/retroachievements-hardcore-p0-audit.md
@@ -1,0 +1,70 @@
+# RetroAchievements Hardcore P0 Audit
+
+This note tracks the P0 hardcore-compliance audit for issue #438. It covers the native RetroAchievements path only. Libretro/RetroArch core behavior is tracked separately because those cores run through the libretro host.
+
+## Scope
+
+Native RA-enabled cores audited:
+
+- Nestopia
+- FCEU
+- BSNES
+- SNES9x
+- Gambatte
+- GenesisPlus
+- mGBA
+- Mupen64Plus
+- Mednafen
+
+## Enforcement model
+
+Hardcore restrictions are enforced only when all of these are true:
+
+1. The user has enabled the RetroAchievements hardcore preference.
+2. A RetroAchievements token is stored.
+3. The selected core advertises `OEGameCoreSupportsRetroAchievements` for the active system.
+
+This avoids disabling save states, rewind, cheats, or speed controls for non-RA games or unsupported core/system pairs just because the user is signed in.
+
+## P0 audit results
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Startup hardcore ordering | Pass | `OEGameDocument` pushes the effective hardcore state to the helper before startup save-state restore decisions. |
+| Startup resume behavior | Pass | Startup save-state restore routes through `loadState(state:)`, which checks `HardcoreModePolicy.allows(.loadState, hardcoreEnabled:)` before calling the helper. |
+| Normal save-state load | Pass | `OEGameDocument.loadState(_:)` shows a user-facing block in hardcore before pausing, and `loadState(state:)` has a second guard. |
+| Quick-load | Pass | `quickLoad(_:)` routes through `loadState(_:)` / `loadState(state:)`, so it inherits the same block. |
+| Helper load-state path | Pass | `OpenEmuHelperApp.loadStateFromFile(at:)` rejects load requests when helper-side `_hardcoreEnabled` is true. |
+| Rewind | Pass | Host, helper, and base `OEGameCore` paths block rewind while hardcore is active. Enabling hardcore also clears any already-active rewind flag. |
+| Frame advance | Pass | Host, helper, and base `OEGameCore` paths block frame advance while hardcore is active. Enabling hardcore also clears any pending frame-step flag. |
+| Fast-forward / analog speed | Pass | `OEGameCore.fastForward(_:)` and `fastForwardAtSpeed(_:)` return without changing rate when hardcore is active. |
+| Slow motion | Pass | `OEGameCore.slowMotionAtSpeed(_:)` returns without changing rate when hardcore is active. |
+| Cheats | Pass | Saved cheat autoload is skipped in hardcore, document-level cheat actions return early, and helper-side `setCheat` rejects calls in hardcore. |
+| Mode switch: softcore → hardcore | Pass | Mid-session switch to enforced hardcore prompts for a full game reset before enabling the helper/core hardcore flag. |
+| Mode switch: hardcore → softcore | Pass | Disabling hardcore pushes softcore mode without requiring reset. |
+| User-Agent | Pass for native RA path | Native RA HTTP requests are centralized through `oeRetroAchievementsServerCall`, which sends `OpenEmu/<app-version> (macOS <os-version>) <rcheevos-clause>`. |
+
+## User-Agent disclosure
+
+Current native RA traffic does not identify as another emulator. All native RA cores create their `rc_client_t` with the shared OpenEmu transport function:
+
+```objc
+rc_client_create(<core>_rc_read_memory, oeRetroAchievementsServerCall)
+```
+
+The shared transport builds the HTTP `User-Agent` as:
+
+```text
+OpenEmu/<host-version> (macOS <os-version>) <rcheevos user-agent clause>
+```
+
+No current native RA core overrides this with a core-specific or upstream-emulator identity.
+
+## Known non-P0 follow-ups
+
+These are still tracked in #438 but are not part of P0 gate closure:
+
+- Gameplay overlays for progress, challenge, leaderboard, mastery, and offline/reconnect events.
+- Offline queue verification and visible reconnect/sync UI.
+- Save-state hit storage for softcore correctness.
+- Libretro RA behavior after the libretro RA path is ready.

--- a/docs/retroachievements-hardcore-p0-audit.md
+++ b/docs/retroachievements-hardcore-p0-audit.md
@@ -37,8 +37,8 @@ This avoids disabling save states, rewind, cheats, or speed controls for non-RA 
 | Helper load-state path | Pass | `OpenEmuHelperApp.loadStateFromFile(at:)` rejects load requests when helper-side `_hardcoreEnabled` is true. |
 | Rewind | Pass | Host, helper, and base `OEGameCore` paths block rewind while hardcore is active. Enabling hardcore also clears any already-active rewind flag. |
 | Frame advance | Pass | Host, helper, and base `OEGameCore` paths block frame advance while hardcore is active. Enabling hardcore also clears any pending frame-step flag. |
-| Fast-forward / analog speed | Pass | `OEGameCore.fastForward(_:)` and `fastForwardAtSpeed(_:)` return without changing rate when hardcore is active. |
-| Slow motion | Pass | `OEGameCore.slowMotionAtSpeed(_:)` returns without changing rate when hardcore is active. |
+| Fast-forward / analog speed | Pass | `OEGameCore.fastForward(_:)` and `fastForwardAtSpeed(_:)` return without changing rate when hardcore is active. Enabling hardcore also normalizes active and paused-resume fast-forward state back to 1x. |
+| Slow motion | Pass | `OEGameCore.slowMotionAtSpeed(_:)` returns without changing rate when hardcore is active. Enabling hardcore also normalizes active slow-motion state back to 1x. |
 | Cheats | Pass | Saved cheat autoload is skipped in hardcore, document-level cheat actions return early, and helper-side `setCheat` rejects calls in hardcore. |
 | Mode switch: softcore → hardcore | Pass | Mid-session switch to enforced hardcore prompts for a full game reset before enabling the helper/core hardcore flag. |
 | Mode switch: hardcore → softcore | Pass | Disabling hardcore pushes softcore mode without requiring reset. |


### PR DESCRIPTION
## What does this PR do?

Closes the next #438 P0 audit slice after #517 by tightening the remaining hardcore-mode edge cases and documenting the native RA P0 audit.

This PR:
- Scopes mid-session hardcore enforcement to RA-supported core/system pairs, not just “signed in + preference enabled.”
- Clears active rewind and pending frame-step immediately when helper/core hardcore mode turns on.
- Adds regression tests for those immediate-clear behaviors.
- Adds `docs/retroachievements-hardcore-p0-audit.md` covering save-state load, quick-load, startup resume, helper load-state, rewind, frame advance, speed controls, cheats, mode switching, and native RA User-Agent behavior.

## What did you test?

- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmuBase -configuration Debug -destination 'platform=macOS,arch=arm64' test`
  - 34 tests passed.
- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
  - Build succeeded.

## Which cores or systems are affected?

- Host app hardcore enforcement logic.
- `OpenEmuBase` core-level rewind/frame-step state.
- Native RA audit covers:
  - Nestopia
  - FCEU
  - BSNES
  - SNES9x
  - Gambatte
  - GenesisPlus
  - mGBA
  - Mupen64Plus
  - Mednafen

## Did you use AI tools?

Yes. Used pi/Claude to audit the #438 P0 checklist, identify the remaining enforcement-scope gap, implement the fix/tests, and draft the audit note.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 518 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmuBase \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  test 2>&1 | tail -80

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -50
```

Manual checks:

1. Sign into RetroAchievements and leave hardcore preference enabled.
2. Launch an RA-supported game/core and confirm hardcore restrictions apply.
3. Launch a non-RA or unsupported game/core and confirm save-state load/quick-resume is not blocked just because an RA token exists.
4. In an RA-supported hardcore session, confirm rewind/frame-step/speed controls remain blocked after toggling into hardcore.

Not included in this PR:

- Gameplay event overlays.
- Offline/reconnect/server-error UI.
- Save-state hit storage.
- Libretro RA behavior.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: host `xcodebuild` build passed
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
