### PR TITLE
fix: move VGDB sync and RA core scan off main thread; tune AppHang threshold

### DIFF
--- a/OpenEmu/OELibraryDatabase.swift
+++ b/OpenEmu/OELibraryDatabase.swift
@@ -606,8 +606,10 @@ final class OELibraryDatabase: NSObject {
         request.fetchLimit = Self.openVGDBSyncBatchSize
         request.predicate = predicate
         
-        let context = mainThreadContext
-        
+        // Use a private-queue child context so all performAndWait calls in this
+        // loop run on a background queue, not the main thread.
+        let context = makeChildContext()
+
         var count = 0
         context.performAndWait {
             count = (try? context.count(for: request)) ?? 0
@@ -715,6 +717,12 @@ final class OELibraryDatabase: NSObject {
                 count = (try? context.count(for: request)) ?? 0
             }
             
+            // Child-context save only pushes changes into mainThreadContext in memory.
+            // managedObjectContextDidSave triggers writerContext.save() only when
+            // mainThreadContext saves, so we must flush it explicitly after each batch.
+            let mainCtx = mainThreadContext
+            mainCtx.perform { try? mainCtx.save() }
+
             context.perform {
                 for objectID in previousBoxImages {
                     if let item = OEDBImage.object(with: objectID, in: context) {
@@ -722,6 +730,7 @@ final class OELibraryDatabase: NSObject {
                     }
                 }
                 try? context.save()
+                mainCtx.perform { try? mainCtx.save() }
             }
         }
     }

--- a/OpenEmu/PrefCoresController.swift
+++ b/OpenEmu/PrefCoresController.swift
@@ -178,8 +178,16 @@ final class PrefCoresController: NSViewController {
     // MARK: - Data
 
     private func rebuildEntries() {
-        let allRetroArch = scanRetroArchCores()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let allRetroArch = self.scanRetroArchCores()
+            DispatchQueue.main.async { [weak self] in
+                self?.applyEntries(retroArchCores: allRetroArch)
+            }
+        }
+    }
 
+    private func applyEntries(retroArchCores allRetroArch: [RetroArchCore]) {
         var map: [String: (name: String, cores: [CoreDownload])] = [:]
         for core in CoreUpdater.shared.coreList {
             for sysID in core.systemIdentifiers {

--- a/OpenEmu/SentryService.swift
+++ b/OpenEmu/SentryService.swift
@@ -168,9 +168,6 @@ enum SentryService {
             // OS-level diagnostics: hangs the in-process detector misses,
             // CPU exceptions, disk-write spikes. Off by default in the SDK.
             options.enableMetricKit  = true
-            // Default is 2.0s. UI thread blocks shorter than that — like the
-            // OEAlert runModal hang we fixed in 01456229 — slip through silently.
-            options.appHangTimeoutInterval = 1.0
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Three targeted fixes for the Sentry hang storm introduced in build v1.1.2+15.

**PrefCoresController** (OPENEMU-SILICON-60, 10 events, 4 users): `scanRetroArchCores()` was doing synchronous directory listing and file I/O on the main thread, triggered via KVO every time `CoreUpdater.coreList` changed. The scan now runs on a background queue; results are applied back on main via `applyEntries()`.

**OELibraryDatabase** (OPENEMU-SILICON-6D, 6 events, 3 users): `openVGDBSyncThreadMain` used `mainThreadContext` (a `.mainQueueConcurrencyType` context) with `performAndWait`, which forced every database read and save in the VGDB sync loop onto the main thread. Replaced with `makeChildContext()` (`.privateQueueConcurrencyType`). Added explicit `mainThreadContext.perform { save() }` calls after each batch so the `managedObjectContextDidSave → writerContext.save()` cascade to disk still fires (that handler only triggers on `mainThreadContext`).

**SentryService**: removed `appHangTimeoutInterval = 1.0`; reverts to the SDK default of 2.0s. The 1.0s threshold caused 102 new issues in build +15 (vs 3 in +14) — mostly single-event AppHangs across unrelated code paths that aren't actionable. The `OEAlert.runModal` hang that motivated 1.0s was already fixed.

## What did you test?

- `./Scripts/verify.sh --launch` passes (all checks green, no new warnings vs main, no crash reports)
- Opened Preferences → Cores while core updates were pending — no hang, list loads immediately
- Library import with several ROMs — VGDB sync completes and game art/metadata saves correctly

## Which cores or systems are affected?

General app change — no core-specific code touched.

## Did you use AI tools?

Used Claude to draft the fix, reviewed and tested it myself.

## Linked issues

Related to #524

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 525 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

The adversarial reviewer raised two findings against the `makeChildContext()` change:

**Block (fixed): save-to-disk path broken** — `managedObjectContextDidSave` only calls `writerContext.save()` when `context == mainThreadContext`; a child-context save fires its own notification but never matches that check. Fixed by adding explicit `mainThreadContext.perform { mainThreadContext.save() }` calls after each batch's `context.save()`.

**Block (rebutted): async deletion interleave** — Reviewer claimed the `context.perform` deletion block could interleave with the next iteration's `context.performAndWait`. Rebuttal: Core Data serializes all `perform`/`performAndWait` calls on the same private queue in dispatch order. The deletion block is enqueued before the next iteration's fetch block, so they run in order — identical serialization guarantee to the old `mainThreadContext` on its serial main queue.

**Note: AppHang threshold** — Reviewer flagged that removing the 1.0s threshold means any hang between 1s–2s won't be caught. The `OEAlert runModal` fix (01456229) is confirmed in git history. Accepted risk: 2.0s catches all multi-second hangs, and the two reproducible hangs fixed here (PrefCores + VGDB) are well above that threshold.