### PR TITLE
fix: add RetroAchievements pause idle compliance

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -257,6 +257,20 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
                                                       userInfo:payload];
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     delete emulator;

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -284,6 +284,20 @@ static __weak FCEUGameCore *_current;
                                                       userInfo:payload];
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -286,6 +286,20 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
                                                       userInfo:payload];
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -341,6 +341,20 @@ static __weak GenPlusGameCore *_current;
 	return self;
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -3358,6 +3358,20 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
     return self;
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     for(unsigned i = 0; i < 13; i++)

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -331,6 +331,20 @@ static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     return self;
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     SetStateCallback(NULL, NULL);

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -308,6 +308,20 @@ static __weak NESGameCore *_current;
                                                       userInfo:payload];
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     delete[] _soundBuffer;

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -602,6 +602,12 @@ OE_EXPORTED_CLASS
 @property(nonatomic, getter=isEmulationPaused) BOOL pauseEmulation;
 - (void)setPauseEmulation:(BOOL)pauseEmulation NS_REQUIRES_SUPER;
 
+/// Called while emulation is paused so RetroAchievements can continue routine server communication.
+- (void)retroAchievementsIdle;
+
+/// Returns whether a RetroAchievements hardcore session may pause right now.
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *_Nullable)framesRemaining;
+
 /// When didExecute is called, will be the next wakeup time.
 @property (nonatomic, readonly) NSTimeInterval nextFrameTime;
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -646,6 +646,18 @@ static Class GameCoreClass = Nil;
     return _rate == 0;
 }
 
+- (void)retroAchievementsIdle
+{
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (framesRemaining != NULL) {
+        *framesRemaining = 0;
+    }
+    return YES;
+}
+
 - (void)fastForwardAtSpeed:(CGFloat)fastForwardSpeed;
 {
     if (self.hardcoreEnabled) return;

--- a/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
@@ -76,6 +76,24 @@
                    @"OEGameCore.hardcoreEnabled default must remain OFF; the helper sets it true at session start.");
 }
 
+- (void)testRetroAchievementsPauseDefaultsAllowPause
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    uint32_t framesRemaining = UINT32_MAX;
+
+    XCTAssertTrue([core canPauseRetroAchievementsHardcoreWithFramesRemaining:&framesRemaining],
+                  @"Base OEGameCore must allow pause by default so non-RA cores keep existing pause behavior.");
+    XCTAssertEqual(framesRemaining, 0u,
+                   @"Base OEGameCore should report no retry delay when pause is allowed by default.");
+}
+
+- (void)testRetroAchievementsIdleDefaultIsNoOp
+{
+    OEGameCore *core = [[OEGameCore alloc] init];
+    XCTAssertNoThrow([core retroAchievementsIdle],
+                     @"Base OEGameCore idle hook must be safe for non-RA cores.");
+}
+
 #pragma mark - fastForward:
 
 - (void)testFastForwardBlockedWhenHardcoreEnabled

--- a/OpenEmu/GameWindowController.swift
+++ b/OpenEmu/GameWindowController.swift
@@ -667,7 +667,7 @@ extension GameWindowController: NSWindowDelegate {
         windowedFrame = window.frame
         
         resumePlayingAfterFullScreenTransition = !gameDocument.isEmulationPaused
-        gameDocument.isEmulationPaused = true
+        gameDocument.requestEmulationPauseRespectingRetroAchievementsHardcore()
         
         // move the screenshot window to the same screen as the game window
         // otherwise it will be shown in the system full-screen animation
@@ -777,7 +777,7 @@ extension GameWindowController: NSWindowDelegate {
         fullScreenStatus = .exiting
         resumePlayingAfterFullScreenTransition = !gameDocument.isEmulationPaused
         
-        gameDocument.isEmulationPaused = true
+        gameDocument.requestEmulationPauseRespectingRetroAchievementsHardcore()
         
         let gameViewController = gameDocument.gameViewController
         gameViewController?.controlsWindow.canShow = false

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -213,7 +213,7 @@ final class MainWindowController: NSWindowController {
             shouldExitFullScreenWhenGameFinishes = false
             shouldUndockGameWindowOnFullScreenExit = true
         } else {
-            gameDocument?.isEmulationPaused = true
+            gameDocument?.requestEmulationPauseRespectingRetroAchievementsHardcore()
             currentContentController = nil
             gameDocument?.gameWindowController = nil
             
@@ -444,7 +444,7 @@ extension MainWindowController: NSWindowDelegate {
     func windowWillEnterFullScreen(_ notification: Notification) {
         if let gameDocument = gameDocument, gameDocument.gameWindowController == self {
             resumePlayingAfterFullScreenTransition = !gameDocument.isEmulationPaused
-            gameDocument.isEmulationPaused = true
+            gameDocument.requestEmulationPauseRespectingRetroAchievementsHardcore()
         }
     }
     
@@ -464,7 +464,7 @@ extension MainWindowController: NSWindowDelegate {
     func windowWillExitFullScreen(_ notification: Notification) {
         if let gameDocument = gameDocument {
             resumePlayingAfterFullScreenTransition = !gameDocument.isEmulationPaused
-            gameDocument.isEmulationPaused = true
+            gameDocument.requestEmulationPauseRespectingRetroAchievementsHardcore()
         }
     }
     

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1041,8 +1041,11 @@ final class OEGameDocument: NSDocument {
     @objc private func windowDidResignMain(_ notification: Notification) {
         let backgroundPause = UserDefaults.standard.bool(forKey: OEBackgroundPauseKey)
         if backgroundPause && emulationStatus == .playing {
-            isEmulationPaused = true
-            pausedByGoingToBackground = true
+            requestEmulationPauseRespectingRetroAchievementsHardcore { [weak self] paused in
+                if paused {
+                    self?.pausedByGoingToBackground = true
+                }
+            }
         }
     }
     
@@ -1069,35 +1072,53 @@ final class OEGameDocument: NSDocument {
     
     @objc private func didReceiveLowBatteryWarning(_ notification: Notification) {
         let isRunning = !isEmulationPaused
-        isEmulationPaused = true
-        
-        let devHandler = notification.object as? OEDeviceHandler
-        let message = String(format: NSLocalizedString("The battery in device number %lu, %@, is low. Please charge or replace the battery.", comment: "Low battery alert detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
-        let alert = OEAlert()
-        alert.messageText = NSLocalizedString("Low Controller Battery", comment: "Device battery level is low.")
-        alert.informativeText = message
-        alert.defaultButtonTitle = NSLocalizedString("Resume", comment: "")
-        alert.runModal()
-        
+        let showAlert = { [weak self] in
+            guard let self else { return }
+            let devHandler = notification.object as? OEDeviceHandler
+            let message = String(format: NSLocalizedString("The battery in device number %lu, %@, is low. Please charge or replace the battery.", comment: "Low battery alert detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
+            let alert = OEAlert()
+            alert.messageText = NSLocalizedString("Low Controller Battery", comment: "Device battery level is low.")
+            alert.informativeText = message
+            alert.defaultButtonTitle = NSLocalizedString("Resume", comment: "")
+            alert.runModal()
+
+            if isRunning && self.isEmulationPaused {
+                self.isEmulationPaused = false
+            }
+        }
+
         if isRunning {
-            isEmulationPaused = false
+            requestEmulationPauseRespectingRetroAchievementsHardcore { _ in
+                showAlert()
+            }
+        } else {
+            showAlert()
         }
     }
     
     @objc private func deviceDidDisconnect(_ notification: Notification) {
         let isRunning = !isEmulationPaused
-        isEmulationPaused = true
-        
-        let devHandler = notification.userInfo?[OEDeviceManagerDeviceHandlerUserInfoKey] as? OEDeviceHandler
-        let message = String(format: NSLocalizedString("Device number %lu, %@, has disconnected.", comment: "Device disconnection detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
-        let alert = OEAlert()
-        alert.messageText = NSLocalizedString("Device Disconnected", comment: "A controller device has disconnected.")
-        alert.informativeText = message
-        alert.defaultButtonTitle = NSLocalizedString("Resume", comment: "Resume game after battery warning button label")
-        alert.runModal()
-        
+        let showAlert = { [weak self] in
+            guard let self else { return }
+            let devHandler = notification.userInfo?[OEDeviceManagerDeviceHandlerUserInfoKey] as? OEDeviceHandler
+            let message = String(format: NSLocalizedString("Device number %lu, %@, has disconnected.", comment: "Device disconnection detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
+            let alert = OEAlert()
+            alert.messageText = NSLocalizedString("Device Disconnected", comment: "A controller device has disconnected.")
+            alert.informativeText = message
+            alert.defaultButtonTitle = NSLocalizedString("Resume", comment: "Resume game after battery warning button label")
+            alert.runModal()
+
+            if isRunning && self.isEmulationPaused {
+                self.isEmulationPaused = false
+            }
+        }
+
         if isRunning {
-            isEmulationPaused = false
+            requestEmulationPauseRespectingRetroAchievementsHardcore { _ in
+                showAlert()
+            }
+        } else {
+            showAlert()
         }
     }
     
@@ -1135,6 +1156,8 @@ final class OEGameDocument: NSDocument {
         gameViewController.showHardcoreNotification(isHardcoreModeEnabled)
     }
     
+    private var retroAchievementsHardcorePausePreflightSatisfied = false
+
     var isEmulationPaused: Bool {
         get {
             return emulationStatus != .playing
@@ -1147,6 +1170,10 @@ final class OEGameDocument: NSDocument {
                 return
             }
             if pauseEmulation {
+                if emulationStatus == .playing && isHardcoreModeEnabled && !retroAchievementsHardcorePausePreflightSatisfied {
+                    showRetroAchievementsPauseBlockedToast(framesRemaining: 0)
+                    return
+                }
                 SentryService.addBreadcrumb(message: "Emulation paused", category: "emulation")
                 enableOSSleep()
                 emulationStatus = .paused
@@ -1178,7 +1205,59 @@ final class OEGameDocument: NSDocument {
     }
     
     @objc func toggleEmulationPaused(_ sender: Any?) {
-        isEmulationPaused.toggle()
+        if isEmulationPaused {
+            isEmulationPaused = false
+            return
+        }
+
+        requestEmulationPauseRespectingRetroAchievementsHardcore()
+    }
+
+    func requestEmulationPauseRespectingRetroAchievementsHardcore(showBlockedToast: Bool = true, completion: ((Bool) -> Void)? = nil) {
+        guard emulationStatus == .playing else {
+            completion?(false)
+            return
+        }
+
+        guard isHardcoreModeEnabled else {
+            isEmulationPaused = true
+            completion?(true)
+            return
+        }
+
+        guard let gameCoreManager else {
+            completion?(false)
+            return
+        }
+
+        gameCoreManager.canPauseRetroAchievementsHardcore { [weak self] allowed, framesRemaining in
+            guard let self else { return }
+            guard self.emulationStatus == .playing else {
+                completion?(false)
+                return
+            }
+
+            if allowed {
+                self.retroAchievementsHardcorePausePreflightSatisfied = true
+                defer { self.retroAchievementsHardcorePausePreflightSatisfied = false }
+                self.isEmulationPaused = true
+                completion?(self.isEmulationPaused)
+            } else {
+                if showBlockedToast {
+                    self.showRetroAchievementsPauseBlockedToast(framesRemaining: framesRemaining)
+                }
+                completion?(false)
+            }
+        }
+    }
+
+    private func showRetroAchievementsPauseBlockedToast(framesRemaining: UInt32) {
+        let seconds = max(1, Int(ceil(Double(framesRemaining) / 60.0)))
+        gameViewController?.showRetroAchievementsEventToast(
+            title: NSLocalizedString("Pause Blocked in Hardcore", comment: "RetroAchievements pause blocked title"),
+            subtitle: String(format: NSLocalizedString("Try again in about %d seconds.", comment: "RetroAchievements pause blocked subtitle"), seconds),
+            symbolName: "pause.slash"
+        )
     }
     
     @objc func resetEmulation(_ sender: Any?) {
@@ -1200,47 +1279,58 @@ final class OEGameDocument: NSDocument {
             && OECredentialStore.shared.get(.retroAchievementsToken) != nil
 
         if willEnforce && HardcoreModePolicy.requiresResetWhenEnabling {
-            isEmulationPaused = true
-            let alert = OEAlert()
-            alert.messageText = NSLocalizedString("Switching to hardcore mode requires restarting the game.", comment: "")
-            alert.informativeText = NSLocalizedString("Save states, rewind, frame advance, and cheats will be disabled.", comment: "")
-            alert.defaultButtonTitle = NSLocalizedString("Restart Game", comment: "")
-            alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
-
-            let handleResponse: (NSApplication.ModalResponse) -> Void = { [weak self] response in
-                guard let self else { return }
-                if response == .alertFirstButtonReturn {
-                    // Flush active cheats from the core before engaging hardcore.
-                    // setHardcoreEnabled(true) blocks the document's setCheat guard,
-                    // but core cheat lists persist across a reset — they must be
-                    // cleared first so the restarted session is clean (#447).
-                    self.cheats.filter(\.isEnabled).forEach {
-                        self.gameCoreManager?.setCheat($0.code, withType: $0.type, enabled: false)
-                    }
-                    self.gameCoreManager?.setHardcoreEnabled(true)
-                    self.gameCoreManager?.resetEmulation { [weak self] in
-                        self?.isEmulationPaused = false
-                    }
-                    self.gameViewController.showHardcoreNotification(true)
-                } else {
-                    // User cancelled — revert the preference so UI and state agree.
-                    // Post the change so the prefs checkbox can resync (#446); if we
-                    // only write UserDefaults, the imperatively-set checkbox stays
-                    // visually checked until the pane is rebuilt.
-                    UserDefaults.standard.set(false, forKey: RAHardcoreEnabledKey)
-                    NotificationCenter.default.post(
-                        name: .OERAHardcoreDidChange,
-                        object: nil,
-                        userInfo: [OEHardcoreEnabledKey: false]
-                    )
-                    self.isEmulationPaused = false
-                }
+            let revertHardcorePreference = {
+                UserDefaults.standard.set(false, forKey: RAHardcoreEnabledKey)
+                NotificationCenter.default.post(
+                    name: .OERAHardcoreDidChange,
+                    object: nil,
+                    userInfo: [OEHardcoreEnabledKey: false]
+                )
             }
 
-            if let win = gameWindowController?.window {
-                alert.beginSheetModal(for: win, completionHandler: handleResponse)
-            } else {
-                handleResponse(alert.runModal())
+            requestEmulationPauseRespectingRetroAchievementsHardcore { [weak self] paused in
+                guard let self else { return }
+                guard paused else {
+                    revertHardcorePreference()
+                    return
+                }
+
+                let alert = OEAlert()
+                alert.messageText = NSLocalizedString("Switching to hardcore mode requires restarting the game.", comment: "")
+                alert.informativeText = NSLocalizedString("Save states, rewind, frame advance, and cheats will be disabled.", comment: "")
+                alert.defaultButtonTitle = NSLocalizedString("Restart Game", comment: "")
+                alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
+
+                let handleResponse: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+                    guard let self else { return }
+                    if response == .alertFirstButtonReturn {
+                        // Flush active cheats from the core before engaging hardcore.
+                        // setHardcoreEnabled(true) blocks the document's setCheat guard,
+                        // but core cheat lists persist across a reset — they must be
+                        // cleared first so the restarted session is clean (#447).
+                        self.cheats.filter(\.isEnabled).forEach {
+                            self.gameCoreManager?.setCheat($0.code, withType: $0.type, enabled: false)
+                        }
+                        self.gameCoreManager?.setHardcoreEnabled(true)
+                        self.gameCoreManager?.resetEmulation { [weak self] in
+                            self?.isEmulationPaused = false
+                        }
+                        self.gameViewController.showHardcoreNotification(true)
+                    } else {
+                        // User cancelled — revert the preference so UI and state agree.
+                        // Post the change so the prefs checkbox can resync (#446); if we
+                        // only write UserDefaults, the imperatively-set checkbox stays
+                        // visually checked until the pane is rebuilt.
+                        revertHardcorePreference()
+                        self.isEmulationPaused = false
+                    }
+                }
+
+                if let win = self.gameWindowController?.window {
+                    alert.beginSheetModal(for: win, completionHandler: handleResponse)
+                } else {
+                    handleResponse(alert.runModal())
+                }
             }
         } else if !enabled && HardcoreModePolicy.requiresResetWhenDisabling {
             // Reserved branch for future spec changes — currently unreachable.
@@ -1286,7 +1376,7 @@ final class OEGameDocument: NSDocument {
             isEmulationPaused = true
         }
         
-        return pauseNeeded
+        return pauseNeeded && isEmulationPaused
     }
     
     // MARK: - Actions
@@ -1333,6 +1423,7 @@ final class OEGameDocument: NSDocument {
         }
         
         isEmulationPaused = true
+        guard isEmulationPaused else { return }
         
         let alert = OEAlert()
         alert.messageText = NSLocalizedString("If you change the core you current progress will be lost and save states will not work anymore.", comment: "")

--- a/OpenEmuKit/Source/GameCoreManager.swift
+++ b/OpenEmuKit/Source/GameCoreManager.swift
@@ -84,6 +84,18 @@ extension GameCoreManager: OEGameCoreHelper {
     public func setPauseEmulation(_ pauseEmulation: Bool) {
         gameCoreHelper?.setPauseEmulation(pauseEmulation)
     }
+
+    public func canPauseRetroAchievementsHardcore(completionHandler block: @escaping (Bool, UInt32) -> Void) {
+        guard let gameCoreHelper else {
+            block(true, 0)
+            return
+        }
+        gameCoreHelper.canPauseRetroAchievementsHardcore { allowed, framesRemaining in
+            DispatchQueue.main.async {
+                block(allowed, framesRemaining)
+            }
+        }
+    }
     
     public func setEffectsMode(_ mode: OEGameCoreEffectsMode) {
         gameCoreHelper?.setEffectsMode(mode)

--- a/OpenEmuKit/Source/OEGameCoreHelper.swift
+++ b/OpenEmuKit/Source/OEGameCoreHelper.swift
@@ -50,6 +50,9 @@ import AudioToolbox
      * @param pauseEmulation Specify @c true to pause the core.
      */
     func setPauseEmulation(_ pauseEmulation: Bool)
+
+    /// Returns whether a RetroAchievements hardcore session may pause right now.
+    func canPauseRetroAchievementsHardcore(completionHandler block: @escaping (Bool, UInt32) -> Void)
     
     /** Specifies how and when shader effects are rendered.
      *

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -102,6 +102,7 @@ extension OSLog {
     var _achievementObserver: Any?
     var _raSessionObserver: Any?
     var _raEventObserver: Any?
+    var _raIdleTimer: DispatchSourceTimer?
 
     // frame rate debugging
     var previous    = CFTimeInterval()
@@ -406,6 +407,38 @@ extension OSLog {
         gameCore.perform {
             self.gameCore.setPauseEmulation(paused)
         }
+        if paused {
+            startRetroAchievementsIdleTimer()
+        } else {
+            stopRetroAchievementsIdleTimer()
+        }
+    }
+
+    public func canPauseRetroAchievementsHardcore(completionHandler block: @escaping (Bool, UInt32) -> Void) {
+        gameCore.perform {
+            var framesRemaining: UInt32 = 0
+            let allowed = self.gameCore.canPauseRetroAchievementsHardcore(withFramesRemaining: &framesRemaining)
+            block(allowed, framesRemaining)
+        }
+    }
+
+    private func startRetroAchievementsIdleTimer() {
+        stopRetroAchievementsIdleTimer()
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+        timer.schedule(deadline: .now(), repeating: 1.0)
+        timer.setEventHandler { [weak self] in
+            guard let self, let gameCore = self.gameCore else { return }
+            gameCore.perform {
+                gameCore.retroAchievementsIdle()
+            }
+        }
+        _raIdleTimer = timer
+        timer.resume()
+    }
+
+    private func stopRetroAchievementsIdleTimer() {
+        _raIdleTimer?.cancel()
+        _raIdleTimer = nil
     }
     
     public func setEffectsMode(_ mode: OEGameCoreEffectsMode) {
@@ -498,6 +531,8 @@ extension OSLog {
     
     public func stopEmulation(completionHandler handler: @escaping () -> Void) {
         guard let gameCore = gameCore else { return }
+
+        stopRetroAchievementsIdleTimer()
 
         if let observer = _achievementObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -168,6 +168,20 @@ static __weak SNESGameCore *_current;
     return self;
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     S9xSetSamplesAvailableCallback(NULL, NULL);

--- a/docs/retroachievements-implementation-guide.md
+++ b/docs/retroachievements-implementation-guide.md
@@ -176,9 +176,9 @@ The upstream `rc_client` integration guide says fast-forward is allowed in hardc
 
 ### Pause and idle behavior
 
-When emulation is paused, stop calling `rc_client_do_frame()` and call `rc_client_idle()` at least once per second instead. This keeps routine server communication alive while gameplay is stopped.
+When emulation is paused, stop calling `rc_client_do_frame()` and call `rc_client_idle()` at least once per second instead. This keeps routine server communication alive while gameplay is stopped. OpenEmu-Silicon implements this through a helper-side idle timer that calls each native RA core's `retroAchievementsIdle` hook while paused.
 
-In hardcore mode, call `rc_client_can_pause()` immediately before honoring a user pause request. If it returns false, do not pause and show a short user-facing message. This prevents pause-spam from becoming a slow-motion workaround.
+In hardcore mode, call `rc_client_can_pause()` immediately before honoring a user pause request. If it returns false, do not pause and show a short user-facing message. This prevents pause-spam from becoming a slow-motion workaround. OpenEmu-Silicon implements this for user-initiated pause toggles through `canPauseRetroAchievementsHardcoreWithFramesRemaining:`.
 
 ### Automatically disabling hardcore when no RA processing is required
 
@@ -205,8 +205,8 @@ If a save state does not contain RA progress data, call `rc_client_deserialize_p
 
 - [ ] `rc_client_set_allow_background_memory_reads(_rcClient, 0)` called before logging setup
 - [ ] `rc_client_do_frame()` called every emulated frame, including frames not displayed during frame skip or performance catch-up
-- [ ] `rc_client_idle()` called while emulation is paused and `do_frame` is not running
-- [ ] `rc_client_can_pause()` checked before allowing a user pause in hardcore mode
+- [x] `rc_client_idle()` called while emulation is paused and `do_frame` is not running
+- [x] `rc_client_can_pause()` checked before allowing a user pause in hardcore mode
 - [ ] `rc_client_reset()` called on emulation reset and after a hardcore reset request
 - [ ] `RC_CLIENT_EVENT_RESET` handled instead of silently ignored
 - [ ] Save states serialize/deserialize RA progress for softcore correctness, or explicitly document why the core does not support save-state progress yet

--- a/docs/retroachievements-p1-verification.md
+++ b/docs/retroachievements-p1-verification.md
@@ -37,7 +37,7 @@ Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked
 | Multiple media changes | Gap / follow-up | No current native-core call to `rc_client_begin_change_media()` was found. Needs design for disc/disk swap systems, especially Mednafen PSX/PCE-CD/Saturn. |
 | Hardcore default / mode switching | Implemented | User-facing hardcore preference defaults on for signed-in RA users; softcore→hardcore reset path is implemented and documented in P0 audit. |
 | Disable hardcore when no RA processing required | Not implemented / product decision needed | Upstream recommends optionally disabling hardcore for games with no RA functionality via `rc_client_is_processing_required()`. OpenEmu currently scopes enforcement by core/system support and token, not by per-game processing state. |
-| Pause / idle | Gap / compliance-adjacent | `rc_client_idle()` while paused and `rc_client_can_pause()` before hardcore pause are documented but not implemented. |
+| Pause / idle | Implemented; verification needed | `rc_client_idle()` is called once per second while the helper is paused, and user-initiated hardcore pause attempts call `rc_client_can_pause()` before pausing. Needs manual verification with a real RA session. |
 | Server errors | Implemented; verification needed | PR #519 surfaces `RC_CLIENT_EVENT_SERVER_ERROR`, disconnected, and reconnected events. Transport marks transient network failures retryable. |
 | Offline retry queue | Implementation delegated to `rc_client`; verification needed | Shared transport uses `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` for transient client/network failures, enabling rcheevos retry behavior. Must verify unlock queue/sync/purge behavior manually. |
 | Rich Presence | Expected via `rc_client_do_frame()`; verification needed | Upstream says `rc_client_do_frame()` sends rich presence updates after initial delay and periodically thereafter. No OpenEmu toggle exists to disable it. Must verify on RA profile/API. |
@@ -89,7 +89,7 @@ Upstream behavior: `rc_client_do_frame()` sends rich presence after the first up
 | Launch known RA game with rich presence and wait at least 30 seconds while playing | RA profile/activity shows current game/rich presence for OpenEmu-Silicon session. | Not yet verified. |
 | Continue playing for several minutes | Rich presence continues updating periodically. | Not yet verified. |
 | Hardcore mode enabled | No OpenEmu UI exists to disable rich presence; behavior should remain active. | Not yet verified. |
-| Pause emulation for >60 seconds | Known gap: `rc_client_idle()` while paused is not implemented, so active-player/rich-presence continuity may degrade. | Follow-up required. |
+| Pause emulation for >60 seconds | `rc_client_idle()` should keep routine server communication alive while paused. | Not yet verified after implementation. |
 
 ### Leaderboards
 
@@ -121,14 +121,23 @@ Upstream behavior: transient non-client-initiated request failures can be queued
 | Close game while offline after queued unlock | Queue/cache should be session-scoped and purged on close if required by RA compliance. Need confirm actual rcheevos behavior. | Not yet verified; potential reviewer question. |
 | Force server error response | Server-error toast appears with API/error context; non-retryable server errors are not silently queued. | Not yet verified. |
 
-### Pause / idle follow-up
+### Pause / idle verification
 
 The upstream guide explicitly calls for:
 
 - `rc_client_idle()` while emulation is paused and `rc_client_do_frame()` is not running.
 - `rc_client_can_pause()` immediately before honoring pause in hardcore mode.
 
-Current status: documented gap. This should be a focused follow-up PR because it needs host/core/helper API design and user-facing messaging if pause is denied.
+Current status: implemented for native RA cores. The helper starts a once-per-second RA idle timer while paused and stops it on resume/stop. User-initiated pause attempts in hardcore ask the active core whether pause is allowed before changing host pause state; denied pauses show a short in-game message.
+
+Manual verification still needed:
+
+| Test | Expected result | Status |
+| --- | --- | --- |
+| Softcore pause | Pause/resume still works normally. | Not yet verified. |
+| Hardcore pause after enough gameplay frames | Pause succeeds. | Not yet verified. |
+| Hardcore pause spam | Some pause attempts are denied with a user-facing message. | Not yet verified. |
+| Pause for >60 seconds in an RA session | Routine server communication/rich presence remains active. | Not yet verified. |
 
 ### Save-state progress follow-up
 
@@ -160,8 +169,7 @@ Current status: no native call found. This matters most for Mednafen PSX/PCE-CD/
 
 ## Follow-up implementation candidates
 
-1. Pause/idle compliance: `rc_client_idle()` while paused and `rc_client_can_pause()` guard for hardcore pause attempts.
-2. Rich Presence/leaderboard/offline manual verification evidence pass.
-3. Save-state progress serialization for softcore correctness.
-4. Media-change handling for multi-disc/disk systems.
-5. Achievements window live-state polish for active challenge/progress state.
+1. Rich Presence/leaderboard/offline manual verification evidence pass.
+2. Save-state progress serialization for softcore correctness.
+3. Media-change handling for multi-disc/disk systems.
+4. Achievements window live-state polish for active challenge/progress state.

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -326,6 +326,20 @@ static struct mLogger logger = { .log = _log };
 	return self;
 }
 
+
+- (void)retroAchievementsIdle
+{
+    if (_rcClient) {
+        rc_client_idle(_rcClient);
+    }
+}
+
+- (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (!_rcClient) { return YES; }
+    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+}
+
 - (void)dealloc
 {
     mCoreConfigDeinit(&core->config);


### PR DESCRIPTION
## What does this PR do?

Continues #438 by closing the native `rc_client` pause/idle compliance gap called out by the official rcheevos integration guide.

This PR:
- Adds default `OEGameCore` hooks for RetroAchievements idle and hardcore pause checks.
- Implements those hooks in all 9 native RA cores with:
  - `rc_client_idle(_rcClient)` while paused
  - `rc_client_can_pause(_rcClient, &framesRemaining)` before user-initiated hardcore pause
- Starts a helper-side once-per-second RA idle timer while emulation is paused, and stops it on resume/stop.
- Changes user-initiated pause toggles in hardcore to ask the active core before pausing.
- Shows a short in-game message when rcheevos denies a hardcore pause attempt.
- Updates `docs/retroachievements-implementation-guide.md` and `docs/retroachievements-p1-verification.md`.

This is intended as the last focused native P1 implementation gap before doing the remaining manual evidence pass for Rich Presence, leaderboards, and offline queueing.

## What did you test?

- `git diff --check`
- Host app build:
  - `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- OpenEmuBase tests:
  - `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmuBase -configuration Debug -destination 'platform=macOS,arch=arm64' test`
  - 39 tests passed.
- Release builds passed for all modified native RA core schemes:
  - `OpenEmu + Nestopia`
  - `OpenEmu + FCEU`
  - `OpenEmu + BSNES`
  - `OpenEmu + SNES9x`
  - `OpenEmu + Gambatte`
  - `OpenEmu + GenesisPlus`
  - `OpenEmu + mGBA`
  - `OpenEmu + Mupen64Plus`
  - `OpenEmu + Mednafen`

## Which cores or systems are affected?

Host app / OpenEmuBase / OpenEmuKit helper plumbing plus all native RA-enabled cores:

- Nestopia
- FCEU
- BSNES
- SNES9x
- Gambatte
- GenesisPlus
- mGBA
- Mupen64Plus
- Mednafen

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 523 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -50

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmuBase \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  test 2>&1 | tail -80
```

Build/install a touched RA core before manual testing. Example:

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme 'OpenEmu + Nestopia' \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

./Scripts/install-core.sh --release Nestopia
./Scripts/verify-core-installed.sh --release Nestopia
./Scripts/launch-debug.sh
```

Manual behavior checks:

1. Sign into RetroAchievements.
2. Launch a known RA-supported game on a native RA core.
3. Softcore: confirm pause/resume still works normally.
4. Hardcore: after normal gameplay, confirm user-initiated pause works when rcheevos allows it.
5. Hardcore: attempt pause spam and confirm denied attempts show a short “Pause Blocked in Hardcore” toast instead of pausing.
6. Pause for more than 60 seconds and confirm Rich Presence/active-player behavior remains healthy during pause where RA exposes that state.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes for host app and modified core schemes
- [x] OpenEmuBase tests pass
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

