### PR TITLE
fix: defer RetroAchievements memory validation in native cores

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -425,6 +425,7 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
         rc_client_set_event_handler(_rcClient, bsnes_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, bsnes_rc_log);
 
         __weak BSNESGameCore *weakSelf = self;

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -419,6 +419,7 @@ static __weak FCEUGameCore *_current;
         rc_client_set_event_handler(_rcClient, fceu_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, fceu_rc_log);
 
         __weak FCEUGameCore *weakSelf = self;

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -335,6 +335,7 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
         rc_client_set_event_handler(_rcClient, gambatte_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, gambatte_rc_log);
 
         __weak GBGameCore *weakSelf = self;

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -408,6 +408,7 @@ static __weak GenPlusGameCore *_current;
         rc_client_set_event_handler(_rcClient, genplus_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, genplus_rc_log);
 
         __weak GenPlusGameCore *weakSelf = self;

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -417,6 +417,7 @@ static __weak NESGameCore *_current;
         rc_client_set_event_handler(_rcClient, nestopia_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, nestopia_rc_log);
 
         __weak NESGameCore *weakSelf = self;

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -728,6 +728,7 @@ static __weak SNESGameCore *_current;
             rc_client_set_event_handler(_rcClient, snes9x_rc_event_handler);
             _raHardcoreEnabled = YES;
             rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+            rc_client_set_allow_background_memory_reads(_rcClient, 0);
             rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, snes9x_rc_log);
 
             __weak SNESGameCore *weakSelf = self;

--- a/docs/retroachievements-implementation-guide.md
+++ b/docs/retroachievements-implementation-guide.md
@@ -127,7 +127,7 @@ The fix is `memcpy` with no address manipulation, as shown above.
 
 **Fix:** Call `rc_client_set_allow_background_memory_reads(_rcClient, 0)` during `rc_client` initialization. This defers address validation to the `rc_client_do_frame()` call in the frame loop, where emulated RAM is guaranteed live.
 
-**Affected cores fixed:** Mupen64Plus (PR #345), Mednafen (PR #346).
+**Affected cores fixed:** Mupen64Plus (PR #345), Mednafen (PR #346), and the remaining native RA cores in the #438 compliance follow-up (Nestopia, FCEU, BSNES, SNES9x, Gambatte, GenesisPlus, and mGBA).
 
 **Every new integration must include this call.** It is easy to omit because achievements appear to load (no error) and the game runs normally — the failure is silent.
 

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -364,6 +364,7 @@ static struct mLogger logger = { .log = _log };
         rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
         _raHardcoreEnabled = YES;
         rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(_rcClient, 0);
         rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mGBA_rc_log);
 
         // Register token observer before game identification so we don't miss


### PR DESCRIPTION
## What does this PR do?

Closes the next #438 native-core compliance hardening slice by applying the `rc_client_set_allow_background_memory_reads(_rcClient, 0)` requirement from `docs/retroachievements-implementation-guide.md` to the remaining native RetroAchievements cores.

This prevents rcheevos from validating achievement memory on the HTTP callback thread before each emulator core has live RAM, which can silently deactivate achievements.

Updated cores:

- Nestopia
- FCEU
- BSNES
- SNES9x
- Gambatte
- GenesisPlus
- mGBA

Mupen64Plus and Mednafen already had this guard, so all current native RA cores now match the implementation guide.

## What did you test?

- `git diff --check`
- Confirmed all 9 native RA cores now contain exactly one `rc_client_set_allow_background_memory_reads` call.
- Release builds passed for all modified core schemes:
  - `OpenEmu + Nestopia`
  - `OpenEmu + FCEU`
  - `OpenEmu + BSNES`
  - `OpenEmu + SNES9x`
  - `OpenEmu + Gambatte`
  - `OpenEmu + GenesisPlus`
  - `OpenEmu + mGBA`

## Which cores or systems are affected?

Native RetroAchievements-enabled cores:

- Nestopia / NES + FDS
- FCEU / NES
- BSNES / SNES
- SNES9x / SNES
- Gambatte / Game Boy + Game Boy Color
- GenesisPlus / Sega systems supported by that core
- mGBA / Game Boy Advance

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 520 --repo nickybmon/OpenEmu-Silicon

for scheme in 'OpenEmu + Nestopia' 'OpenEmu + FCEU' 'OpenEmu + BSNES' 'OpenEmu + SNES9x' 'OpenEmu + Gambatte' 'OpenEmu + GenesisPlus' 'OpenEmu + mGBA'; do
  xcodebuild \
    -workspace OpenEmu-metal.xcworkspace \
    -scheme "$scheme" \
    -configuration Release \
    -destination 'platform=macOS,arch=arm64' \
    build 2>&1 | tail -30
done
```

Manual smoke test for any touched core:

```bash
./Scripts/install-core.sh --release <CoreName>
./Scripts/verify-core-installed.sh --release <CoreName>
./Scripts/launch-debug.sh
```

Then sign into RetroAchievements, launch a known supported game for that core, and confirm achievements still load/session metadata appears.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes for modified core schemes
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
