### PR TITLE
fix: avoid keychain prompts after credential migration

### DIFF
--- a/OpenEmu/OECredentialStore.swift
+++ b/OpenEmu/OECredentialStore.swift
@@ -184,10 +184,16 @@ final class OECredentialStore {
         guard !isLoaded else { return }
         isLoaded = true
 
-        // One-time migration: if old keychain items exist, move them here and delete them.
-        migrateFromKeychain()
-
         let url = OECredentialStore.storeURL
+
+        // One-time migration: only touch legacy keychain items when the encrypted
+        // file store does not exist yet. If the store already exists, trying to
+        // read old keychain leftovers can trigger a macOS access prompt when a
+        // different Debug/Release build or app path launches.
+        if !FileManager.default.fileExists(atPath: url.path) {
+            migrateFromKeychain()
+        }
+
         guard FileManager.default.fileExists(atPath: url.path),
               let ciphertext = try? Data(contentsOf: url)
         else { return }
@@ -244,8 +250,9 @@ final class OECredentialStore {
     /// cache, then deletes the keychain items. This runs exactly once — after the store
     /// file exists the keychain items are gone and this code is never reached again.
     ///
-    /// Users will not see any permission dialogs: reading a keychain item that the same
-    /// binary created previously does not prompt. We just clean up and move on.
+    /// Migration must never show a Keychain permission dialog. If macOS would require
+    /// interaction because the item was created by a different binary/path/signature,
+    /// skip that item and let the user sign in again through Preferences instead.
     private func migrateFromKeychain() {
         var migrated = 0
 
@@ -282,11 +289,12 @@ final class OECredentialStore {
 
     private func keychainRead(service: String, account: String) -> String? {
         let query: [CFString: Any] = [
-            kSecClass:       kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: account,
-            kSecReturnData:  kCFBooleanTrue!,
-            kSecMatchLimit:  kSecMatchLimitOne,
+            kSecClass:               kSecClassGenericPassword,
+            kSecAttrService:         service,
+            kSecAttrAccount:         account,
+            kSecReturnData:          kCFBooleanTrue!,
+            kSecMatchLimit:          kSecMatchLimitOne,
+            kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
         ]
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)


### PR DESCRIPTION
## What does this PR do?

Fixes a credential migration edge case where a stale legacy Keychain item could trigger a macOS Keychain access prompt after the encrypted credential file store already exists.

This happened during RA testing after accidentally launching an older Debug build that recreated the old `com.openemu.RetroAchievements` Keychain item. The newer app then tried to migrate/read the stale item and macOS prompted for Keychain access because the app path/signature differed.

This PR:
- Skips legacy Keychain migration entirely once `~/Library/Application Support/OpenEmu/.oe_credentials` already exists.
- Adds `kSecUseAuthenticationUIFail` to migration reads so they never show a Keychain prompt.
- Leaves users with inaccessible legacy Keychain entries to sign in again through Preferences instead of seeing a system permission dialog.

## What did you test?

- Deleted stale OpenEmu build outputs:
  - `~/Builds/openemu`
  - OpenEmu-related DerivedData folders
- Deleted the stale legacy RA Keychain item:
  - `security delete-generic-password -s com.openemu.RetroAchievements -a token`
- Verified no RA Keychain item remained.
- Host app build:
  - `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- Launched the fresh DerivedData app and confirmed the running app path was:
  - `~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-.../Build/Products/Debug/OpenEmu.app`

## Which cores or systems are affected?

Main app credential storage only. This affects RetroAchievements, ScreenScraper, and Google Drive legacy Keychain migration behavior.

## Did you use AI tools?

Used Claude to diagnose the stale Keychain prompt, patch migration behavior, and run local verification.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

git diff --check

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -60
```

Regression check:

1. Ensure `~/Library/Application Support/OpenEmu/.oe_credentials` exists.
2. If a stale legacy Keychain item exists, launch the app from a fresh Debug build.
3. Expected: app does not show a Keychain access prompt. If the encrypted credential store lacks a token, the user signs in normally through Preferences.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes for host app
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
