### PR TITLE
feat: add RetroAchievements gameplay event indicators

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -104,6 +104,7 @@ static void bsnes_rc_login_callback(int result, const char *error_message,
 
 static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -136,6 +136,7 @@ static void fceu_rc_login_callback(int result, const char *error_message,
 
 static void fceu_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -140,6 +140,7 @@ static void gambatte_rc_login_callback(int result, const char *error_message,
 
 static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -191,6 +191,7 @@ static void genplus_rc_login_callback(int result, const char *error_message,
 
 static void genplus_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -247,6 +247,7 @@ static void mednafen_rc_login_callback(int result, const char *error_message,
 
 static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -178,6 +178,7 @@ static void mupen_rc_login_callback(int result, const char *error_message,
 
 static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -152,6 +152,7 @@ static void nestopia_rc_login_callback(int result, const char *error_message,
 
 static void nestopia_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -50,6 +50,8 @@ final class GameViewController: NSViewController {
     private var notificationView: OEGameLayerNotificationView!
     private var achievementBannerView: OEAchievementBannerView!
     private var retroAchievementsPlacardView: OERetroAchievementsPlacardView!
+    private var retroAchievementsEventToastView: OERetroAchievementsEventToastView!
+    private var retroAchievementsIndicatorStackView: OERetroAchievementsIndicatorStackView!
 
     // Save Sync status badge
     private var syncStatusOverlay: OESyncStatusOverlayView!
@@ -118,6 +120,14 @@ final class GameViewController: NSViewController {
         retroAchievementsPlacardView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(retroAchievementsPlacardView)
 
+        retroAchievementsEventToastView = OERetroAchievementsEventToastView(frame: .zero)
+        retroAchievementsEventToastView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(retroAchievementsEventToastView)
+
+        retroAchievementsIndicatorStackView = OERetroAchievementsIndicatorStackView(frame: .zero)
+        retroAchievementsIndicatorStackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(retroAchievementsIndicatorStackView)
+
         NSLayoutConstraint.activate([
             achievementBannerView.widthAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerWidth),
             achievementBannerView.heightAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerHeight),
@@ -127,6 +137,14 @@ final class GameViewController: NSViewController {
             retroAchievementsPlacardView.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.82),
             retroAchievementsPlacardView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             retroAchievementsPlacardView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+
+            retroAchievementsEventToastView.widthAnchor.constraint(equalToConstant: 390),
+            retroAchievementsEventToastView.heightAnchor.constraint(equalToConstant: 62),
+            retroAchievementsEventToastView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            retroAchievementsEventToastView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -24),
+
+            retroAchievementsIndicatorStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            retroAchievementsIndicatorStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
         ])
 
         syncStatusToken = NotificationCenter.default.addObserver(forName: .OESaveSyncStatusDidChange, object: nil, queue: .main) { [weak self] notification in
@@ -358,8 +376,36 @@ extension GameViewController {
         notificationView.showStepBackward()
     }
 
-    func showAchievementUnlocked(title: String, points: UInt32) {
-        achievementBannerView.show(title: title, points: points)
+    func showAchievementUnlocked(title: String, description: String, badgeURL: String, points: UInt32) {
+        achievementBannerView.show(title: title, description: description, badgeURL: badgeURL, points: points)
+    }
+
+    func showRetroAchievementsEventToast(title: String, subtitle: String, badgeURL: String? = nil, symbolName: String = "trophy.fill") {
+        retroAchievementsEventToastView.show(title: title, subtitle: subtitle, badgeURL: badgeURL, symbolName: symbolName)
+    }
+
+    func showRetroAchievementsChallenge(id: UInt32, title: String) {
+        retroAchievementsIndicatorStackView.showChallenge(id: id, title: title)
+    }
+
+    func hideRetroAchievementsChallenge(id: UInt32) {
+        retroAchievementsIndicatorStackView.hideChallenge(id: id)
+    }
+
+    func showRetroAchievementsLeaderboard(id: UInt32, display: String) {
+        retroAchievementsIndicatorStackView.showLeaderboard(id: id, display: display)
+    }
+
+    func hideRetroAchievementsLeaderboard(id: UInt32) {
+        retroAchievementsIndicatorStackView.hideLeaderboard(id: id)
+    }
+
+    func showRetroAchievementsProgress(title: String, progress: String) {
+        retroAchievementsIndicatorStackView.showProgress(title: title, progress: progress)
+    }
+
+    func hideRetroAchievementsProgress() {
+        retroAchievementsIndicatorStackView.hideProgress()
     }
 
     func showRetroAchievementsPlacard(info: [String: Any], hardcore: Bool, signedIn: Bool) {

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -52,6 +52,7 @@ final class GameViewController: NSViewController {
     private var retroAchievementsPlacardView: OERetroAchievementsPlacardView!
     private var retroAchievementsEventToastView: OERetroAchievementsEventToastView!
     private var retroAchievementsIndicatorStackView: OERetroAchievementsIndicatorStackView!
+    private var retroAchievementsNoticeView: OERetroAchievementsNoticeView!
 
     // Save Sync status badge
     private var syncStatusOverlay: OESyncStatusOverlayView!
@@ -128,6 +129,10 @@ final class GameViewController: NSViewController {
         retroAchievementsIndicatorStackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(retroAchievementsIndicatorStackView)
 
+        retroAchievementsNoticeView = OERetroAchievementsNoticeView(frame: .zero)
+        retroAchievementsNoticeView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(retroAchievementsNoticeView)
+
         NSLayoutConstraint.activate([
             achievementBannerView.widthAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerWidth),
             achievementBannerView.heightAnchor.constraint(equalToConstant: OEAchievementBannerView.bannerHeight),
@@ -145,6 +150,9 @@ final class GameViewController: NSViewController {
 
             retroAchievementsIndicatorStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             retroAchievementsIndicatorStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+
+            retroAchievementsNoticeView.leadingAnchor.constraint(equalTo: notificationView.trailingAnchor, constant: 10),
+            retroAchievementsNoticeView.centerYAnchor.constraint(equalTo: notificationView.centerYAnchor),
         ])
 
         syncStatusToken = NotificationCenter.default.addObserver(forName: .OESaveSyncStatusDidChange, object: nil, queue: .main) { [weak self] notification in
@@ -396,8 +404,16 @@ extension GameViewController {
         retroAchievementsIndicatorStackView.showLeaderboard(id: id, display: display)
     }
 
+    func updateRetroAchievementsLeaderboard(id: UInt32, display: String) {
+        retroAchievementsIndicatorStackView.updateLeaderboard(id: id, display: display)
+    }
+
     func hideRetroAchievementsLeaderboard(id: UInt32) {
         retroAchievementsIndicatorStackView.hideLeaderboard(id: id)
+    }
+
+    func hideAllRetroAchievementsLeaderboards() {
+        retroAchievementsIndicatorStackView.hideAllLeaderboards()
     }
 
     func showRetroAchievementsProgress(title: String, progress: String) {
@@ -408,8 +424,13 @@ extension GameViewController {
         retroAchievementsIndicatorStackView.hideProgress()
     }
 
+    func showRetroAchievementsUnknownEmulatorNotice() {
+        retroAchievementsNoticeView.showUnknownEmulatorWarning()
+    }
+
     func clearRetroAchievementsIndicators() {
         retroAchievementsIndicatorStackView.clear()
+        retroAchievementsNoticeView.clear()
     }
 
     func showRetroAchievementsPlacard(info: [String: Any], hardcore: Bool, signedIn: Bool) {
@@ -495,7 +516,7 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         let points = (info[OERetroAchievementsUnlockedPointsKey] as? NSNumber)?.intValue ?? 0
         let totalPoints = (info[OERetroAchievementsTotalPointsKey] as? NSNumber)?.intValue ?? 0
         let account = signedIn ? NSLocalizedString("Logged in", comment: "RetroAchievements placard signed in") : NSLocalizedString("Not logged in", comment: "RetroAchievements placard signed out")
-        summaryLabel.stringValue = String(format: NSLocalizedString("%@ · Recognized · %d of %d achievements · %d of %d points", comment: "RetroAchievements boot placard summary"), account, unlocked, total, points, totalPoints)
+        summaryLabel.stringValue = String(format: NSLocalizedString("%@ · %d of %d achievements · %d of %d points", comment: "RetroAchievements boot placard summary"), account, unlocked, total, points, totalPoints)
 
         modeLabel.stringValue = hardcore ? NSLocalizedString("Hardcore Mode", comment: "RetroAchievements hardcore mode") : NSLocalizedString("Softcore Mode", comment: "RetroAchievements softcore mode")
         modeLabel.textColor = .labelColor

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -408,6 +408,10 @@ extension GameViewController {
         retroAchievementsIndicatorStackView.hideProgress()
     }
 
+    func clearRetroAchievementsIndicators() {
+        retroAchievementsIndicatorStackView.clear()
+    }
+
     func showRetroAchievementsPlacard(info: [String: Any], hardcore: Bool, signedIn: Bool) {
         retroAchievementsPlacardView.show(info: info, hardcore: hardcore, signedIn: signedIn)
     }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -625,6 +625,7 @@ final class OEGameDocument: NSDocument {
 
                 self.emulationStatus = .notSetup
                 self.retroAchievementsSessionInfo = nil
+                self.gameViewController?.clearRetroAchievementsIndicators()
                 self.didShowRetroAchievementsBootPlacard = false
                 
                 self.gameCoreManager = nil
@@ -773,6 +774,7 @@ final class OEGameDocument: NSDocument {
         
         emulationStatus = .notSetup
         retroAchievementsSessionInfo = nil
+        gameViewController?.clearRetroAchievementsIndicators()
         didShowRetroAchievementsBootPlacard = false
         gameCoreManager?.stopEmulation() {
             OEBindingsController.default.systemBindings(for: self.systemPlugin.controller).remove(self)
@@ -2310,6 +2312,9 @@ extension OEGameDocument: OESystemBindingsObserver {
 
     func retroAchievementsSessionUpdated(_ info: [String: Any]) {
         DispatchQueue.main.async {
+            if self.retroAchievementsSessionInfo == nil {
+                self.gameViewController?.clearRetroAchievementsIndicators()
+            }
             self.retroAchievementsSessionInfo = info
             NotificationCenter.default.post(name: .OERetroAchievementsSessionDidChange, object: self, userInfo: info)
             if !self.didShowRetroAchievementsBootPlacard {
@@ -2376,8 +2381,7 @@ extension OEGameDocument: OESystemBindingsObserver {
         case "leaderboardFailed":
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Failed", comment: "RA leaderboard failed"), subtitle: title, symbolName: "xmark.circle.fill")
         case "leaderboardSubmitted":
-            let subtitle = display.isEmpty ? title : String(format: NSLocalizedString("%@ — %@", comment: "RA leaderboard submitted subtitle"), display, title)
-            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Submitted", comment: "RA leaderboard submitted"), subtitle: subtitle, symbolName: "checkmark.seal.fill")
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Submitted", comment: "RA leaderboard submitted"), subtitle: title, symbolName: "checkmark.seal.fill")
         case "leaderboardTrackerShow", "leaderboardTrackerUpdate":
             gameViewController?.showRetroAchievementsLeaderboard(id: id, display: display)
         case "leaderboardTrackerHide":
@@ -2396,13 +2400,18 @@ extension OEGameDocument: OESystemBindingsObserver {
         case "subsetCompleted":
             let verb = isHardcoreModeEnabled ? NSLocalizedString("Mastered", comment: "RA mastered subset") : NSLocalizedString("Completed", comment: "RA completed subset")
             gameViewController?.showRetroAchievementsEventToast(title: "\(verb) \(title)", subtitle: NSLocalizedString("Achievement set complete", comment: "RA subset completed subtitle"), badgeURL: badgeURL, symbolName: "crown.fill")
+        case "resetRequested":
+            gameCoreManager?.resetEmulation { [weak self] in
+                self?.isEmulationPaused = false
+            }
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Hardcore Reset", comment: "RA reset requested"), subtitle: NSLocalizedString("Restarting to apply hardcore mode.", comment: "RA reset requested subtitle"), symbolName: "arrow.clockwise.circle.fill")
         case "serverError":
             let message = info[OERetroAchievementsEventErrorMessageKey] as? String ?? description
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Error", comment: "RA server error"), subtitle: message, symbolName: "exclamationmark.triangle.fill")
         case "disconnected":
-            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Offline", comment: "RA disconnected"), subtitle: NSLocalizedString("Unlocks will retry when reconnected.", comment: "RA disconnected subtitle"), symbolName: "wifi.slash")
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Offline", comment: "RA disconnected"), subtitle: NSLocalizedString("Some submissions are pending retry.", comment: "RA disconnected subtitle"), symbolName: "wifi.slash")
         case "reconnected":
-            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Reconnected", comment: "RA reconnected"), subtitle: NSLocalizedString("Pending unlocks synced.", comment: "RA reconnected subtitle"), symbolName: "wifi")
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Reconnected", comment: "RA reconnected"), subtitle: NSLocalizedString("Pending submissions completed.", comment: "RA reconnected subtitle"), symbolName: "wifi")
         default:
             return
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -162,7 +162,6 @@ final class OEGameDocument: NSDocument {
     private var retroAchievementsWindowController: NSWindowController?
     @objc dynamic private(set) var retroAchievementsSessionInfo: [String: Any]?
     private var retroAchievementsSuppressedUnlockIDs = Set<UInt32>()
-    private var retroAchievementsSuppressedUnlockTitles = Set<String>()
     private var didShowRetroAchievementsBootPlacard = false
     private var raCredentialObserver: Any?
     private var raHardcoreObserver: Any?
@@ -628,7 +627,6 @@ final class OEGameDocument: NSDocument {
                 self.emulationStatus = .notSetup
                 self.retroAchievementsSessionInfo = nil
                 self.retroAchievementsSuppressedUnlockIDs.removeAll()
-                self.retroAchievementsSuppressedUnlockTitles.removeAll()
                 self.gameViewController?.clearRetroAchievementsIndicators()
                 self.didShowRetroAchievementsBootPlacard = false
                 
@@ -779,7 +777,6 @@ final class OEGameDocument: NSDocument {
         emulationStatus = .notSetup
         retroAchievementsSessionInfo = nil
         retroAchievementsSuppressedUnlockIDs.removeAll()
-        retroAchievementsSuppressedUnlockTitles.removeAll()
         gameViewController?.clearRetroAchievementsIndicators()
         didShowRetroAchievementsBootPlacard = false
         gameCoreManager?.stopEmulation() {
@@ -2341,12 +2338,10 @@ extension OEGameDocument: OESystemBindingsObserver {
                 self.gameViewController?.showRetroAchievementsUnknownEmulatorNotice()
                 return
             }
-            let normalizedTitle = self.normalizedRetroAchievementsUnlockTitle(title)
-            if self.retroAchievementsSuppressedUnlockIDs.contains(id) || self.retroAchievementsSuppressedUnlockTitles.contains(normalizedTitle) {
+            if self.retroAchievementsSuppressedUnlockIDs.contains(id) {
                 return
             }
             self.retroAchievementsSuppressedUnlockIDs.insert(id)
-            self.retroAchievementsSuppressedUnlockTitles.insert(normalizedTitle)
 
             // In-app banner — always visible regardless of Focus mode or notification settings
             self.gameViewController?.showAchievementUnlocked(title: title, description: description, badgeURL: badgeURL, points: points)
@@ -2371,11 +2366,6 @@ extension OEGameDocument: OESystemBindingsObserver {
         return foldedTitle.contains("unknown emulator") || foldedTitle.contains("unknown emu")
     }
 
-    private func normalizedRetroAchievementsUnlockTitle(_ title: String) -> String {
-        title.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private func updateRetroAchievementsSuppressedUnlockIDs(from info: [String: Any]) {
         let requiredUnlockFlag = isHardcoreModeEnabled ? 2 : 1
         let achievements = info[OERetroAchievementsAchievementsKey] as? [[String: Any]] ?? []
@@ -2384,9 +2374,6 @@ extension OEGameDocument: OESystemBindingsObserver {
             let unlocked = (achievement[OERetroAchievementsUnlockedKey] as? NSNumber)?.intValue ?? 0
             if (unlocked & requiredUnlockFlag) != 0 {
                 retroAchievementsSuppressedUnlockIDs.insert(id)
-                if let title = achievement[OEAchievementTitleKey] as? String {
-                    retroAchievementsSuppressedUnlockTitles.insert(normalizedRetroAchievementsUnlockTitle(title))
-                }
             }
         }
     }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -161,6 +161,8 @@ final class OEGameDocument: NSDocument {
     private var gameCoreManager: GameCoreManager?
     private var retroAchievementsWindowController: NSWindowController?
     @objc dynamic private(set) var retroAchievementsSessionInfo: [String: Any]?
+    private var retroAchievementsSuppressedUnlockIDs = Set<UInt32>()
+    private var retroAchievementsSuppressedUnlockTitles = Set<String>()
     private var didShowRetroAchievementsBootPlacard = false
     private var raCredentialObserver: Any?
     private var raHardcoreObserver: Any?
@@ -625,6 +627,8 @@ final class OEGameDocument: NSDocument {
 
                 self.emulationStatus = .notSetup
                 self.retroAchievementsSessionInfo = nil
+                self.retroAchievementsSuppressedUnlockIDs.removeAll()
+                self.retroAchievementsSuppressedUnlockTitles.removeAll()
                 self.gameViewController?.clearRetroAchievementsIndicators()
                 self.didShowRetroAchievementsBootPlacard = false
                 
@@ -774,6 +778,8 @@ final class OEGameDocument: NSDocument {
         
         emulationStatus = .notSetup
         retroAchievementsSessionInfo = nil
+        retroAchievementsSuppressedUnlockIDs.removeAll()
+        retroAchievementsSuppressedUnlockTitles.removeAll()
         gameViewController?.clearRetroAchievementsIndicators()
         didShowRetroAchievementsBootPlacard = false
         gameCoreManager?.stopEmulation() {
@@ -2316,6 +2322,7 @@ extension OEGameDocument: OESystemBindingsObserver {
                 self.gameViewController?.clearRetroAchievementsIndicators()
             }
             self.retroAchievementsSessionInfo = info
+            self.updateRetroAchievementsSuppressedUnlockIDs(from: info)
             NotificationCenter.default.post(name: .OERetroAchievementsSessionDidChange, object: self, userInfo: info)
             if !self.didShowRetroAchievementsBootPlacard {
                 self.didShowRetroAchievementsBootPlacard = true
@@ -2330,6 +2337,17 @@ extension OEGameDocument: OESystemBindingsObserver {
 
     func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32) {
         DispatchQueue.main.async {
+            if self.isRetroAchievementsUnknownEmulatorWarning(title: title) {
+                self.gameViewController?.showRetroAchievementsUnknownEmulatorNotice()
+                return
+            }
+            let normalizedTitle = self.normalizedRetroAchievementsUnlockTitle(title)
+            if self.retroAchievementsSuppressedUnlockIDs.contains(id) || self.retroAchievementsSuppressedUnlockTitles.contains(normalizedTitle) {
+                return
+            }
+            self.retroAchievementsSuppressedUnlockIDs.insert(id)
+            self.retroAchievementsSuppressedUnlockTitles.insert(normalizedTitle)
+
             // In-app banner — always visible regardless of Focus mode or notification settings
             self.gameViewController?.showAchievementUnlocked(title: title, description: description, badgeURL: badgeURL, points: points)
 
@@ -2345,6 +2363,31 @@ extension OEGameDocument: OESystemBindingsObserver {
                 trigger: nil
             )
             UNUserNotificationCenter.current().add(request)
+        }
+    }
+
+    private func isRetroAchievementsUnknownEmulatorWarning(title: String) -> Bool {
+        let foldedTitle = title.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        return foldedTitle.contains("unknown emulator") || foldedTitle.contains("unknown emu")
+    }
+
+    private func normalizedRetroAchievementsUnlockTitle(_ title: String) -> String {
+        title.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func updateRetroAchievementsSuppressedUnlockIDs(from info: [String: Any]) {
+        let requiredUnlockFlag = isHardcoreModeEnabled ? 2 : 1
+        let achievements = info[OERetroAchievementsAchievementsKey] as? [[String: Any]] ?? []
+        for achievement in achievements {
+            guard let id = (achievement[OEAchievementIDKey] as? NSNumber)?.uint32Value else { continue }
+            let unlocked = (achievement[OERetroAchievementsUnlockedKey] as? NSNumber)?.intValue ?? 0
+            if (unlocked & requiredUnlockFlag) != 0 {
+                retroAchievementsSuppressedUnlockIDs.insert(id)
+                if let title = achievement[OEAchievementTitleKey] as? String {
+                    retroAchievementsSuppressedUnlockTitles.insert(normalizedRetroAchievementsUnlockTitle(title))
+                }
+            }
         }
     }
 
@@ -2379,14 +2422,19 @@ extension OEGameDocument: OESystemBindingsObserver {
         case "leaderboardStarted":
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Started", comment: "RA leaderboard started"), subtitle: title, symbolName: "flag.checkered")
         case "leaderboardFailed":
+            gameViewController?.hideAllRetroAchievementsLeaderboards()
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Failed", comment: "RA leaderboard failed"), subtitle: title, symbolName: "xmark.circle.fill")
         case "leaderboardSubmitted":
+            gameViewController?.hideAllRetroAchievementsLeaderboards()
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Submitted", comment: "RA leaderboard submitted"), subtitle: title, symbolName: "checkmark.seal.fill")
-        case "leaderboardTrackerShow", "leaderboardTrackerUpdate":
+        case "leaderboardTrackerShow":
             gameViewController?.showRetroAchievementsLeaderboard(id: id, display: display)
+        case "leaderboardTrackerUpdate":
+            gameViewController?.updateRetroAchievementsLeaderboard(id: id, display: display)
         case "leaderboardTrackerHide":
             gameViewController?.hideRetroAchievementsLeaderboard(id: id)
         case "leaderboardScoreboard":
+            gameViewController?.hideAllRetroAchievementsLeaderboards()
             let submitted = info[OERetroAchievementsEventSubmittedScoreKey] as? String ?? ""
             let rank = (info[OERetroAchievementsEventRankKey] as? NSNumber)?.intValue ?? 0
             let subtitle = rank > 0

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2326,7 +2326,7 @@ extension OEGameDocument: OESystemBindingsObserver {
     func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32) {
         DispatchQueue.main.async {
             // In-app banner — always visible regardless of Focus mode or notification settings
-            self.gameViewController?.showAchievementUnlocked(title: title, points: points)
+            self.gameViewController?.showAchievementUnlocked(title: title, description: description, badgeURL: badgeURL, points: points)
 
             // macOS system notification — timeSensitive breaks through Focus/DND
             let content = UNMutableNotificationContent()
@@ -2340,6 +2340,71 @@ extension OEGameDocument: OESystemBindingsObserver {
                 trigger: nil
             )
             UNUserNotificationCenter.current().add(request)
+        }
+    }
+
+    func retroAchievementsEvent(_ info: [String: Any]) {
+        DispatchQueue.main.async {
+            self.handleRetroAchievementsEvent(info)
+        }
+    }
+
+    private func handleRetroAchievementsEvent(_ info: [String: Any]) {
+        guard let kind = info[OERetroAchievementsEventKindKey] as? String else { return }
+        let id = (info[OERetroAchievementsEventIDKey] as? NSNumber)?.uint32Value ?? 0
+        let title = info[OERetroAchievementsEventTitleKey] as? String ?? NSLocalizedString("RetroAchievements", comment: "RetroAchievements event fallback title")
+        let description = info[OERetroAchievementsEventDescriptionKey] as? String ?? ""
+        let badgeURL = info[OERetroAchievementsEventBadgeURLKey] as? String
+        let display = info[OERetroAchievementsEventDisplayKey] as? String ?? ""
+
+        switch kind {
+        case "achievementUnlocked":
+            // The dedicated achievement unlock path already shows the richer unlock
+            // banner and macOS notification. Keep this event for future routing only.
+            return
+        case "challengeShow":
+            gameViewController?.showRetroAchievementsChallenge(id: id, title: title)
+        case "challengeHide":
+            gameViewController?.hideRetroAchievementsChallenge(id: id)
+        case "progressShow", "progressUpdate":
+            let progress = info[OERetroAchievementsMeasuredProgressKey] as? String ?? display
+            gameViewController?.showRetroAchievementsProgress(title: title, progress: progress)
+        case "progressHide":
+            gameViewController?.hideRetroAchievementsProgress()
+        case "leaderboardStarted":
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Started", comment: "RA leaderboard started"), subtitle: title, symbolName: "flag.checkered")
+        case "leaderboardFailed":
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Failed", comment: "RA leaderboard failed"), subtitle: title, symbolName: "xmark.circle.fill")
+        case "leaderboardSubmitted":
+            let subtitle = display.isEmpty ? title : String(format: NSLocalizedString("%@ — %@", comment: "RA leaderboard submitted subtitle"), display, title)
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Submitted", comment: "RA leaderboard submitted"), subtitle: subtitle, symbolName: "checkmark.seal.fill")
+        case "leaderboardTrackerShow", "leaderboardTrackerUpdate":
+            gameViewController?.showRetroAchievementsLeaderboard(id: id, display: display)
+        case "leaderboardTrackerHide":
+            gameViewController?.hideRetroAchievementsLeaderboard(id: id)
+        case "leaderboardScoreboard":
+            let submitted = info[OERetroAchievementsEventSubmittedScoreKey] as? String ?? ""
+            let rank = (info[OERetroAchievementsEventRankKey] as? NSNumber)?.intValue ?? 0
+            let subtitle = rank > 0
+                ? String(format: NSLocalizedString("%@ · Rank #%d", comment: "RA leaderboard scoreboard"), submitted, rank)
+                : submitted
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("Leaderboard Result", comment: "RA leaderboard result"), subtitle: subtitle, symbolName: "list.number")
+        case "gameCompleted":
+            let gameTitle = retroAchievementsSessionInfo?[OERetroAchievementsGameTitleKey] as? String ?? rom.game?.displayName ?? title
+            let verb = isHardcoreModeEnabled ? NSLocalizedString("Mastered", comment: "RA mastered game") : NSLocalizedString("Completed", comment: "RA completed game")
+            gameViewController?.showRetroAchievementsEventToast(title: "\(verb) \(gameTitle)", subtitle: NSLocalizedString("All achievements earned", comment: "RA game completed subtitle"), badgeURL: retroAchievementsSessionInfo?[OERetroAchievementsGameBadgeURLKey] as? String, symbolName: "crown.fill")
+        case "subsetCompleted":
+            let verb = isHardcoreModeEnabled ? NSLocalizedString("Mastered", comment: "RA mastered subset") : NSLocalizedString("Completed", comment: "RA completed subset")
+            gameViewController?.showRetroAchievementsEventToast(title: "\(verb) \(title)", subtitle: NSLocalizedString("Achievement set complete", comment: "RA subset completed subtitle"), badgeURL: badgeURL, symbolName: "crown.fill")
+        case "serverError":
+            let message = info[OERetroAchievementsEventErrorMessageKey] as? String ?? description
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Error", comment: "RA server error"), subtitle: message, symbolName: "exclamationmark.triangle.fill")
+        case "disconnected":
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Offline", comment: "RA disconnected"), subtitle: NSLocalizedString("Unlocks will retry when reconnected.", comment: "RA disconnected subtitle"), symbolName: "wifi.slash")
+        case "reconnected":
+            gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Reconnected", comment: "RA reconnected"), subtitle: NSLocalizedString("Pending unlocks synced.", comment: "RA reconnected subtitle"), symbolName: "wifi")
+        default:
+            return
         }
     }
 }

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -37,6 +37,7 @@ final class OEAchievementBannerView: NSView {
     private let ptsLabel    = NSTextField(labelWithString: "")
     private let iconView    = NSImageView()
     private var imageTask: URLSessionDataTask?
+    private var currentBadgeURL: URL?
 
     private var hideWorkItem: DispatchWorkItem?
 
@@ -120,13 +121,18 @@ final class OEAchievementBannerView: NSView {
         ptsLabel.stringValue   = points > 0 ? "+\(points) pts" : ""
 
         imageTask?.cancel()
+        currentBadgeURL = nil
         let iconConfig = NSImage.SymbolConfiguration(pointSize: 26, weight: .semibold)
         iconView.image = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: nil)?
             .withSymbolConfiguration(iconConfig)
         if let url = URL(string: badgeURL), !badgeURL.isEmpty {
+            currentBadgeURL = url
             imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
                 guard let data, let image = NSImage(data: data) else { return }
-                DispatchQueue.main.async { self?.iconView.image = image }
+                DispatchQueue.main.async {
+                    guard self?.currentBadgeURL == url else { return }
+                    self?.iconView.image = image
+                }
             }
             imageTask?.resume()
         }
@@ -159,6 +165,7 @@ final class OERetroAchievementsEventToastView: NSVisualEffectView {
     private let imageView = NSImageView()
     private var hideWorkItem: DispatchWorkItem?
     private var imageTask: URLSessionDataTask?
+    private var currentBadgeURL: URL?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -214,15 +221,20 @@ final class OERetroAchievementsEventToastView: NSVisualEffectView {
         subtitleLabel.stringValue = subtitle
         hideWorkItem?.cancel()
         imageTask?.cancel()
+        currentBadgeURL = nil
         isHidden = false
 
         let config = NSImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
         imageView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?.withSymbolConfiguration(config)
         imageView.contentTintColor = .systemYellow
         if let badgeURL, let url = URL(string: badgeURL), !badgeURL.isEmpty {
+            currentBadgeURL = url
             imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
                 guard let data, let image = NSImage(data: data) else { return }
-                DispatchQueue.main.async { self?.imageView.image = image }
+                DispatchQueue.main.async {
+                    guard self?.currentBadgeURL == url else { return }
+                    self?.imageView.image = image
+                }
             }
             imageTask?.resume()
         }

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -244,10 +244,58 @@ final class OERetroAchievementsEventToastView: NSVisualEffectView {
     }
 }
 
+private final class OERetroAchievementsChipLabel: NSView {
+    private let label = NSTextField(labelWithString: "")
+
+    var stringValue: String {
+        get { label.stringValue }
+        set { label.stringValue = newValue; invalidateIntrinsicContentSize() }
+    }
+
+    var font: NSFont? {
+        get { label.font }
+        set { label.font = newValue; invalidateIntrinsicContentSize() }
+    }
+
+    var textColor: NSColor? {
+        get { label.textColor }
+        set { label.textColor = newValue }
+    }
+
+    var lineBreakMode: NSLineBreakMode {
+        get { label.lineBreakMode }
+        set { label.lineBreakMode = newValue }
+    }
+
+    var maximumNumberOfLines: Int {
+        get { label.maximumNumberOfLines }
+        set { label.maximumNumberOfLines = newValue }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+        ])
+    }
+
+    convenience init(labelWithString string: String) {
+        self.init(frame: .zero)
+        stringValue = string
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
 final class OERetroAchievementsIndicatorStackView: NSStackView {
-    private var challengeViews: [UInt32: NSTextField] = [:]
-    private var leaderboardViews: [UInt32: NSTextField] = [:]
-    private let progressLabel = NSTextField(labelWithString: "")
+    private var challengeViews: [UInt32: OERetroAchievementsChipLabel] = [:]
+    private var leaderboardViews: [UInt32: OERetroAchievementsChipLabel] = [:]
+    private let progressLabel = OERetroAchievementsChipLabel(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -255,6 +303,7 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         alignment = .trailing
         spacing = 6
         isHidden = true
+        configureChip(progressLabel, color: .systemGreen)
         progressLabel.isHidden = true
     }
 
@@ -306,8 +355,23 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         updateVisibility()
     }
 
-    private func makeChip(color: NSColor) -> NSTextField {
-        let label = NSTextField(labelWithString: "")
+    func clear() {
+        for label in Array(challengeViews.values) + Array(leaderboardViews.values) {
+            removeArrangedSubview(label)
+            label.removeFromSuperview()
+        }
+        challengeViews.removeAll()
+        leaderboardViews.removeAll()
+        hideProgress()
+    }
+
+    private func makeChip(color: NSColor) -> OERetroAchievementsChipLabel {
+        let label = OERetroAchievementsChipLabel(labelWithString: "")
+        configureChip(label, color: color)
+        return label
+    }
+
+    private func configureChip(_ label: OERetroAchievementsChipLabel, color: NSColor) {
         label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
         label.textColor = .white
         label.wantsLayer = true
@@ -316,8 +380,7 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         label.lineBreakMode = .byTruncatingTail
         label.maximumNumberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.widthAnchor.constraint(lessThanOrEqualToConstant: 320).isActive = true
-        return label
+        label.widthAnchor.constraint(lessThanOrEqualToConstant: 340).isActive = true
     }
 
     private func updateVisibility() {

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -292,6 +292,43 @@ private final class OERetroAchievementsChipLabel: NSView {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
+final class OERetroAchievementsNoticeView: NSStackView {
+    private let noticeLabel = OERetroAchievementsChipLabel(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        orientation = .horizontal
+        alignment = .leading
+        spacing = 0
+        isHidden = true
+        configureChip(noticeLabel)
+        addArrangedSubview(noticeLabel)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func showUnknownEmulatorWarning() {
+        noticeLabel.stringValue = NSLocalizedString("RA: Unknown emulator", comment: "RetroAchievements unknown emulator compact notice")
+        isHidden = false
+    }
+
+    func clear() {
+        isHidden = true
+    }
+
+    private func configureChip(_ label: OERetroAchievementsChipLabel) {
+        label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        label.textColor = .white
+        label.wantsLayer = true
+        label.layer?.backgroundColor = NSColor.systemYellow.withAlphaComponent(0.82).cgColor
+        label.layer?.cornerRadius = 8
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.widthAnchor.constraint(lessThanOrEqualToConstant: 240).isActive = true
+    }
+}
+
 final class OERetroAchievementsIndicatorStackView: NSStackView {
     private var challengeViews: [UInt32: OERetroAchievementsChipLabel] = [:]
     private var leaderboardViews: [UInt32: OERetroAchievementsChipLabel] = [:]
@@ -336,10 +373,25 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         updateVisibility()
     }
 
+    func updateLeaderboard(id: UInt32, display: String) {
+        guard let label = leaderboardViews[id] else { return }
+        label.stringValue = "Leaderboard: \(display)"
+        updateVisibility()
+    }
+
     func hideLeaderboard(id: UInt32) {
         guard let label = leaderboardViews.removeValue(forKey: id) else { return }
         removeArrangedSubview(label)
         label.removeFromSuperview()
+        updateVisibility()
+    }
+
+    func hideAllLeaderboards() {
+        for label in leaderboardViews.values {
+            removeArrangedSubview(label)
+            label.removeFromSuperview()
+        }
+        leaderboardViews.removeAll()
         updateVisibility()
     }
 

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -28,13 +28,15 @@ import Cocoa
 
 final class OEAchievementBannerView: NSView {
 
-    static let bannerWidth:  CGFloat = 310
-    static let bannerHeight: CGFloat = 66
+    static let bannerWidth:  CGFloat = 430
+    static let bannerHeight: CGFloat = 82
 
     private let headerLabel = NSTextField(labelWithString: "Achievement Unlocked!")
     private let titleLabel  = NSTextField(labelWithString: "")
+    private let descriptionLabel = NSTextField(labelWithString: "")
     private let ptsLabel    = NSTextField(labelWithString: "")
     private let iconView    = NSImageView()
+    private var imageTask: URLSessionDataTask?
 
     private var hideWorkItem: DispatchWorkItem?
 
@@ -58,7 +60,11 @@ final class OEAchievementBannerView: NSView {
         iconView.image = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: nil)?
             .withSymbolConfiguration(iconConfig)
         iconView.contentTintColor = .systemYellow
+        iconView.imageScaling = .scaleProportionallyUpOrDown
         iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.wantsLayer = true
+        iconView.layer?.cornerRadius = 6
+        iconView.layer?.masksToBounds = true
         addSubview(iconView)
 
         headerLabel.font = .systemFont(ofSize: 10, weight: .semibold)
@@ -66,11 +72,17 @@ final class OEAchievementBannerView: NSView {
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(headerLabel)
 
-        titleLabel.font = .systemFont(ofSize: 13, weight: .bold)
+        titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
         titleLabel.textColor = .white
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(titleLabel)
+
+        descriptionLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        descriptionLabel.textColor = NSColor(white: 0.82, alpha: 1)
+        descriptionLabel.lineBreakMode = .byTruncatingTail
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(descriptionLabel)
 
         ptsLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         ptsLabel.textColor = NSColor(white: 0.75, alpha: 1)
@@ -81,8 +93,8 @@ final class OEAchievementBannerView: NSView {
         NSLayoutConstraint.activate([
             iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: 30),
-            iconView.heightAnchor.constraint(equalToConstant: 30),
+            iconView.widthAnchor.constraint(equalToConstant: 52),
+            iconView.heightAnchor.constraint(equalToConstant: 52),
 
             ptsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
             ptsLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -95,12 +107,29 @@ final class OEAchievementBannerView: NSView {
             titleLabel.leadingAnchor.constraint(equalTo: headerLabel.leadingAnchor),
             titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: ptsLabel.leadingAnchor, constant: -8),
             titleLabel.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: 3),
+
+            descriptionLabel.leadingAnchor.constraint(equalTo: headerLabel.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 3),
         ])
     }
 
-    func show(title: String, points: UInt32) {
+    func show(title: String, description: String, badgeURL: String, points: UInt32) {
         titleLabel.stringValue = title
+        descriptionLabel.stringValue = description
         ptsLabel.stringValue   = points > 0 ? "+\(points) pts" : ""
+
+        imageTask?.cancel()
+        let iconConfig = NSImage.SymbolConfiguration(pointSize: 26, weight: .semibold)
+        iconView.image = NSImage(systemSymbolName: "trophy.fill", accessibilityDescription: nil)?
+            .withSymbolConfiguration(iconConfig)
+        if let url = URL(string: badgeURL), !badgeURL.isEmpty {
+            imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+                guard let data, let image = NSImage(data: data) else { return }
+                DispatchQueue.main.async { self?.iconView.image = image }
+            }
+            imageTask?.resume()
+        }
 
         hideWorkItem?.cancel()
 
@@ -119,6 +148,180 @@ final class OEAchievementBannerView: NSView {
         }
         hideWorkItem = item
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.5, execute: item)
+    }
+}
+
+// MARK: - RetroAchievements Event Views
+
+final class OERetroAchievementsEventToastView: NSVisualEffectView {
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(labelWithString: "")
+    private let imageView = NSImageView()
+    private var hideWorkItem: DispatchWorkItem?
+    private var imageTask: URLSessionDataTask?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        material = .hudWindow
+        blendingMode = .withinWindow
+        state = .active
+        wantsLayer = true
+        layer?.cornerRadius = 10
+        layer?.masksToBounds = true
+        alphaValue = 0
+        isHidden = true
+
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.wantsLayer = true
+        imageView.layer?.cornerRadius = 5
+        imageView.layer?.masksToBounds = true
+        addSubview(imageView)
+
+        titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        titleLabel.textColor = .labelColor
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+
+        subtitleLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        subtitleLabel.textColor = .secondaryLabelColor
+        subtitleLabel.lineBreakMode = .byTruncatingTail
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(subtitleLabel)
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 38),
+            imageView.heightAnchor.constraint(equalToConstant: 38),
+
+            titleLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 3),
+            subtitleLabel.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -10),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func show(title: String, subtitle: String, badgeURL: String? = nil, symbolName: String = "trophy.fill") {
+        titleLabel.stringValue = title
+        subtitleLabel.stringValue = subtitle
+        hideWorkItem?.cancel()
+        imageTask?.cancel()
+        isHidden = false
+
+        let config = NSImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+        imageView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?.withSymbolConfiguration(config)
+        imageView.contentTintColor = .systemYellow
+        if let badgeURL, let url = URL(string: badgeURL), !badgeURL.isEmpty {
+            imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+                guard let data, let image = NSImage(data: data) else { return }
+                DispatchQueue.main.async { self?.imageView.image = image }
+            }
+            imageTask?.resume()
+        }
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.2
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            animator().alphaValue = 1
+        }
+        let item = DispatchWorkItem { [weak self] in
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.35
+                ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
+                self?.animator().alphaValue = 0
+            } completionHandler: { self?.isHidden = true }
+        }
+        hideWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0, execute: item)
+    }
+}
+
+final class OERetroAchievementsIndicatorStackView: NSStackView {
+    private var challengeViews: [UInt32: NSTextField] = [:]
+    private var leaderboardViews: [UInt32: NSTextField] = [:]
+    private let progressLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        orientation = .vertical
+        alignment = .trailing
+        spacing = 6
+        isHidden = true
+        progressLabel.isHidden = true
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func showChallenge(id: UInt32, title: String) {
+        let label = challengeViews[id] ?? makeChip(color: .systemOrange)
+        label.stringValue = "Challenge: \(title)"
+        if challengeViews[id] == nil {
+            challengeViews[id] = label
+            addArrangedSubview(label)
+        }
+        updateVisibility()
+    }
+
+    func hideChallenge(id: UInt32) {
+        guard let label = challengeViews.removeValue(forKey: id) else { return }
+        removeArrangedSubview(label)
+        label.removeFromSuperview()
+        updateVisibility()
+    }
+
+    func showLeaderboard(id: UInt32, display: String) {
+        let label = leaderboardViews[id] ?? makeChip(color: .systemBlue)
+        label.stringValue = "Leaderboard: \(display)"
+        if leaderboardViews[id] == nil {
+            leaderboardViews[id] = label
+            addArrangedSubview(label)
+        }
+        updateVisibility()
+    }
+
+    func hideLeaderboard(id: UInt32) {
+        guard let label = leaderboardViews.removeValue(forKey: id) else { return }
+        removeArrangedSubview(label)
+        label.removeFromSuperview()
+        updateVisibility()
+    }
+
+    func showProgress(title: String, progress: String) {
+        if progressLabel.superview == nil { addArrangedSubview(progressLabel) }
+        progressLabel.stringValue = progress.isEmpty ? title : "\(title): \(progress)"
+        progressLabel.isHidden = false
+        updateVisibility()
+    }
+
+    func hideProgress() {
+        progressLabel.isHidden = true
+        updateVisibility()
+    }
+
+    private func makeChip(color: NSColor) -> NSTextField {
+        let label = NSTextField(labelWithString: "")
+        label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        label.textColor = .white
+        label.wantsLayer = true
+        label.layer?.backgroundColor = color.withAlphaComponent(0.82).cgColor
+        label.layer?.cornerRadius = 8
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.widthAnchor.constraint(lessThanOrEqualToConstant: 320).isActive = true
+        return label
+    }
+
+    private func updateVisibility() {
+        isHidden = challengeViews.isEmpty && leaderboardViews.isEmpty && progressLabel.isHidden
     }
 }
 

--- a/OpenEmuKit/Source/OEGameCoreOwner.swift
+++ b/OpenEmuKit/Source/OEGameCoreOwner.swift
@@ -90,4 +90,9 @@ public typealias OEContextID = UInt32
     /// Called when the helper receives updated RetroAchievements metadata for the active game.
     /// The payload contains property-list-safe values using `OERetroAchievements*Key` constants.
     @objc optional func retroAchievementsSessionUpdated(_ info: [String: Any])
+
+    /// Called when rcheevos emits a gameplay UI event such as challenge/progress
+    /// indicator changes, leaderboard tracker updates, mastery, or server state.
+    /// The payload contains property-list-safe values using `OERetroAchievementsEvent*Key` constants.
+    @objc optional func retroAchievementsEvent(_ info: [String: Any])
 }

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -96,3 +96,25 @@ public let OERetroAchievementsBadgeLockedURLKey      = "badgeLockedURL"
 public let OERetroAchievementsRarityKey              = "rarity"
 public let OERetroAchievementsHardcoreRarityKey      = "rarityHardcore"
 public let OERetroAchievementsUnlockedKey            = "unlocked"
+
+/// Posted inside the helper process by a core plugin when rcheevos emits a
+/// gameplay UI event. The helper forwards this to the host via `OEGameCoreOwner`.
+public extension Notification.Name {
+    static let OERetroAchievementsEvent = Notification.Name("OERetroAchievementsEvent")
+}
+
+/// Keys in the RetroAchievements gameplay event `userInfo` dictionary.
+public let OERetroAchievementsEventTypeKey       = "eventType"
+public let OERetroAchievementsEventKindKey       = "eventKind"
+public let OERetroAchievementsEventIDKey         = "eventID"
+public let OERetroAchievementsEventTitleKey      = "eventTitle"
+public let OERetroAchievementsEventDescriptionKey = "eventDescription"
+public let OERetroAchievementsEventBadgeURLKey   = "eventBadgeURL"
+public let OERetroAchievementsEventPointsKey     = "eventPoints"
+public let OERetroAchievementsEventDisplayKey    = "eventDisplay"
+public let OERetroAchievementsEventSubmittedScoreKey = "eventSubmittedScore"
+public let OERetroAchievementsEventBestScoreKey  = "eventBestScore"
+public let OERetroAchievementsEventRankKey       = "eventRank"
+public let OERetroAchievementsEventTotalEntriesKey = "eventTotalEntries"
+public let OERetroAchievementsEventErrorMessageKey = "eventErrorMessage"
+public let OERetroAchievementsEventAPIKey        = "eventAPI"

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -83,6 +83,24 @@
 #define OERAHardcoreRarityKey        @"rarityHardcore"
 #define OERAUnlockedKey              @"unlocked"
 
+/// NSNotificationCenter name posted by a core plugin when rcheevos emits a gameplay UI event.
+/// The helper app observes this and forwards the payload to the host via OEGameCoreOwner.
+#define OERAEventNotification        @"OERetroAchievementsEvent"
+#define OERAEventTypeKey             @"eventType"
+#define OERAEventKindKey             @"eventKind"
+#define OERAEventIDKey               @"eventID"
+#define OERAEventTitleKey            @"eventTitle"
+#define OERAEventDescriptionKey      @"eventDescription"
+#define OERAEventBadgeURLKey         @"eventBadgeURL"
+#define OERAEventPointsKey           @"eventPoints"
+#define OERAEventDisplayKey          @"eventDisplay"
+#define OERAEventSubmittedScoreKey   @"eventSubmittedScore"
+#define OERAEventBestScoreKey        @"eventBestScore"
+#define OERAEventRankKey             @"eventRank"
+#define OERAEventTotalEntriesKey     @"eventTotalEntries"
+#define OERAEventErrorMessageKey     @"eventErrorMessage"
+#define OERAEventAPIKey              @"eventAPI"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -95,6 +113,14 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
                                     rc_client_server_callback_t callback,
                                     void *callback_data,
                                     rc_client_t *client);
+
+/**
+ * Posts a property-list-safe OERAEventNotification for rcheevos gameplay UI
+ * events. Core event handlers should call this before handling achievement
+ * unlocks or refreshing session snapshots.
+ */
+void oeRetroAchievementsPostEventNotification(const rc_client_event_t *event,
+                                               rc_client_t *client);
 
 #ifdef __cplusplus
 }

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -24,11 +24,14 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import <Foundation/Foundation.h>
+#import <string.h>
 #import "OERetroAchievementsTransport.h"
 
 static NSString *OEStringFromCString(const char *string)
 {
-    return string ? [NSString stringWithUTF8String:string] : @"";
+    if (!string) { return @""; }
+    NSString *value = [NSString stringWithCString:string encoding:NSUTF8StringEncoding];
+    return value ?: @"";
 }
 
 static void OEAddAchievementPayload(NSMutableDictionary *payload, const rc_client_achievement_t *achievement)
@@ -50,7 +53,9 @@ static void OEAddLeaderboardPayload(NSMutableDictionary *payload, const rc_clien
     payload[OERAEventIDKey] = @(leaderboard->id);
     payload[OERAEventTitleKey] = OEStringFromCString(leaderboard->title);
     payload[OERAEventDescriptionKey] = OEStringFromCString(leaderboard->description);
-    payload[OERAEventDisplayKey] = OEStringFromCString(leaderboard->tracker_value);
+    if (leaderboard->tracker_value) {
+        payload[OERAEventDisplayKey] = OEStringFromCString(leaderboard->tracker_value);
+    }
 }
 
 void oeRetroAchievementsPostEventNotification(const rc_client_event_t *event,
@@ -125,6 +130,9 @@ void oeRetroAchievementsPostEventNotification(const rc_client_event_t *event,
                 payload[OERAEventRankKey] = @(event->leaderboard_scoreboard->new_rank);
                 payload[OERAEventTotalEntriesKey] = @(event->leaderboard_scoreboard->num_entries);
             }
+            break;
+        case RC_CLIENT_EVENT_RESET:
+            payload[OERAEventKindKey] = @"resetRequested";
             break;
         case RC_CLIENT_EVENT_GAME_COMPLETED:
             payload[OERAEventKindKey] = @"gameCompleted";
@@ -215,10 +223,11 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
             dataTaskWithRequest:urlRequest
               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             if (error || !data) {
+                const char *message = error ? error.localizedDescription.UTF8String : "";
                 rc_api_server_response_t err = {
-                    .body             = error ? error.localizedDescription.UTF8String : "",
-                    .body_length      = 0,
-                    .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR
+                    .body             = message,
+                    .body_length      = strlen(message),
+                    .http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR
                 };
                 callback(&err, callback_data);
                 return;

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -24,7 +24,141 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import <Foundation/Foundation.h>
-#import <rc_client.h>
+#import "OERetroAchievementsTransport.h"
+
+static NSString *OEStringFromCString(const char *string)
+{
+    return string ? [NSString stringWithUTF8String:string] : @"";
+}
+
+static void OEAddAchievementPayload(NSMutableDictionary *payload, const rc_client_achievement_t *achievement)
+{
+    if (!achievement) { return; }
+    payload[OERAEventIDKey] = @(achievement->id);
+    payload[OERAEventTitleKey] = OEStringFromCString(achievement->title);
+    payload[OERAEventDescriptionKey] = OEStringFromCString(achievement->description);
+    payload[OERAEventPointsKey] = @(achievement->points);
+    payload[OERAMeasuredProgressKey] = OEStringFromCString(achievement->measured_progress);
+    payload[OERAMeasuredPercentKey] = @(achievement->measured_percent);
+    if (achievement->badge_url) { payload[OERAEventBadgeURLKey] = OEStringFromCString(achievement->badge_url); }
+    if (achievement->badge_locked_url) { payload[OERABadgeLockedURLKey] = OEStringFromCString(achievement->badge_locked_url); }
+}
+
+static void OEAddLeaderboardPayload(NSMutableDictionary *payload, const rc_client_leaderboard_t *leaderboard)
+{
+    if (!leaderboard) { return; }
+    payload[OERAEventIDKey] = @(leaderboard->id);
+    payload[OERAEventTitleKey] = OEStringFromCString(leaderboard->title);
+    payload[OERAEventDescriptionKey] = OEStringFromCString(leaderboard->description);
+    payload[OERAEventDisplayKey] = OEStringFromCString(leaderboard->tracker_value);
+}
+
+void oeRetroAchievementsPostEventNotification(const rc_client_event_t *event,
+                                               rc_client_t *client)
+{
+    (void)client;
+    if (!event) { return; }
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAEventTypeKey] = @(event->type);
+
+    switch (event->type) {
+        case RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED:
+            payload[OERAEventKindKey] = @"achievementUnlocked";
+            OEAddAchievementPayload(payload, event->achievement);
+            break;
+        case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW:
+            payload[OERAEventKindKey] = @"challengeShow";
+            OEAddAchievementPayload(payload, event->achievement);
+            break;
+        case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE:
+            payload[OERAEventKindKey] = @"challengeHide";
+            OEAddAchievementPayload(payload, event->achievement);
+            break;
+        case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
+            payload[OERAEventKindKey] = @"progressShow";
+            OEAddAchievementPayload(payload, event->achievement);
+            break;
+        case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
+            payload[OERAEventKindKey] = @"progressUpdate";
+            OEAddAchievementPayload(payload, event->achievement);
+            break;
+        case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_HIDE:
+            payload[OERAEventKindKey] = @"progressHide";
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_STARTED:
+            payload[OERAEventKindKey] = @"leaderboardStarted";
+            OEAddLeaderboardPayload(payload, event->leaderboard);
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_FAILED:
+            payload[OERAEventKindKey] = @"leaderboardFailed";
+            OEAddLeaderboardPayload(payload, event->leaderboard);
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED:
+            payload[OERAEventKindKey] = @"leaderboardSubmitted";
+            OEAddLeaderboardPayload(payload, event->leaderboard);
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW:
+            payload[OERAEventKindKey] = @"leaderboardTrackerShow";
+            if (event->leaderboard_tracker) {
+                payload[OERAEventIDKey] = @(event->leaderboard_tracker->id);
+                payload[OERAEventDisplayKey] = OEStringFromCString(event->leaderboard_tracker->display);
+            }
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE:
+            payload[OERAEventKindKey] = @"leaderboardTrackerUpdate";
+            if (event->leaderboard_tracker) {
+                payload[OERAEventIDKey] = @(event->leaderboard_tracker->id);
+                payload[OERAEventDisplayKey] = OEStringFromCString(event->leaderboard_tracker->display);
+            }
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE:
+            payload[OERAEventKindKey] = @"leaderboardTrackerHide";
+            if (event->leaderboard_tracker) { payload[OERAEventIDKey] = @(event->leaderboard_tracker->id); }
+            break;
+        case RC_CLIENT_EVENT_LEADERBOARD_SCOREBOARD:
+            payload[OERAEventKindKey] = @"leaderboardScoreboard";
+            if (event->leaderboard_scoreboard) {
+                payload[OERAEventIDKey] = @(event->leaderboard_scoreboard->leaderboard_id);
+                payload[OERAEventSubmittedScoreKey] = OEStringFromCString(event->leaderboard_scoreboard->submitted_score);
+                payload[OERAEventBestScoreKey] = OEStringFromCString(event->leaderboard_scoreboard->best_score);
+                payload[OERAEventRankKey] = @(event->leaderboard_scoreboard->new_rank);
+                payload[OERAEventTotalEntriesKey] = @(event->leaderboard_scoreboard->num_entries);
+            }
+            break;
+        case RC_CLIENT_EVENT_GAME_COMPLETED:
+            payload[OERAEventKindKey] = @"gameCompleted";
+            break;
+        case RC_CLIENT_EVENT_SUBSET_COMPLETED:
+            payload[OERAEventKindKey] = @"subsetCompleted";
+            if (event->subset) {
+                payload[OERAEventIDKey] = @(event->subset->id);
+                payload[OERAEventTitleKey] = OEStringFromCString(event->subset->title);
+                if (event->subset->badge_url) { payload[OERAEventBadgeURLKey] = OEStringFromCString(event->subset->badge_url); }
+            }
+            break;
+        case RC_CLIENT_EVENT_SERVER_ERROR:
+            payload[OERAEventKindKey] = @"serverError";
+            if (event->server_error) {
+                payload[OERAEventErrorMessageKey] = OEStringFromCString(event->server_error->error_message);
+                payload[OERAEventAPIKey] = OEStringFromCString(event->server_error->api);
+                payload[OERAEventIDKey] = @(event->server_error->related_id);
+            }
+            break;
+        case RC_CLIENT_EVENT_DISCONNECTED:
+            payload[OERAEventKindKey] = @"disconnected";
+            break;
+        case RC_CLIENT_EVENT_RECONNECTED:
+            payload[OERAEventKindKey] = @"reconnected";
+            break;
+        default:
+            return;
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERAEventNotification
+                                                        object:nil
+                                                      userInfo:payload];
+}
 
 // Bridge a rcheevos HTTP request to NSURLSession.
 // This function is passed as the `server_call_function` argument to rc_client_create.

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -195,11 +195,11 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
     rc_client_get_user_agent_clause(client, rcClause, sizeof(rcClause));
 
     // RA expects an identifying User-Agent so they can correlate traffic to the host app.
-    // Format: OpenEmu/<host-version> (macOS <os-version>) rcheevos/<...>
+    // Format: OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<...>
     NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
     NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
     NSString *osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld", (long)osv.majorVersion, (long)osv.minorVersion, (long)osv.patchVersion];
-    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu/%@ (macOS %@) %@",
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %@) %@",
                             hostVersion, osVersion, [NSString stringWithUTF8String:rcClause]];
     [urlRequest setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -233,6 +233,17 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
                 return;
             }
 
+            if (![response isKindOfClass:NSHTTPURLResponse.class]) {
+                const char *message = "Invalid HTTP response";
+                rc_api_server_response_t err = {
+                    .body             = message,
+                    .body_length      = strlen(message),
+                    .http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR
+                };
+                callback(&err, callback_data);
+                return;
+            }
+
             NSHTTPURLResponse *http = (NSHTTPURLResponse *)response;
             rc_api_server_response_t server_response = {
                 .body             = (const char *)data.bytes,

--- a/OpenEmuKit/Source/OEXPCGameCoreManager.swift
+++ b/OpenEmuKit/Source/OEXPCGameCoreManager.swift
@@ -77,6 +77,11 @@ import OpenEmuKitPrivate
                                       for: #selector(OEGameCoreOwner.retroAchievementsSessionUpdated(_:)),
                                       argumentIndex: 0,
                                       ofReply: false)
+            // swiftlint:disable:next force_cast
+            ownerInterface.setClasses(propertyListClasses as! Set<AnyHashable>,
+                                      for: #selector(OEGameCoreOwner.retroAchievementsEvent(_:)),
+                                      argumentIndex: 0,
+                                      ofReply: false)
             cn.exportedInterface = ownerInterface
             cn.exportedObject = proxy
 

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -101,6 +101,7 @@ extension OSLog {
     // Observer for achievement unlock notifications posted by the active core plugin.
     var _achievementObserver: Any?
     var _raSessionObserver: Any?
+    var _raEventObserver: Any?
 
     // frame rate debugging
     var previous    = CFTimeInterval()
@@ -367,6 +368,17 @@ extension OSLog {
                   let info = note.userInfo as? [String: Any] else { return }
             owner.retroAchievementsSessionUpdated?(info)
         }
+
+        _raEventObserver = NotificationCenter.default.addObserver(
+            forName: .OERetroAchievementsEvent,
+            object: nil,
+            queue: nil
+        ) { [weak self] note in
+            guard let self = self,
+                  let owner = self.gameCoreOwner,
+                  let info = note.userInfo as? [String: Any] else { return }
+            owner.retroAchievementsEvent?(info)
+        }
     }
     
     // MARK: - OEGameCoreOwner subclass handles
@@ -494,6 +506,10 @@ extension OSLog {
         if let observer = _raSessionObserver {
             NotificationCenter.default.removeObserver(observer)
             _raSessionObserver = nil
+        }
+        if let observer = _raEventObserver {
+            NotificationCenter.default.removeObserver(observer)
+            _raEventObserver = nil
         }
 
         gameCore.stopEmulation {

--- a/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
@@ -126,6 +126,11 @@ internal import os.log
                                   for: #selector(OEGameCoreOwner.retroAchievementsSessionUpdated(_:)),
                                   argumentIndex: 0,
                                   ofReply: false)
+        // swiftlint:disable:next force_cast
+        ownerInterface.setClasses(propertyListClasses as! Set<AnyHashable>,
+                                  for: #selector(OEGameCoreOwner.retroAchievementsEvent(_:)),
+                                  argumentIndex: 0,
+                                  ofReply: false)
         newConnection.remoteObjectInterface = ownerInterface
         newConnection.invalidationHandler = {
             os_log(.debug, log: .helper, "Connection was invalidated; exiting.")

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -131,6 +131,7 @@ static void snes9x_rc_login_callback(int result, const char *error_message,
 
 static void snes9x_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }

--- a/docs/retroachievements-hardcore-p0-audit.md
+++ b/docs/retroachievements-hardcore-p0-audit.md
@@ -42,7 +42,7 @@ This avoids disabling save states, rewind, cheats, or speed controls for non-RA 
 | Cheats | Pass | Saved cheat autoload is skipped in hardcore, document-level cheat actions return early, and helper-side `setCheat` rejects calls in hardcore. |
 | Mode switch: softcore → hardcore | Pass | Mid-session switch to enforced hardcore prompts for a full game reset before enabling the helper/core hardcore flag. |
 | Mode switch: hardcore → softcore | Pass | Disabling hardcore pushes softcore mode without requiring reset. |
-| User-Agent | Pass for native RA path | Native RA HTTP requests are centralized through `oeRetroAchievementsServerCall`, which sends `OpenEmu/<app-version> (macOS <os-version>) <rcheevos-clause>`. |
+| User-Agent | Pass for native RA path | Native RA HTTP requests are centralized through `oeRetroAchievementsServerCall`, which sends `OpenEmu-Silicon/<app-version> (macOS <os-version>) <rcheevos-clause>`. RA still reports this as an unknown emulator until OpenEmu-Silicon receives RA-side recognition/approval. |
 
 ## User-Agent disclosure
 
@@ -55,10 +55,10 @@ rc_client_create(<core>_rc_read_memory, oeRetroAchievementsServerCall)
 The shared transport builds the HTTP `User-Agent` as:
 
 ```text
-OpenEmu/<host-version> (macOS <os-version>) <rcheevos user-agent clause>
+OpenEmu-Silicon/<host-version> (macOS <os-version>) <rcheevos user-agent clause>
 ```
 
-No current native RA core overrides this with a core-specific or upstream-emulator identity.
+No current native RA core overrides this with a core-specific or upstream-emulator identity. During manual testing, RetroAchievements still displayed an "unknown emulator" warning for OpenEmu-Silicon, so hardcore credit depends on RA-side client recognition/approval.
 
 ## Known non-P0 follow-ups
 

--- a/docs/retroachievements-implementation-guide.md
+++ b/docs/retroachievements-implementation-guide.md
@@ -6,6 +6,10 @@ The canonical reference implementations are:
 - **Mednafen** — `Mednafen/MednafenGameCore.mm` (multi-system: PSX, PCE, Lynx, NGP)
 - **Mupen64Plus** — `Mupen64Plus/MupenGameCore.m` (N64)
 
+Primary upstream references:
+- [`rc_client` integration guide](https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration) — runtime integration, event handling, hardcore behavior, save-state progress, media change, and transport expectations.
+- [RetroAchievements API docs](https://api-docs.retroachievements.org/) — public read API for profile/game/community data. Do not use the public API in place of `rc_client` for runtime login, game sessions, unlocks, leaderboards, or rich presence.
+
 ---
 
 ## Required call sequence during `loadFileAtPath:`
@@ -40,9 +44,43 @@ if (_rcClient) {
 | Event | Call |
 |---|---|
 | Game loading | `rc_client_begin_identify_and_load_game()` |
-| Save state load | `rc_client_reset()` |
+| Save state load | `rc_client_reset()` today; long term, deserialize RA progress from the save state (see below) |
 | Emulation reset | `rc_client_reset()` |
 | Stop / dealloc | `rc_client_unload_game()` then `rc_client_destroy()` |
+| Disc / media change | `rc_client_begin_change_media()` for systems that can swap discs/disks |
+
+If `rc_client_set_hardcore_enabled(_rcClient, 1)` is called while a game is loaded, rcheevos may raise `RC_CLIENT_EVENT_RESET`. The emulator must reset the game and then call `rc_client_reset()` before achievement processing resumes. Do not silently drop this event.
+
+---
+
+## Transport requirements
+
+All native RA cores must use the shared `oeRetroAchievementsServerCall` transport so traffic identifies as OpenEmu-Silicon instead of another emulator.
+
+Transport requirements from the upstream `rc_client` guide:
+
+- Always send a `User-Agent` in this shape: `<product>/<product-version> (<system-information>) <extensions>`.
+- Include `rc_client_get_user_agent_clause()` in the extensions so the server can see the rcheevos version.
+- The product/version must be numeric enough for RA to parse. If RA cannot parse or recognize the client version, hardcore unlocks may be demoted to softcore server-side.
+- For transient client/network failures, pass `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` so rcheevos can queue and retry non-client-initiated updates such as unlocks.
+- Use `RC_API_SERVER_RESPONSE_CLIENT_ERROR` only for errors that should not be retried.
+
+---
+
+## Public API vs `rc_client`
+
+The public RetroAchievements API uses a user's **web API key**, not the `rc_client` login token. It is useful for optional out-of-game surfaces such as profile stats, game metadata, hash/debug tools, ticket/community workflows, or richer library views.
+
+Do **not** use the public API for runtime features that `rc_client` already owns:
+
+- login/session runtime
+- game identification and loading during play
+- achievement unlock submission
+- leaderboard submission
+- rich presence updates
+- retry/offline queue behavior
+
+Runtime behavior should flow through `rc_client` so hashing, server payloads, hardcore mode, retry semantics, leaderboards, and rich presence stay aligned with RA's emulator integration contract.
 
 ---
 
@@ -117,14 +155,57 @@ The fix is `memcpy` with no address manipulation, as shown above.
 
 ---
 
+## Hardcore mode requirements
+
+OpenEmu-Silicon supports a user-facing hardcore preference, but RA's upstream recommendation is that hardcore be enabled by default for opted-in RA users. If the user starts in softcore and switches to hardcore mid-session, reset the game before allowing hardcore unlocks.
+
+Hardcore-restricted features include:
+
+- loading save states
+- rewind
+- slowdown / frame advance
+- cheats or gameplay-modifying hacks
+- debugger/memory inspection windows
+- input playback
+
+The upstream `rc_client` integration guide says fast-forward is allowed in hardcore. OpenEmu-Silicon may choose to be stricter, but if fast-forward remains blocked, keep that as an explicit product/compliance decision rather than an accidental interpretation of RA's baseline rules.
+
+### Pause and idle behavior
+
+When emulation is paused, stop calling `rc_client_do_frame()` and call `rc_client_idle()` at least once per second instead. This keeps routine server communication alive while gameplay is stopped.
+
+In hardcore mode, call `rc_client_can_pause()` immediately before honoring a user pause request. If it returns false, do not pause and show a short user-facing message. This prevents pause-spam from becoming a slow-motion workaround.
+
+### Save-state progress
+
+Blocking save-state loads in hardcore is required, but softcore still needs correct RA runtime progress when save states are used. When save states are written, include the RA progress blob:
+
+- `rc_client_progress_size()`
+- `rc_client_serialize_progress()` or `rc_client_serialize_progress_sized()`
+
+When save states are loaded, restore the blob with:
+
+- `rc_client_deserialize_progress()` or `rc_client_deserialize_progress_sized()`
+
+If a save state does not contain RA progress data, call `rc_client_deserialize_progress(_rcClient, NULL)` to reset runtime progress cleanly.
+
+---
+
 ## Checklist for a new rc_client integration
 
 - [ ] `rc_client_set_allow_background_memory_reads(_rcClient, 0)` called before logging setup
-- [ ] `rc_client_do_frame()` called every emulated frame
-- [ ] `rc_client_reset()` called on save state load and emulation reset
+- [ ] `rc_client_do_frame()` called every emulated frame, including frames not displayed during frame skip or performance catch-up
+- [ ] `rc_client_idle()` called while emulation is paused and `do_frame` is not running
+- [ ] `rc_client_can_pause()` checked before allowing a user pause in hardcore mode
+- [ ] `rc_client_reset()` called on emulation reset and after a hardcore reset request
+- [ ] `RC_CLIENT_EVENT_RESET` handled instead of silently ignored
+- [ ] Save states serialize/deserialize RA progress for softcore correctness, or explicitly document why the core does not support save-state progress yet
+- [ ] Disc/media changes call `rc_client_begin_change_media()` where applicable
 - [ ] `rc_client_unload_game()` + `rc_client_destroy()` called on stop/dealloc
 - [ ] `rc_read_memory` returns 0 (not garbage) when RAM pointer is null
 - [ ] `rc_read_memory` returns partial count when request exceeds RAM size
 - [ ] No byte-swap unless the system's achievement set was explicitly authored against byte-swapped addresses
 - [ ] `RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED` posts `OEAchievementUnlockedNotification`
+- [ ] Gameplay UI events are bridged: challenge indicators, progress, leaderboard start/fail/submit/trackers/scoreboards, completion/mastery, server error, disconnected, reconnected
+- [ ] Shared transport sends OpenEmu's User-Agent and uses retryable client errors for transient network failures
 - [ ] Tested with a real game and achievement that fires in RetroArch — confirm it fires in OE too

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -129,6 +129,7 @@ static void mGBA_rc_login_callback(int result, const char *error_message,
 
 static void mGBA_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
 {
+    oeRetroAchievementsPostEventNotification(event, client);
     if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
     const rc_client_achievement_t *ach = event->achievement;
     if (!ach) { return; }


### PR DESCRIPTION
## What does this PR do?

Adds the next RetroAchievements #438 gameplay UX slice, aligned to the official `rc_client` integration guide.

This PR:
- Adds a generic rcheevos gameplay-event bridge from native RA cores → helper → host app.
- Improves the existing achievement unlock banner with badge artwork, description text, and points.
- Adds challenge indicators for `ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW/HIDE`.
- Adds progress indicators for `ACHIEVEMENT_PROGRESS_INDICATOR_SHOW/UPDATE/HIDE`.
- Adds leaderboard start/fail/submit/result toasts and tracker chips.
- Clears leaderboard tracker chips on terminal leaderboard events, and avoids recreating stale chips from late tracker updates.
- Adds mastery/completion toasts for game and subset completion.
- Surfaces server error, disconnected, and reconnected events as native toasts.
- Shows RetroAchievements' "unknown emulator" warning as a compact in-game chip instead of the achievement-unlocked banner.
- Identifies the client transport as `OpenEmu-Silicon/<version> ... rcheevos/<version>`.

## What did you test?

- `./Scripts/verify.sh` — ALL PASS
- `git diff --check`
- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmuBase -configuration Debug -destination 'platform=macOS,arch=arm64' test`
  - 37 tests passed.
- Release builds passed for all modified native RA core schemes:
  - `OpenEmu + mGBA`
  - `OpenEmu + Nestopia`
  - `OpenEmu + FCEU`
  - `OpenEmu + Gambatte`
  - `OpenEmu + GenesisPlus`
  - `OpenEmu + BSNES`
  - `OpenEmu + SNES9x`
  - `OpenEmu + Mupen64Plus`
  - `OpenEmu + Mednafen`
- Manual Nestopia / Super Mario Bros. testing:
  - Softcore unlocks persist and show as unlocked in the Achievements window.
  - Challenge chips appear and hide correctly when the condition fails.
  - Leaderboard tracker chip appears during the level and clears when the leaderboard result toast appears.
  - RetroAchievements' unknown-emulator warning appears as a compact chip rather than an achievement-unlocked banner.
  - Hardcore credit is not granted while RetroAchievements reports OpenEmu-Silicon as an unknown emulator; this appears to require RA-side client approval/recognition.

## Which cores or systems are affected?

Host app / OpenEmuKit plus all native RA-enabled cores:

- Nestopia
- FCEU
- BSNES
- SNES9x
- Gambatte
- GenesisPlus
- mGBA
- Mupen64Plus
- Mednafen

## Did you use AI tools?

Yes. Used pi/Claude to read the official rcheevos `rc_client` integration guide, map rcheevos event types to OpenEmu UI, implement the bridge/UI, and run local verification.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 519 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -50

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmuBase \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  test 2>&1 | tail -50
```

For manual core testing, build/install a touched RA core before launching. Example:

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + Nestopia' \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

./Scripts/install-core.sh Nestopia --release
./Scripts/verify-core-installed.sh Nestopia --release
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Manual behavior checks:

1. Sign into RetroAchievements.
2. Launch a known RA-supported game.
3. Unlock an achievement and confirm the in-game banner includes badge art, title, description, and points; macOS notification still appears.
4. Use games/sets with measured achievements, challenges, or leaderboards where available and confirm rcheevos events surface as native toasts/chips.
5. Confirm leaderboard tracker chips clear after fail/submit/result.
6. Confirm the Achievements window still opens and receives session metadata.
7. In softcore, confirm earned achievements persist after relaunch.
8. In hardcore, expect RetroAchievements to show an unknown-emulator warning until OpenEmu-Silicon is approved/recognized by the RA team; hardcore credit will not persist while RA treats the client as unknown.

Not included in this PR:

- RA-side approval/recognition for OpenEmu-Silicon hardcore credit.
- `rc_client_can_pause` pause-spam guard.
- Deeper offline queue verification beyond surfacing disconnect/reconnect/server-error events.
- Save-state hit storage / RA progress serialization.
- `rc_client_idle()` while paused.
- Libretro RA behavior.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: host `xcodebuild` build passed
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
