### PR TITLE
feat: surface RetroAchievements unrecognized-game feedback

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -86,6 +86,7 @@ static void bsnes_rc_load_game_callback(int result, const char *error_message,
     BSNESGameCore *self = (__bridge BSNESGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-BSNES] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -98,6 +99,7 @@ static void bsnes_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-BSNES] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -118,6 +118,7 @@ static void fceu_rc_load_game_callback(int result, const char *error_message,
     FCEUGameCore *self = (__bridge FCEUGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-FCEU] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -130,6 +131,7 @@ static void fceu_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-FCEU] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -122,6 +122,7 @@ static void gambatte_rc_load_game_callback(int result, const char *error_message
     GBGameCore *self = (__bridge GBGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-Gambatte] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -134,6 +135,7 @@ static void gambatte_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-Gambatte] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -173,6 +173,7 @@ static void genplus_rc_load_game_callback(int result, const char *error_message,
     GenPlusGameCore *self = (__bridge GenPlusGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-GenPlus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -185,6 +186,7 @@ static void genplus_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-GenPlus] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -229,6 +229,7 @@ static void mednafen_rc_load_game_callback(int result, const char *error_message
     MednafenGameCore *self = (__bridge MednafenGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-Mednafen] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -241,6 +242,7 @@ static void mednafen_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-Mednafen] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -160,6 +160,7 @@ static void mupen_rc_load_game_callback(int result, const char *error_message,
     MupenGameCore *self = (__bridge MupenGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-Mupen64Plus] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -172,6 +173,7 @@ static void mupen_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-Mupen64Plus] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -134,6 +134,7 @@ static void nestopia_rc_load_game_callback(int result, const char *error_message
     NESGameCore *self = (__bridge NESGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-Nestopia] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -146,6 +147,7 @@ static void nestopia_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-Nestopia] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -509,24 +509,33 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         hideWorkItem?.cancel()
         isHidden = false
 
-        titleLabel.stringValue = info[OERetroAchievementsGameTitleKey] as? String ?? NSLocalizedString("RetroAchievements", comment: "RetroAchievements placard fallback title")
-
-        let unlocked = (info[OERetroAchievementsUnlockedCountKey] as? NSNumber)?.intValue ?? 0
-        let total = (info[OERetroAchievementsAchievementCountKey] as? NSNumber)?.intValue ?? 0
-        let points = (info[OERetroAchievementsUnlockedPointsKey] as? NSNumber)?.intValue ?? 0
-        let totalPoints = (info[OERetroAchievementsTotalPointsKey] as? NSNumber)?.intValue ?? 0
-        let account = signedIn ? NSLocalizedString("Logged in", comment: "RetroAchievements placard signed in") : NSLocalizedString("Not logged in", comment: "RetroAchievements placard signed out")
-        summaryLabel.stringValue = String(format: NSLocalizedString("%@ · %d of %d achievements · %d of %d points", comment: "RetroAchievements boot placard summary"), account, unlocked, total, points, totalPoints)
-
-        modeLabel.stringValue = hardcore ? NSLocalizedString("Hardcore Mode", comment: "RetroAchievements hardcore mode") : NSLocalizedString("Softcore Mode", comment: "RetroAchievements softcore mode")
-        modeLabel.textColor = .labelColor
-
         imageView.image = nil
-        if let urlString = info[OERetroAchievementsGameBadgeURLKey] as? String, let url = URL(string: urlString) {
-            URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
-                guard let data, let image = NSImage(data: data) else { return }
-                DispatchQueue.main.async { self?.imageView.image = image }
-            }.resume()
+
+        if let status = info[OERetroAchievementsSessionStatusKey] as? String {
+            titleLabel.stringValue = sessionStatusTitle(status)
+            summaryLabel.stringValue = sessionStatusMessage(status, info: info)
+            modeLabel.stringValue = NSLocalizedString("Achievements unavailable", comment: "RetroAchievements placard unavailable mode")
+            modeLabel.textColor = .systemYellow
+            imageView.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
+        } else {
+            titleLabel.stringValue = info[OERetroAchievementsGameTitleKey] as? String ?? NSLocalizedString("RetroAchievements", comment: "RetroAchievements placard fallback title")
+
+            let unlocked = (info[OERetroAchievementsUnlockedCountKey] as? NSNumber)?.intValue ?? 0
+            let total = (info[OERetroAchievementsAchievementCountKey] as? NSNumber)?.intValue ?? 0
+            let points = (info[OERetroAchievementsUnlockedPointsKey] as? NSNumber)?.intValue ?? 0
+            let totalPoints = (info[OERetroAchievementsTotalPointsKey] as? NSNumber)?.intValue ?? 0
+            let account = signedIn ? NSLocalizedString("Logged in", comment: "RetroAchievements placard signed in") : NSLocalizedString("Not logged in", comment: "RetroAchievements placard signed out")
+            summaryLabel.stringValue = String(format: NSLocalizedString("%@ · %d of %d achievements · %d of %d points", comment: "RetroAchievements boot placard summary"), account, unlocked, total, points, totalPoints)
+
+            modeLabel.stringValue = hardcore ? NSLocalizedString("Hardcore Mode", comment: "RetroAchievements hardcore mode") : NSLocalizedString("Softcore Mode", comment: "RetroAchievements softcore mode")
+            modeLabel.textColor = .labelColor
+
+            if let urlString = info[OERetroAchievementsGameBadgeURLKey] as? String, let url = URL(string: urlString) {
+                URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+                    guard let data, let image = NSImage(data: data) else { return }
+                    DispatchQueue.main.async { self?.imageView.image = image }
+                }.resume()
+            }
         }
 
         NSAnimationContext.runAnimationGroup { context in
@@ -544,6 +553,31 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         }
         hideWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0, execute: workItem)
+    }
+
+    private func sessionStatusTitle(_ status: String) -> String {
+        switch status {
+        case "unrecognized":
+            return NSLocalizedString("RetroAchievements: Game Not Recognized", comment: "RetroAchievements unrecognized game placard title")
+        case "loginFailed":
+            return NSLocalizedString("RetroAchievements Sign-In Failed", comment: "RetroAchievements login failed placard title")
+        default:
+            return NSLocalizedString("RetroAchievements Unavailable", comment: "RetroAchievements unavailable placard title")
+        }
+    }
+
+    private func sessionStatusMessage(_ status: String, info: [String: Any]) -> String {
+        if let message = info[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+            return message
+        }
+        switch status {
+        case "unrecognized":
+            return NSLocalizedString("No achievement set was found for this game/hash.", comment: "RetroAchievements unrecognized game placard message")
+        case "loginFailed":
+            return NSLocalizedString("Please sign in again from Preferences → Achievements.", comment: "RetroAchievements login failed placard message")
+        default:
+            return NSLocalizedString("RetroAchievements could not load for this session.", comment: "RetroAchievements unavailable placard message")
+        }
     }
 }
 
@@ -656,9 +690,10 @@ final class RetroAchievementsGameViewController: NSViewController {
         }
 
         if achievements.isEmpty {
-            let message = info == nil
-                ? NSLocalizedString("Waiting for RetroAchievements game metadata from the emulator core. If this stays empty, confirm you are signed in and the active core/game supports RetroAchievements.", comment: "RetroAchievements waiting message")
-                : NSLocalizedString("No achievements were reported for this game.", comment: "RetroAchievements empty list message")
+            let message = sessionStatusMessage(info: info, document: document)
+                ?? (info == nil
+                    ? NSLocalizedString("Waiting for RetroAchievements game metadata from the emulator core. If this stays empty, confirm you are signed in and the active core/game supports RetroAchievements.", comment: "RetroAchievements waiting message")
+                    : NSLocalizedString("No achievements were reported for this game.", comment: "RetroAchievements empty list message"))
             contentStack.addArrangedSubview(makeBodyLabel(message, color: .secondaryLabelColor))
             scrollToTop()
             return
@@ -724,9 +759,10 @@ final class RetroAchievementsGameViewController: NSViewController {
         let total = (info?[OERetroAchievementsAchievementCountKey] as? NSNumber)?.intValue
         let points = (info?[OERetroAchievementsUnlockedPointsKey] as? NSNumber)?.intValue
         let totalPoints = (info?[OERetroAchievementsTotalPointsKey] as? NSNumber)?.intValue
-        let progress = unlocked != nil && total != nil && points != nil && totalPoints != nil
-            ? String(format: NSLocalizedString("Unlocked %d of %d achievements · %d of %d points", comment: "RetroAchievements summary"), unlocked!, total!, points!, totalPoints!)
-            : summaryText(document: document)
+        let progress = sessionStatusMessage(info: info, document: document)
+            ?? (unlocked != nil && total != nil && points != nil && totalPoints != nil
+                ? String(format: NSLocalizedString("Unlocked %d of %d achievements · %d of %d points", comment: "RetroAchievements summary"), unlocked!, total!, points!, totalPoints!)
+                : summaryText(document: document))
         textStack.addArrangedSubview(makeBodyLabel(progress, color: .labelColor))
 
         let mode = document.isHardcoreModeEnabled ? NSLocalizedString("Hardcore Mode", comment: "RetroAchievements hardcore mode") : NSLocalizedString("Softcore Mode", comment: "RetroAchievements softcore mode")
@@ -884,6 +920,21 @@ final class RetroAchievementsGameViewController: NSViewController {
         label.font = .systemFont(ofSize: 12, weight: .semibold)
         label.textColor = color
         return label
+    }
+
+    private func sessionStatusMessage(info: [String: Any]?, document: OEGameDocument) -> String? {
+        guard let status = info?[OERetroAchievementsSessionStatusKey] as? String else { return nil }
+        if let message = info?[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+            return message
+        }
+        switch status {
+        case "unrecognized":
+            return NSLocalizedString("RetroAchievements is enabled, but no achievement set was found for this game/hash.", comment: "RetroAchievements unrecognized game window message")
+        case "loginFailed":
+            return NSLocalizedString("RetroAchievements sign-in failed. Please sign in again from Preferences → Achievements.", comment: "RetroAchievements login failed window message")
+        default:
+            return NSLocalizedString("RetroAchievements could not load for this session.", comment: "RetroAchievements generic load failure window message")
+        }
     }
 
     private func summaryText(document: OEGameDocument) -> String {

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -557,9 +557,9 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
 
     private func sessionStatusTitle(_ status: String) -> String {
         switch status {
-        case "unrecognized":
+        case OERetroAchievementsSessionStatusUnrecognized:
             return NSLocalizedString("RetroAchievements: Game Not Recognized", comment: "RetroAchievements unrecognized game placard title")
-        case "loginFailed":
+        case OERetroAchievementsSessionStatusLoginFailed:
             return NSLocalizedString("RetroAchievements Sign-In Failed", comment: "RetroAchievements login failed placard title")
         default:
             return NSLocalizedString("RetroAchievements Unavailable", comment: "RetroAchievements unavailable placard title")
@@ -567,15 +567,18 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
     }
 
     private func sessionStatusMessage(_ status: String, info: [String: Any]) -> String {
-        if let message = info[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
-            return message
-        }
         switch status {
-        case "unrecognized":
+        case OERetroAchievementsSessionStatusUnrecognized:
             return NSLocalizedString("No achievement set was found for this game/hash.", comment: "RetroAchievements unrecognized game placard message")
-        case "loginFailed":
+        case OERetroAchievementsSessionStatusLoginFailed:
+            if let message = info[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+                return message
+            }
             return NSLocalizedString("Please sign in again from Preferences → Achievements.", comment: "RetroAchievements login failed placard message")
         default:
+            if let message = info[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+                return message
+            }
             return NSLocalizedString("RetroAchievements could not load for this session.", comment: "RetroAchievements unavailable placard message")
         }
     }
@@ -924,15 +927,18 @@ final class RetroAchievementsGameViewController: NSViewController {
 
     private func sessionStatusMessage(info: [String: Any]?, document: OEGameDocument) -> String? {
         guard let status = info?[OERetroAchievementsSessionStatusKey] as? String else { return nil }
-        if let message = info?[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
-            return message
-        }
         switch status {
-        case "unrecognized":
+        case OERetroAchievementsSessionStatusUnrecognized:
             return NSLocalizedString("RetroAchievements is enabled, but no achievement set was found for this game/hash.", comment: "RetroAchievements unrecognized game window message")
-        case "loginFailed":
+        case OERetroAchievementsSessionStatusLoginFailed:
+            if let message = info?[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+                return message
+            }
             return NSLocalizedString("RetroAchievements sign-in failed. Please sign in again from Preferences → Achievements.", comment: "RetroAchievements login failed window message")
         default:
+            if let message = info?[OERetroAchievementsSessionErrorMessageKey] as? String, !message.isEmpty {
+                return message
+            }
             return NSLocalizedString("RetroAchievements could not load for this session.", comment: "RetroAchievements generic load failure window message")
         }
     }

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -99,6 +99,9 @@ public let OERetroAchievementsUnlockedKey            = "unlocked"
 public let OERetroAchievementsSessionStatusKey       = "sessionStatus"
 public let OERetroAchievementsSessionErrorCodeKey    = "sessionErrorCode"
 public let OERetroAchievementsSessionErrorMessageKey = "sessionErrorMessage"
+public let OERetroAchievementsSessionStatusUnrecognized = "unrecognized"
+public let OERetroAchievementsSessionStatusLoginFailed  = "loginFailed"
+public let OERetroAchievementsSessionStatusLoadFailed   = "loadFailed"
 
 /// Posted inside the helper process by a core plugin when rcheevos emits a
 /// gameplay UI event. The helper forwards this to the host via `OEGameCoreOwner`.

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -96,6 +96,9 @@ public let OERetroAchievementsBadgeLockedURLKey      = "badgeLockedURL"
 public let OERetroAchievementsRarityKey              = "rarity"
 public let OERetroAchievementsHardcoreRarityKey      = "rarityHardcore"
 public let OERetroAchievementsUnlockedKey            = "unlocked"
+public let OERetroAchievementsSessionStatusKey       = "sessionStatus"
+public let OERetroAchievementsSessionErrorCodeKey    = "sessionErrorCode"
+public let OERetroAchievementsSessionErrorMessageKey = "sessionErrorMessage"
 
 /// Posted inside the helper process by a core plugin when rcheevos emits a
 /// gameplay UI event. The helper forwards this to the host via `OEGameCoreOwner`.

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -82,6 +82,9 @@
 #define OERARarityKey                @"rarity"
 #define OERAHardcoreRarityKey        @"rarityHardcore"
 #define OERAUnlockedKey              @"unlocked"
+#define OERASessionStatusKey         @"sessionStatus"
+#define OERASessionErrorCodeKey      @"sessionErrorCode"
+#define OERASessionErrorMessageKey   @"sessionErrorMessage"
 
 /// NSNotificationCenter name posted by a core plugin when rcheevos emits a gameplay UI event.
 /// The helper app observes this and forwards the payload to the host via OEGameCoreOwner.
@@ -121,6 +124,13 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
  */
 void oeRetroAchievementsPostEventNotification(const rc_client_event_t *event,
                                                rc_client_t *client);
+
+/**
+ * Posts property-list-safe OERASessionUpdatedNotification payloads when
+ * login or game identification fails before a normal session snapshot exists.
+ */
+void oeRetroAchievementsPostSessionLoadFailure(int result, const char *error_message);
+void oeRetroAchievementsPostLoginFailure(int result, const char *error_message);
 
 #ifdef __cplusplus
 }

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -85,6 +85,9 @@
 #define OERASessionStatusKey         @"sessionStatus"
 #define OERASessionErrorCodeKey      @"sessionErrorCode"
 #define OERASessionErrorMessageKey   @"sessionErrorMessage"
+#define OERASessionStatusUnrecognized @"unrecognized"
+#define OERASessionStatusLoginFailed  @"loginFailed"
+#define OERASessionStatusLoadFailed   @"loadFailed"
 
 /// NSNotificationCenter name posted by a core plugin when rcheevos emits a gameplay UI event.
 /// The helper app observes this and forwards the payload to the host via OEGameCoreOwner.

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -48,17 +48,25 @@ static void OEPostSessionStatus(NSString *status, int result, const char *error_
                                                       userInfo:payload];
 }
 
+static BOOL OEIsUnrecognizedGameResult(int result)
+{
+    // rcheevos currently reports unknown/no-set hashes through these two
+    // results. Keep this classification centralized so new upstream result
+    // codes can be added in one place if needed.
+    return result == RC_NO_GAME_LOADED || result == RC_NOT_FOUND;
+}
+
 void oeRetroAchievementsPostSessionLoadFailure(int result, const char *error_message)
 {
-    NSString *status = (result == RC_NO_GAME_LOADED || result == RC_NOT_FOUND)
-        ? @"unrecognized"
-        : @"loadFailed";
+    NSString *status = OEIsUnrecognizedGameResult(result)
+        ? OERASessionStatusUnrecognized
+        : OERASessionStatusLoadFailed;
     OEPostSessionStatus(status, result, error_message);
 }
 
 void oeRetroAchievementsPostLoginFailure(int result, const char *error_message)
 {
-    OEPostSessionStatus(@"loginFailed", result, error_message);
+    OEPostSessionStatus(OERASessionStatusLoginFailed, result, error_message);
 }
 
 static void OEAddAchievementPayload(NSMutableDictionary *payload, const rc_client_achievement_t *achievement)

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -34,6 +34,33 @@ static NSString *OEStringFromCString(const char *string)
     return value ?: @"";
 }
 
+static void OEPostSessionStatus(NSString *status, int result, const char *error_message)
+{
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERASessionStatusKey] = status;
+    payload[OERASessionErrorCodeKey] = @(result);
+
+    NSString *message = OEStringFromCString(error_message);
+    if (message.length > 0) { payload[OERASessionErrorMessageKey] = message; }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                        object:nil
+                                                      userInfo:payload];
+}
+
+void oeRetroAchievementsPostSessionLoadFailure(int result, const char *error_message)
+{
+    NSString *status = (result == RC_NO_GAME_LOADED || result == RC_NOT_FOUND)
+        ? @"unrecognized"
+        : @"loadFailed";
+    OEPostSessionStatus(status, result, error_message);
+}
+
+void oeRetroAchievementsPostLoginFailure(int result, const char *error_message)
+{
+    OEPostSessionStatus(@"loginFailed", result, error_message);
+}
+
 static void OEAddAchievementPayload(NSMutableDictionary *payload, const rc_client_achievement_t *achievement)
 {
     if (!achievement) { return; }

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -113,6 +113,7 @@ static void snes9x_rc_load_game_callback(int result, const char *error_message,
     SNESGameCore *self = (__bridge SNESGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-SNES9x] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -125,6 +126,7 @@ static void snes9x_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [s _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-SNES9x] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -111,6 +111,7 @@ static void mGBA_rc_load_game_callback(int result, const char *error_message,
     mGBAGameCore *self = (__bridge mGBAGameCore *)userdata;
     if (result != RC_OK) {
         NSLog(@"[RA-mGBA] game load failed — result=%d error=%s", result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
         return;
     }
     [self _postRetroAchievementsSessionSnapshot];
@@ -123,6 +124,7 @@ static void mGBA_rc_login_callback(int result, const char *error_message,
     if (result == RC_OK) {
         [self _beginLoadGame];
     } else {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
         NSLog(@"[RA-mGBA] login failed — result=%d error=%s", result, error_message ?: "(none)");
     }
 }


### PR DESCRIPTION
## What does this PR do?

Continues #438 by making RetroAchievements login/game-identification failures visible to players instead of leaving the Achievements window in an indefinite waiting state.

This PR:
- Adds shared session-failure payloads for native rcheevos login and game-load failures.
- Forwards those payloads through the existing helper → host `retroAchievementsSessionUpdated` path.
- Wires all 9 native RA cores to report login and load failures:
  - Nestopia
  - FCEU
  - BSNES
  - SNES9x
  - Gambatte
  - GenesisPlus
  - mGBA
  - Mupen64Plus
  - Mednafen
- Shows a clear boot placard when a supported/signed-in RA session cannot load achievements.
- Updates the Achievements window empty state so unrecognized hashes and login failures are distinct from “still waiting for metadata.”

This covers the #438 P1 item: clear unsupported/unrecognized feedback when RA is enabled but no valid set/hash is found. It also partially advances #318 by surfacing login/identification failures in the UI.

## What did you test?

- `git diff --check`
- Host app build:
  - `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- Release builds passed for all modified native RA core schemes:
  - `OpenEmu + Nestopia`
  - `OpenEmu + FCEU`
  - `OpenEmu + BSNES`
  - `OpenEmu + SNES9x`
  - `OpenEmu + Gambatte`
  - `OpenEmu + GenesisPlus`
  - `OpenEmu + mGBA`
  - `OpenEmu + Mupen64Plus`
  - `OpenEmu + Mednafen`

## Which cores or systems are affected?

Host app RA UI plus all native RetroAchievements-enabled cores:

- Nestopia / NES + FDS
- FCEU / NES
- BSNES / SNES
- SNES9x / SNES
- Gambatte / Game Boy + Game Boy Color
- GenesisPlus / Sega systems supported by that core
- mGBA / Game Boy Advance
- Mupen64Plus / Nintendo 64
- Mednafen / supported Mednafen RA systems

## Linked issues

Related to #438
Related to #318

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 521 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -50
```

Build/install a touched RA core before manual testing. Example:

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + Nestopia' \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

./Scripts/install-core.sh --release Nestopia
./Scripts/verify-core-installed.sh --release Nestopia
./Scripts/launch-debug.sh
```

Manual behavior checks:

1. Sign into RetroAchievements.
2. Launch a known supported game and confirm existing recognized-game placard/window behavior still works.
3. Launch a game/hash with no RA set for a native RA-supported core and confirm:
   - a RetroAchievements “Game Not Recognized” placard appears
   - the Achievements window shows a clear unrecognized-game message instead of waiting forever
4. With invalid/expired RA credentials, confirm the Achievements window and placard show a sign-in failure rather than a generic empty state.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes for host app and modified core schemes
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
