### PR TITLE
docs: map RetroAchievements verification to rc_client guide

### DIFF
--- a/docs/retroachievements-implementation-guide.md
+++ b/docs/retroachievements-implementation-guide.md
@@ -10,6 +10,10 @@ Primary upstream references:
 - [`rc_client` integration guide](https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration) — runtime integration, event handling, hardcore behavior, save-state progress, media change, and transport expectations.
 - [RetroAchievements API docs](https://api-docs.retroachievements.org/) — public read API for profile/game/community data. Do not use the public API in place of `rc_client` for runtime login, game sessions, unlocks, leaderboards, or rich presence.
 
+Related repo-local docs:
+- `docs/retroachievements-hardcore-p0-audit.md` — native hardcore enforcement audit for #438.
+- `docs/retroachievements-p1-verification.md` — verification plan and submission-evidence checklist mapped to the upstream `rc_client` guide.
+
 ---
 
 ## Required call sequence during `loadFileAtPath:`
@@ -175,6 +179,12 @@ The upstream `rc_client` integration guide says fast-forward is allowed in hardc
 When emulation is paused, stop calling `rc_client_do_frame()` and call `rc_client_idle()` at least once per second instead. This keeps routine server communication alive while gameplay is stopped.
 
 In hardcore mode, call `rc_client_can_pause()` immediately before honoring a user pause request. If it returns false, do not pause and show a short user-facing message. This prevents pause-spam from becoming a slow-motion workaround.
+
+### Automatically disabling hardcore when no RA processing is required
+
+The upstream `rc_client` guide recommends optionally disabling hardcore for games that have no RA functionality by checking `rc_client_is_processing_required()`. OpenEmu-Silicon does **not** currently do this per game. Instead, enforcement is scoped to signed-in sessions whose selected core/system advertises RA support, and #438 tracks clear unrecognized/no-set feedback for games without a valid RA set/hash.
+
+If we later auto-disable hardcore per game, re-enable it when unloading the game or before loading the next game.
 
 ### Save-state progress
 

--- a/docs/retroachievements-p1-verification.md
+++ b/docs/retroachievements-p1-verification.md
@@ -1,0 +1,167 @@
+# RetroAchievements P1 Verification Plan
+
+This document is the manual verification and submission-evidence checklist for issue #438. It is based on the upstream [`rc_client` integration guide](https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration) and the current OpenEmu-Silicon native `rc_client` implementation.
+
+Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked separately in #360 and the libretro architecture docs.
+
+## Native RA cores in scope
+
+- Nestopia
+- FCEU
+- BSNES
+- SNES9x
+- Gambatte
+- GenesisPlus
+- mGBA
+- Mupen64Plus
+- Mednafen
+
+## Source checklist from upstream `rc_client` guide
+
+| Upstream area | Current status | Evidence / next verification |
+| --- | --- | --- |
+| Create/destroy `rc_client_t` | Implemented | All native RA cores create `rc_client_t` with `oeRetroAchievementsServerCall`, set userdata, register event handler, and unload/destroy the client on stop/dealloc. |
+| User-Agent | Implemented; RA approval pending | Shared transport sends `OpenEmu-Silicon/<version> (macOS <version>) <rcheevos-clause>`. RA still needs to recognize/approve the client for hardcore credit. |
+| Login with token | Implemented; failure UI in PR #521 | Cores use `rc_client_begin_login_with_token()`. PR #521 surfaces login failure to the host UI. |
+| Start game session | Implemented; failure UI in PR #521 | Cores use `rc_client_begin_identify_and_load_game()`. PR #521 surfaces unrecognized/no-set hash failures. |
+| Game boot placard | Implemented | PR #514 added recognized-game boot placard with title, mode, achievement count, and point summary. PR #521 adds failure placards. |
+| Achievement list | Implemented; polish remaining | PR #514 added native Achievements window. Static measured progress is shown when present. Active challenge/progress state in the window remains a #438 follow-up. |
+| `rc_client_do_frame()` | Implemented | All native RA cores call `rc_client_do_frame()` in their emulation frame loop. Needs representative runtime verification per core. |
+| Achievement unlock notification | Implemented | `RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED` posts in-app unlock banner and macOS notification with unlock sound. |
+| Leaderboard events | Implemented; verification needed | PR #519 bridges start/fail/submit/scoreboard and tracker show/update/hide to native toasts/chips. Needs representative game verification. |
+| Challenge indicators | Implemented; verification needed | PR #519 bridges challenge show/hide to native chips. Manual Nestopia/SMB verification already confirmed show/hide behavior once. |
+| Progress indicators | Implemented; verification needed | PR #519 bridges measured progress show/update/hide to native chips. Needs representative measured-achievement verification. |
+| Completion/mastery notifications | Implemented; verification needed | PR #519 bridges game/subset completion to native toasts. Needs manual evidence. |
+| Reset handling | Implemented | `RC_CLIENT_EVENT_RESET` is bridged and host resets emulation; cores call `rc_client_reset()` on emulator reset/load-state paths. |
+| Save-state progress serialization | Gap / P2 | Hardcore load-state blocking is implemented. Softcore RA progress is still reset on load via `rc_client_reset()`; serialize/deserialize is not implemented. |
+| Multiple media changes | Gap / follow-up | No current native-core call to `rc_client_begin_change_media()` was found. Needs design for disc/disk swap systems, especially Mednafen PSX/PCE-CD/Saturn. |
+| Hardcore default / mode switching | Implemented | User-facing hardcore preference defaults on for signed-in RA users; softcore→hardcore reset path is implemented and documented in P0 audit. |
+| Disable hardcore when no RA processing required | Not implemented / product decision needed | Upstream recommends optionally disabling hardcore for games with no RA functionality via `rc_client_is_processing_required()`. OpenEmu currently scopes enforcement by core/system support and token, not by per-game processing state. |
+| Pause / idle | Gap / compliance-adjacent | `rc_client_idle()` while paused and `rc_client_can_pause()` before hardcore pause are documented but not implemented. |
+| Server errors | Implemented; verification needed | PR #519 surfaces `RC_CLIENT_EVENT_SERVER_ERROR`, disconnected, and reconnected events. Transport marks transient network failures retryable. |
+| Offline retry queue | Implementation delegated to `rc_client`; verification needed | Shared transport uses `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` for transient client/network failures, enabling rcheevos retry behavior. Must verify unlock queue/sync/purge behavior manually. |
+| Rich Presence | Expected via `rc_client_do_frame()`; verification needed | Upstream says `rc_client_do_frame()` sends rich presence updates after initial delay and periodically thereafter. No OpenEmu toggle exists to disable it. Must verify on RA profile/API. |
+
+## Verification matrix
+
+Use real RA credentials and games known to have active achievements, rich presence, measured achievements, challenges, and leaderboards. Build and install the specific core before testing; OpenEmu loads installed core plugins from `~/Library/Application Support/OpenEmu/Cores/`.
+
+### Common setup
+
+```bash
+cd ~/Documents/Cursor/Open\ Emu
+
+# Build host app
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme OpenEmu \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -50
+
+# Build/install a core before manual testing. Example:
+xcodebuild \
+  -workspace OpenEmu-metal.xcworkspace \
+  -scheme 'OpenEmu + Nestopia' \
+  -configuration Release \
+  -destination 'platform=macOS,arch=arm64' \
+  build 2>&1 | tail -30
+
+./Scripts/install-core.sh --release Nestopia
+./Scripts/verify-core-installed.sh --release Nestopia
+./Scripts/launch-debug.sh
+```
+
+### Recognition / placard / Achievements window
+
+| Test | Expected result | Evidence to capture |
+| --- | --- | --- |
+| Known RA game/hash on supported native core | Boot placard appears with game title, hardcore/softcore mode, achievement count, and points. Achievements window populates. | Screenshot/video of boot placard and Achievements window. |
+| Unknown/no-set hash on supported native core | Failure placard and Achievements window clearly say no achievement set was found for this game/hash. | Screenshot after PR #521 lands. |
+| Expired/invalid token | Failure placard/window reports sign-in failure instead of waiting forever. | Screenshot; note whether Preferences still shows signed-in state. |
+
+### Rich Presence
+
+Upstream behavior: `rc_client_do_frame()` sends rich presence after the first update delay, then periodically while the session is active. `rc_client_idle()` should maintain routine communication while paused, but that pause path is not implemented yet.
+
+| Test | Expected result | Status |
+| --- | --- | --- |
+| Launch known RA game with rich presence and wait at least 30 seconds while playing | RA profile/activity shows current game/rich presence for OpenEmu-Silicon session. | Not yet verified. |
+| Continue playing for several minutes | Rich presence continues updating periodically. | Not yet verified. |
+| Hardcore mode enabled | No OpenEmu UI exists to disable rich presence; behavior should remain active. | Not yet verified. |
+| Pause emulation for >60 seconds | Known gap: `rc_client_idle()` while paused is not implemented, so active-player/rich-presence continuity may degrade. | Follow-up required. |
+
+### Leaderboards
+
+| Test | Expected result | Status |
+| --- | --- | --- |
+| Start a known leaderboard attempt | Native leaderboard started toast appears. | Not yet verified after PR #519 beyond Nestopia smoke test. |
+| During attempt | Tracker chip appears and updates without jitter or stale values. | Nestopia/SMB smoke test confirmed tracker appears. Needs broader evidence. |
+| Fail attempt | Tracker clears and failure toast appears. | Not yet fully verified. |
+| Submit attempt | Tracker clears and submitted/result toast appears. | Nestopia/SMB smoke test confirmed result clears tracker. Needs screenshot/video. |
+| Hardcore mode enabled | No OpenEmu UI exists to disable leaderboards; events should remain active. | Not yet verified. |
+
+### Challenge / progress / mastery UI
+
+| Test | Expected result | Status |
+| --- | --- | --- |
+| Trigger challenge indicator | Challenge chip appears, then hides when condition fails/completes. | Nestopia/SMB smoke test confirmed show/hide once. Needs evidence. |
+| Trigger measured achievement progress | Progress chip appears/updates/hides with rcheevos measured progress text. | Not yet verified. |
+| Complete/master game or subset | Completion/mastery toast appears with correct softcore/hardcore verb. | Not yet verified. |
+
+### Offline / reconnect / server errors
+
+Upstream behavior: transient non-client-initiated request failures can be queued and retried if the server callback reports `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR`. OpenEmu's shared transport now does this for `NSURLSession` errors, missing data, and non-HTTP responses.
+
+| Test | Expected result | Status |
+| --- | --- | --- |
+| Disconnect network during active RA session | Offline/disconnected toast appears. | UI implemented; not yet verified. |
+| Unlock achievement while offline | rcheevos queues the unlock for retry rather than losing it. | Not yet verified. |
+| Reconnect network before closing game | Reconnected/sync toast appears and unlock appears on RA profile. | Not yet verified. |
+| Close game while offline after queued unlock | Queue/cache should be session-scoped and purged on close if required by RA compliance. Need confirm actual rcheevos behavior. | Not yet verified; potential reviewer question. |
+| Force server error response | Server-error toast appears with API/error context; non-retryable server errors are not silently queued. | Not yet verified. |
+
+### Pause / idle follow-up
+
+The upstream guide explicitly calls for:
+
+- `rc_client_idle()` while emulation is paused and `rc_client_do_frame()` is not running.
+- `rc_client_can_pause()` immediately before honoring pause in hardcore mode.
+
+Current status: documented gap. This should be a focused follow-up PR because it needs host/core/helper API design and user-facing messaging if pause is denied.
+
+### Save-state progress follow-up
+
+The upstream guide strongly recommends serializing RA runtime progress into save states:
+
+- `rc_client_progress_size()`
+- `rc_client_serialize_progress_sized()`
+- `rc_client_deserialize_progress_sized()`
+
+Current status: documented P2 gap. Hardcore load-state blocking is implemented; softcore save-state correctness still relies on `rc_client_reset()` after loads.
+
+### Media-change follow-up
+
+The upstream guide calls for `rc_client_begin_change_media()` when switching discs/disks.
+
+Current status: no native call found. This matters most for Mednafen PSX/PCE-CD/Saturn and any other multi-disc/disk native RA systems. Needs design before implementation because OpenEmu's disc-change pathways differ by core/system.
+
+## Submission evidence to gather
+
+- Boot placard screenshot for recognized game.
+- Achievements window screenshot showing locked/unlocked achievements, points, badges, and progress where available.
+- Unrecognized/no-set hash screenshot after PR #521.
+- Challenge/progress/leaderboard tracker screenshots or short video.
+- Unlock banner with sound confirmed.
+- Offline/reconnect test notes, including whether queued unlock synced or was purged on close.
+- User-Agent sample from transport logs or packet capture:
+  - `OpenEmu-Silicon/<version> (macOS <version>) rcheevos/<version>`
+- Explicit RA-side approval question: what client registration step is required so OpenEmu-Silicon is no longer treated as an unknown emulator for hardcore credit?
+
+## Follow-up implementation candidates
+
+1. Pause/idle compliance: `rc_client_idle()` while paused and `rc_client_can_pause()` guard for hardcore pause attempts.
+2. Rich Presence/leaderboard/offline manual verification evidence pass.
+3. Save-state progress serialization for softcore correctness.
+4. Media-change handling for multi-disc/disk systems.
+5. Achievements window live-state polish for active challenge/progress state.


### PR DESCRIPTION
## What does this PR do?

Starts the #438 verification/submission-evidence documentation pass and maps the remaining work against the official rcheevos `rc_client` integration guide:

https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration

This PR adds `docs/retroachievements-p1-verification.md`, covering:

- upstream `rc_client` integration checklist mapped to current OpenEmu-Silicon status
- recognized/unrecognized game feedback verification
- Rich Presence verification
- leaderboard verification
- challenge/progress/mastery UI verification
- offline/reconnect/server-error verification
- known follow-up gaps: pause/idle, save-state progress serialization, media changes, per-game `rc_client_is_processing_required()` policy
- submission evidence to gather before RA resubmission

It also links the new verification doc from `docs/retroachievements-implementation-guide.md` and records the upstream recommendation around `rc_client_is_processing_required()`.

## What did you test?

Docs-only change:

- `git diff --check`
- Reviewed the current official `rc_client` integration guide against repo docs and current native RA implementation surfaces.

## Which cores or systems are affected?

No runtime changes. Documentation covers all native RA-enabled cores:

- Nestopia
- FCEU
- BSNES
- SNES9x
- Gambatte
- GenesisPlus
- mGBA
- Mupen64Plus
- Mednafen

## Linked issues

Related to #438
Related to #318

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 522 --repo nickybmon/OpenEmu-Silicon

git diff main...HEAD -- docs/retroachievements-p1-verification.md docs/retroachievements-implementation-guide.md
```

No build required; docs-only.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build not required: docs-only change
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include appropriate documentation format
