### PR TITLE
docs: add core license matrix draft

### DIFF
--- a/docs/core-license-matrix.md
+++ b/docs/core-license-matrix.md
@@ -1,0 +1,75 @@
+# Core License Matrix
+
+This matrix tracks bundled emulator cores and major distribution constraints for OpenEmu-Silicon. It supports the RetroAchievements submission-readiness work in #438.
+
+Status meanings:
+
+- **Confirmed** — license file or explicit license text was found in this repository.
+- **Needs confirmation** — upstream/project URL exists, but a clear top-level license file was not found in this checkout during this pass.
+- **Not shipped as native plugin** — code may exist in-tree, but no current native `.oecoreplugin` Info.plist was found in the expected location during this pass.
+
+This document is evidence, not legal advice.
+
+---
+
+## Distribution-level notes
+
+- OpenEmu-Silicon itself is BSD 2-Clause. See [`LICENSE`](../LICENSE).
+- Several emulator cores are GPL/LGPL/MPL/non-commercial licensed. Binary distribution must preserve each core's license obligations.
+- **Picodrive is non-commercial.** `picodrive/COPYING` states redistributions may not be sold or used in a commercial product or activity.
+- OpenEmu-Silicon currently has no in-app purchases, subscriptions, ads, or paid unlocks documented in [`retroachievements-submission-evidence.md`](retroachievements-submission-evidence.md).
+
+---
+
+## Native plugin/core matrix
+
+| Core/plugin | System(s) | Upstream/project URL | License evidence in repo | Status | Distribution notes |
+| --- | --- | --- | --- | --- | --- |
+| 4DO | 3DO | `http://www.fourdo.com/` | `4DO/libcue-1.4.0/COPYING` for bundled libcue; no single top-level 4DO license found in this pass | Needs confirmation | Confirm 4DO core license before release/package evidence is considered complete. |
+| Bliss | Intellivision | `https://github.com/jeremiah-sypult/BlissEmu` | `Bliss/Bliss/LICENSE.txt` | Confirmed | License file present. |
+| BSNES | SNES | `https://byuu.org/bsnes` | `BSNES/bsnes/LICENSE.txt` | Confirmed | bsnes text states GPLv3-only; bundled helper libraries include permissive terms. |
+| CrabEmu | ColecoVision | `http://crabemu.sourceforge.net/` | `CrabEmu/sound/nes_apu/COPYING` only found in this pass | Needs confirmation | Confirm main CrabEmu license. |
+| Dolphin | GameCube, Wii | `https://dolphin-emu.org/` | `Dolphin/dolphin/COPYING`, `Dolphin/dolphin/Externals/licenses.md` | Confirmed | GPL-family obligations apply; externals have separate licenses. |
+| FCEU | NES / Famicom | `https://github.com/TASEmulators/fceux` | No top-level license file found in `FCEU/` during this pass | Needs confirmation | Confirm FCEUX/FCEU license and source/binary obligations. |
+| Flycast | Dreamcast | `https://github.com/flyinghead/flycast` | `Flycast/flycast/LICENSE` plus dependency licenses under `Flycast/flycast/core/deps/` | Confirmed | Review dependency licenses for binary distribution. |
+| Gambatte | Game Boy / Game Boy Color | `https://gitlab.com/jgemu/gambatte` | `Gambatte/COPYING` | Confirmed | GPLv2 text present. |
+| Genesis Plus GX | Genesis, Master System, Game Gear, SG-1000, Sega CD | `https://github.com/ekeeke/Genesis-Plus-GX` | Dependency licenses under `GenesisPlus/genplusgx_source/`; no single top-level core license found in this pass | Needs confirmation | Confirm core license and dependency obligations. |
+| JollyCV | ColecoVision | `https://gitlab.com/jgemu/jollycv` | `JollyCV/LICENSE`, `JollyCV/src/z80/LICENSE` | Confirmed | License files present. |
+| Mednafen | PSX, PC Engine, PCE-CD, PC-FX, Saturn, Virtual Boy, Lynx, Neo Geo Pocket, WonderSwan | `http://mednafen.sourceforge.net/` | Dependency/license files under `Mednafen/mednafen/` including `lynx/license.txt`, `sms/docs/license`, `snes/src/data/license.html`, `mpcdec/COPYING`, `tremor/COPYING`; no single top-level license found in this pass | Needs confirmation | Confirm Mednafen aggregate license and per-module obligations. |
+| mGBA | Game Boy Advance, Game Boy, Game Boy Color | `https://mgba.io/` | `mGBA/LICENSE` | Confirmed | MPL 2.0 text present. |
+| Mupen64Plus | Nintendo 64 | `https://github.com/mupen64plus` | `Mupen64Plus/mupen64plus-core/LICENSES`, `Mupen64Plus/mupen64plus-core/doc/gpl-license`, `Mupen64Plus/mupen64plus-core/doc/lgpl-license`, plugin/dependency license files | Confirmed | Mixed GPL/LGPL/component obligations; keep component license files with source distribution. |
+| Nestopia | NES, FDS | `https://gitlab.com/jgemu/nestopia` | No top-level license file found in `Nestopia/` during this pass | Needs confirmation | Confirm Nestopia license from upstream. |
+| O2EM | Odyssey² / Videopac+ | `http://sourceforge.net/projects/o2em/` | `O2EM/clean/src/COPYING` | Confirmed | License file present. |
+| Picodrive | 32X, Sega CD | `https://github.com/notaz/picodrive` | `picodrive/COPYING` | Confirmed | **Non-commercial. Do not sell or use in commercial product/activity.** |
+| Potator | Supervision | `http://potator.sourceforge.net` | No clear top-level license file found in `Potator-Core/` during this pass | Needs confirmation | Confirm license before claiming matrix complete. |
+| PPSSPP | PSP | `http://www.ppsspp.org/` | `PPSSPP/PPSSPP-Core/ppsspp/LICENSE.TXT` plus external licenses | Confirmed | GPL-family project; review external licenses for binary packaging. |
+| ProSystem | Atari 7800 | `https://gitlab.com/jgemu/prosystem` | `ProSystem/LICENSE` | Confirmed | License file present. |
+| SNES9x | SNES | `https://github.com/snes9xgit/snes9x` | `SNES9x/src/LICENSE` | Confirmed | Contains non-commercial language: “Under no circumstances will commercial rights be given.” |
+| Stella | Atari 2600 | `http://sourceforge.net/projects/stella/` | No top-level license file found in `Stella/` during this pass | Needs confirmation | Confirm Stella license from upstream/repo contents. |
+
+---
+
+## In-tree cores/directories needing plugin-status confirmation
+
+These directories exist in the repository, but no current native plugin `Info.plist` was found in the expected top-level/core path during this pass.
+
+| Directory | System(s) / purpose | License evidence found | Follow-up |
+| --- | --- | --- | --- |
+| Atari800 | Atari 5200 / Atari 8-bit | Not checked in this pass | Confirm whether native plugin packaging exists and add license evidence. |
+| blueMSX | MSX / ColecoVision fallback | Not checked in this pass | Confirm whether native plugin packaging exists and add license evidence. |
+| DeSmuME | Nintendo DS | `DeSmuME/COPYING` plus dependency licenses | Confirm plugin/package status and license obligations. |
+| PokeMini | Pokémon Mini | `PokeMini/PokeMini/pokemini-code/LICENSE` | Confirm plugin/package status and license obligations. |
+| VecXGL | Vectrex | Not checked in this pass | Confirm plugin/package status and license evidence. |
+| VirtualJaguar | Atari Jaguar | Not checked in this pass | Confirm plugin/package status and license evidence. |
+| MAME | Arcade / experimental | Not checked in this pass | Experimental PR work; confirm if/when shipped. |
+
+---
+
+## Follow-up checklist
+
+- [ ] Confirm upstream licenses for every **Needs confirmation** row.
+- [ ] Confirm which in-tree core directories are actually distributed as user-facing plugin bundles.
+- [ ] Add exact SPDX-style license names where possible.
+- [ ] Add source/binary distribution obligations for GPL/LGPL/MPL/non-commercial cores.
+- [ ] Confirm app release packaging includes or links required license text/source for each shipped binary.
+- [ ] Keep Picodrive and SNES9x non-commercial constraints visible in release/submission notes.

--- a/docs/retroachievements-p1-verification.md
+++ b/docs/retroachievements-p1-verification.md
@@ -171,6 +171,8 @@ Record these results in [`retroachievements-p1-evidence-log.md`](retroachievemen
 - Offline/reconnect test notes, including whether queued unlock synced or was purged on close.
 - User-Agent sample from transport logs or packet capture:
   - `OpenEmu-Silicon/<version> (macOS <version>) rcheevos/<version>`
+- Legal/privacy/submission notes from [`retroachievements-submission-evidence.md`](retroachievements-submission-evidence.md).
+- Core/license status from [`core-license-matrix.md`](core-license-matrix.md).
 - Explicit RA-side approval question: what client registration step is required so OpenEmu-Silicon is no longer treated as an unknown emulator for hardcore credit?
 
 ## Follow-up implementation candidates

--- a/docs/retroachievements-submission-evidence.md
+++ b/docs/retroachievements-submission-evidence.md
@@ -15,7 +15,7 @@ For manual runtime evidence, use [`retroachievements-p1-evidence-log.md`](retroa
 | Privacy policy | Updated for RA/Sentry | See [`privacy-policy.md`](privacy-policy.md). |
 | Public availability timeline | Partial / needs reviewer decision | This fork's GitHub repository is public as of 2026-03-20. Local git history begins 2026-01-25. Upstream OpenEmu predates this fork by years. If RA requires this fork itself to be public for 6 months, earliest date from GitHub visibility is 2026-09-20. |
 | Windows toolkit support | N/A | OpenEmu-Silicon is macOS-only. Windows toolkit support is not applicable. |
-| Core/license matrix | Partial / needs broader pass | RA-native core matrix started below. Full shipped-core matrix remains a separate evidence task. |
+| Core/license matrix | Partial / needs confirmation pass | Initial broader matrix lives in [`core-license-matrix.md`](core-license-matrix.md). Rows marked “Needs confirmation” must be resolved before this checklist item is complete. |
 | Picodrive non-commercial status | Documented here | `picodrive/COPYING` prohibits commercial redistribution/use. Do not charge for builds that include Picodrive. |
 
 ---
@@ -105,35 +105,8 @@ Suggested reviewer wording:
 
 ---
 
-## Native RA core/license matrix — initial pass
+## Core/license matrix
 
-This table is scoped to native RA-enabled cores first. It is not yet the full shipped-core license matrix requested in #438.
+The broader license matrix now lives in [`core-license-matrix.md`](core-license-matrix.md). It covers native plugin/core rows plus in-tree core directories needing plugin-status confirmation.
 
-| Core | Systems | License evidence in repo | Notes |
-| --- | --- | --- | --- |
-| Nestopia | NES, FDS | No top-level license file found in `Nestopia/`; `Info.plist` project URL is `https://gitlab.com/jgemu/nestopia` | Needs upstream license confirmation in full matrix. |
-| FCEU | NES / Famicom | No top-level license file found in `FCEU/` | Needs upstream license confirmation in full matrix. |
-| BSNES | SNES | `BSNES/bsnes/LICENSE.txt` | bsnes is GPLv3-only; bundled helper libraries include permissive terms. |
-| SNES9x | SNES | `SNES9x/src/LICENSE` | Snes9x license includes non-commercial language: “Under no circumstances will commercial rights be given.” |
-| Gambatte | GB, GBC | `Gambatte/COPYING` | GPLv2. |
-| GenesisPlus | Genesis, SMS, Game Gear, SG-1000, Sega CD | No top-level license file found in `GenesisPlus/`; third-party dependency licenses are present under `genplusgx_source/` | Needs upstream license confirmation in full matrix. |
-| mGBA | GBA, GB, GBC | `mGBA/LICENSE` | MPL 2.0. |
-| Mupen64Plus | N64 | `Mupen64Plus/mupen64plus-core/LICENSES`, `doc/gpl-license`, `doc/lgpl-license` | Mixed GPL/LGPL components; needs component-level confirmation in full matrix. |
-| Mednafen | PlayStation, PC Engine, Atari Lynx, Neo Geo Pocket | Dependency license files exist under `Mednafen/mednafen/`; no single top-level license file found in `Mednafen/` | Needs upstream/component license confirmation in full matrix. |
-
-## Full shipped-core matrix follow-up
-
-The full matrix should cover every bundled/distributed core and major vendored dependency, not just RA-enabled native cores.
-
-Suggested columns:
-
-- Core/plugin name
-- Systems
-- Upstream project URL
-- Repo path
-- License(s)
-- License file path(s)
-- Commercial-use constraints
-- Source-availability obligations
-- Binary distribution obligations
-- Notes / unresolved questions
+This remains incomplete until every row marked “Needs confirmation” has an exact license/source-obligation answer.


### PR DESCRIPTION
## What does this PR do?

Adds a first draft core/license matrix for the #438 RetroAchievements submission-readiness work.

This PR creates `docs/core-license-matrix.md` and links it from the RA submission/verification docs. The matrix records:

- bundled native plugin/core rows
- upstream/project URLs from core Info.plists where available
- license evidence files found in the repo
- known non-commercial constraints, especially Picodrive and SNES9x
- rows that still need upstream/license confirmation before #438 can be considered complete

This intentionally does **not** mark the #438 license matrix item complete; it creates the audit surface and exposes unresolved rows.

## What did you test?

- `git diff --check`
- Documentation-only change; no app build run.

## Which cores or systems are affected?

Documentation-only. Covers bundled/native core license evidence and in-tree core directories needing plugin-status confirmation.

## Did you use AI tools?

Used Claude to inspect repo license files/Info.plists and draft the matrix.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

git diff --check
open docs/core-license-matrix.md
open docs/retroachievements-submission-evidence.md
```

Review focus:

1. Confirm each license-evidence path exists.
2. Resolve rows marked `Needs confirmation` before using this as final submission evidence.
3. Confirm Picodrive and SNES9x non-commercial notes are visible enough for release/submission planning.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: not run; documentation-only change
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header where required for source files
