### PR TITLE
docs: add RetroAchievements submission privacy evidence

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,14 +1,49 @@
 # Privacy Policy
 
-**App:** OpenEmu-Silicon  
-**Last updated:** May 3, 2026  
+**App:** OpenEmu-Silicon
+**Last updated:** May 17, 2026
 **Contact:** [Open an issue](https://github.com/nickybmon/OpenEmu-Silicon/issues)
 
 ---
 
 ## What this app does
 
-OpenEmu-Silicon is a macOS game emulator. It runs locally on your computer. It does not create accounts, collect usage data, or connect to any server except when you explicitly enable the optional Google Drive Save Sync feature described below.
+OpenEmu-Silicon is a macOS game emulator. Most gameplay and library features run locally on your computer.
+
+The app only connects to external services for optional features you choose to use, or for optional crash reporting if you consent:
+
+- **RetroAchievements** — optional achievements, leaderboards, and Rich Presence.
+- **Google Drive Save Sync** — optional save-state and battery-save backup/sync.
+- **Sentry crash reporting** — optional crash and hang diagnostics.
+
+OpenEmu-Silicon does not operate its own account server, telemetry backend, or analytics service.
+
+---
+
+## RetroAchievements (optional)
+
+RetroAchievements support lets you earn achievements, submit leaderboard scores, and show Rich Presence for supported games. It is off unless you sign in from **Preferences → Achievements**.
+
+### What is sent to RetroAchievements
+
+When RetroAchievements is enabled, OpenEmu-Silicon uses the rcheevos client library to communicate with RetroAchievements. Depending on the game and session, this may send:
+
+- Your RetroAchievements login/token request.
+- Game hashes and game-identification requests.
+- Achievement unlock submissions.
+- Leaderboard start/update/submit data.
+- Rich Presence updates.
+- Client and system information such as the OpenEmu-Silicon User-Agent, macOS version, and rcheevos version.
+
+### What is stored locally
+
+After sign-in, the RetroAchievements token is stored locally in your macOS Keychain. The app may also store local preferences such as whether hardcore mode is enabled.
+
+Your RetroAchievements password is not stored by OpenEmu-Silicon.
+
+### Data controlled by RetroAchievements
+
+RetroAchievements is an external service. OpenEmu-Silicon does not operate RetroAchievements servers and does not control RetroAchievements-side retention, account deletion, or profile data. For RetroAchievements account/privacy questions, refer to RetroAchievements directly.
 
 ---
 
@@ -45,13 +80,40 @@ You can disconnect Google Drive at any time from **Preferences → Cloud Sync �
 
 ---
 
+## Sentry crash reporting (optional)
+
+OpenEmu-Silicon can send crash, hang, and performance diagnostic reports to Sentry. This is optional and consent-gated. On first launch, the app asks whether you want to send crash reports.
+
+If you opt in, reports may include:
+
+- App version and build number.
+- macOS/device diagnostic information.
+- Stack traces, crash details, hangs, and performance traces.
+- Breadcrumbs and structured logs related to app behavior.
+- Active game title, system identifier, and core identifier at the time of a crash.
+
+Crash reports do **not** intentionally include:
+
+- Game ROM files.
+- Save state files.
+- Battery save files.
+- Passwords.
+
+Sentry events are sent to Sentry's hosted service. The current project configuration uses Sentry's US ingest endpoint (`ingest.us.sentry.io`). OpenEmu-Silicon does not operate Sentry's servers.
+
+You can decline crash reporting when prompted. If you previously opted in and want to stop future reports, open an issue for help resetting the local crash-reporting preference while a user-facing toggle is being added.
+
+---
+
 ## What this app does not do
 
-- Does not collect analytics or usage data
-- Does not transmit data to any server operated by this project
-- Does not share any data with third parties
-- Does not access your Google Drive files outside the hidden App Data folder
-- Does not identify you by name, email, or device
+- Does not sell your data.
+- Does not include ads.
+- Does not include in-app purchases or subscriptions.
+- Does not operate its own analytics backend.
+- Does not transmit game ROMs to this project.
+- Does not transmit save data to this project.
+- Does not access your Google Drive files outside the hidden App Data folder.
 
 ---
 

--- a/docs/retroachievements-p1-evidence-log.md
+++ b/docs/retroachievements-p1-evidence-log.md
@@ -2,7 +2,7 @@
 
 This document records manual verification evidence for issue #438 before resubmitting OpenEmu-Silicon for RetroAchievements review.
 
-Use this alongside [`retroachievements-p1-verification.md`](retroachievements-p1-verification.md). That file describes what to test; this file records what was actually tested, with enough detail for reviewers to reproduce or audit the result.
+Use this alongside [`retroachievements-p1-verification.md`](retroachievements-p1-verification.md). That file describes what to test; this file records what was actually tested, with enough detail for reviewers to reproduce or audit the result. Legal/privacy/submission notes live in [`retroachievements-submission-evidence.md`](retroachievements-submission-evidence.md).
 
 Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked separately in #360.
 

--- a/docs/retroachievements-p1-verification.md
+++ b/docs/retroachievements-p1-verification.md
@@ -2,6 +2,8 @@
 
 This document is the manual verification and submission-evidence checklist for issue #438. It is based on the upstream [`rc_client` integration guide](https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration) and the current OpenEmu-Silicon native `rc_client` implementation.
 
+Use [`retroachievements-p1-evidence-log.md`](retroachievements-p1-evidence-log.md) for manual runtime evidence and [`retroachievements-submission-evidence.md`](retroachievements-submission-evidence.md) for legal/privacy/submission evidence.
+
 Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked separately in #360 and the libretro architecture docs.
 
 ## Native RA cores in scope

--- a/docs/retroachievements-submission-evidence.md
+++ b/docs/retroachievements-submission-evidence.md
@@ -1,0 +1,139 @@
+# RetroAchievements Submission Evidence
+
+This document gathers the non-gameplay evidence needed for issue #438 and a future RetroAchievements reviewer submission.
+
+For manual runtime evidence, use [`retroachievements-p1-evidence-log.md`](retroachievements-p1-evidence-log.md). For implementation details, use [`retroachievements-implementation-guide.md`](retroachievements-implementation-guide.md).
+
+---
+
+## Current status
+
+| Area | Status | Evidence / next action |
+| --- | --- | --- |
+| User-Agent / client identity | Implemented; RA approval pending | OpenEmu-Silicon sends its own User-Agent and should not spoof another emulator. Ask RA what registration step is required for hardcore credit. |
+| No monetization / IAP | Documented here | OpenEmu-Silicon is a free public GitHub project; no in-app purchases, subscriptions, ads, or paid unlocks are implemented in this repo. |
+| Privacy policy | Updated for RA/Sentry | See [`privacy-policy.md`](privacy-policy.md). |
+| Public availability timeline | Partial / needs reviewer decision | This fork's GitHub repository is public as of 2026-03-20. Local git history begins 2026-01-25. Upstream OpenEmu predates this fork by years. If RA requires this fork itself to be public for 6 months, earliest date from GitHub visibility is 2026-09-20. |
+| Windows toolkit support | N/A | OpenEmu-Silicon is macOS-only. Windows toolkit support is not applicable. |
+| Core/license matrix | Partial / needs broader pass | RA-native core matrix started below. Full shipped-core matrix remains a separate evidence task. |
+| Picodrive non-commercial status | Documented here | `picodrive/COPYING` prohibits commercial redistribution/use. Do not charge for builds that include Picodrive. |
+
+---
+
+## RetroAchievements client identity
+
+OpenEmu-Silicon uses native `rc_client` integrations for supported native cores and routes rcheevos HTTP through the shared OpenEmu transport.
+
+Reviewer-facing points:
+
+- Product identity should be OpenEmu-Silicon, not another emulator.
+- OpenEmu-Silicon should not spoof RetroArch, PPSSPP, or any other approved client.
+- The known reviewer-facing question is:
+
+> What exact client registration or approval step is required so `OpenEmu-Silicon/<version> ... rcheevos/<version>` is recognized for hardcore credit?
+
+Runtime User-Agent sample still needs capture from transport logs or packet capture and should be recorded in [`retroachievements-p1-evidence-log.md`](retroachievements-p1-evidence-log.md).
+
+---
+
+## No monetization / commercialization statement
+
+OpenEmu-Silicon is distributed as a free public GitHub project at <https://github.com/nickybmon/OpenEmu-Silicon>.
+
+No monetization features are implemented in this repository:
+
+- No in-app purchases.
+- No subscriptions.
+- No ads.
+- No paid achievements or paid unlocks.
+- No paid online service operated by this project.
+
+Important licensing constraint:
+
+- Picodrive is non-commercial. `picodrive/COPYING` says redistributions may not be sold or used in a commercial product or activity.
+- Any release that includes Picodrive must remain non-commercial.
+
+---
+
+## Privacy / data handling summary
+
+The privacy policy lives at [`privacy-policy.md`](privacy-policy.md).
+
+RetroAchievements-specific summary:
+
+- RA is optional and only active after the user signs in from Preferences → Achievements.
+- RA credentials are exchanged with RetroAchievements/rcheevos; the app stores the resulting token locally in the macOS Keychain.
+- During RA gameplay, OpenEmu-Silicon/rcheevos may send game hashes, game/session state needed for achievement evaluation, unlock submissions, leaderboard submissions, Rich Presence updates, and client/User-Agent information to RetroAchievements.
+- OpenEmu-Silicon does not operate the RetroAchievements servers and does not control RA-side retention.
+
+Crash reporting summary:
+
+- Sentry crash reporting is optional and consent-gated.
+- If enabled, crash reports may include app version/build, OS/device diagnostics, stack traces, performance/hang diagnostics, and active game/system/core context.
+- The consent prompt states that game files, save data, and passwords are not included.
+
+Project-operated servers:
+
+- This project does not operate a backend server for RA, sync, telemetry, or accounts.
+
+---
+
+## Public availability timeline
+
+Known dates:
+
+| Source | Date | Evidence |
+| --- | --- | --- |
+| Local repository history begins | 2026-01-25 | `git log --reverse` first commit: `5103b813 Step 1: OpenEmu Core and SDKs`. |
+| GitHub repository created/public | 2026-03-20 | `gh repo view nickybmon/OpenEmu-Silicon --json createdAt,visibility` reports `createdAt: 2026-03-20T14:47:23Z`, `visibility: PUBLIC`. |
+| Upstream OpenEmu availability | Predates this fork by years | Upstream project: <https://github.com/OpenEmu/OpenEmu>. |
+
+Reviewer note:
+
+- If RA treats OpenEmu-Silicon as a new emulator/client, the six-month public-availability date may need to be counted from 2026-03-20, making the six-month mark 2026-09-20.
+- If RA allows inherited lineage from OpenEmu plus this fork's public development evidence, explain that lineage explicitly in the submission.
+
+---
+
+## Windows toolkit support
+
+OpenEmu-Silicon is a native macOS app. Windows toolkit support is not applicable.
+
+Suggested reviewer wording:
+
+> OpenEmu-Silicon is macOS-only. The RetroAchievements Windows toolkit requirement is not applicable to this platform; runtime verification is done through the native macOS app and rcheevos integration.
+
+---
+
+## Native RA core/license matrix — initial pass
+
+This table is scoped to native RA-enabled cores first. It is not yet the full shipped-core license matrix requested in #438.
+
+| Core | Systems | License evidence in repo | Notes |
+| --- | --- | --- | --- |
+| Nestopia | NES, FDS | No top-level license file found in `Nestopia/`; `Info.plist` project URL is `https://gitlab.com/jgemu/nestopia` | Needs upstream license confirmation in full matrix. |
+| FCEU | NES / Famicom | No top-level license file found in `FCEU/` | Needs upstream license confirmation in full matrix. |
+| BSNES | SNES | `BSNES/bsnes/LICENSE.txt` | bsnes is GPLv3-only; bundled helper libraries include permissive terms. |
+| SNES9x | SNES | `SNES9x/src/LICENSE` | Snes9x license includes non-commercial language: “Under no circumstances will commercial rights be given.” |
+| Gambatte | GB, GBC | `Gambatte/COPYING` | GPLv2. |
+| GenesisPlus | Genesis, SMS, Game Gear, SG-1000, Sega CD | No top-level license file found in `GenesisPlus/`; third-party dependency licenses are present under `genplusgx_source/` | Needs upstream license confirmation in full matrix. |
+| mGBA | GBA, GB, GBC | `mGBA/LICENSE` | MPL 2.0. |
+| Mupen64Plus | N64 | `Mupen64Plus/mupen64plus-core/LICENSES`, `doc/gpl-license`, `doc/lgpl-license` | Mixed GPL/LGPL components; needs component-level confirmation in full matrix. |
+| Mednafen | PlayStation, PC Engine, Atari Lynx, Neo Geo Pocket | Dependency license files exist under `Mednafen/mednafen/`; no single top-level license file found in `Mednafen/` | Needs upstream/component license confirmation in full matrix. |
+
+## Full shipped-core matrix follow-up
+
+The full matrix should cover every bundled/distributed core and major vendored dependency, not just RA-enabled native cores.
+
+Suggested columns:
+
+- Core/plugin name
+- Systems
+- Upstream project URL
+- Repo path
+- License(s)
+- License file path(s)
+- Commercial-use constraints
+- Source-availability obligations
+- Binary distribution obligations
+- Notes / unresolved questions


### PR DESCRIPTION
## What does this PR do?

Adds the first RetroAchievements submission/privacy evidence pass for #438.

This PR:
- Adds `docs/retroachievements-submission-evidence.md` for reviewer-facing non-gameplay evidence.
- Documents no monetization / no IAP / no ads.
- Documents Picodrive's non-commercial constraint.
- Documents public availability dates and the open RA question about whether the fork's six-month clock starts from GitHub public visibility.
- Documents macOS-only Windows-toolkit N/A status.
- Starts a native RA core/license matrix and clearly marks the full shipped-core matrix as follow-up.
- Updates `docs/privacy-policy.md` to cover optional RetroAchievements and optional Sentry crash reporting, not just Google Drive sync.
- Links the new evidence doc from the P1 verification/evidence docs.

## What did you test?

- `git diff --check`
- Documentation-only change; no app build run.

## Which cores or systems are affected?

Documentation-only. The submission evidence references native RA-enabled cores and Picodrive's non-commercial status.

## Did you use AI tools?

Used Claude to gather repo evidence, draft the submission evidence doc, and update the privacy policy.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

git diff --check
open docs/privacy-policy.md
open docs/retroachievements-submission-evidence.md
```

Review focus:

1. Confirm the privacy policy accurately describes current optional services: RetroAchievements, Google Drive Save Sync, and opt-in Sentry crash reporting.
2. Confirm the no-monetization statement is accurate.
3. Confirm the Picodrive non-commercial disclosure is clear enough for RA submission.
4. Confirm the public availability timeline wording is conservative enough for RA review.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: not run; documentation-only change
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header where required for source files
