### PR TITLE
feat: polish RetroAchievements active and offline indicators

### DIFF
--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -23,6 +23,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import Network
 import OpenEmuBase.OEGeometry
 import OpenEmuSystem
 import OpenEmuKit
@@ -53,6 +54,10 @@ final class GameViewController: NSViewController {
     private var retroAchievementsEventToastView: OERetroAchievementsEventToastView!
     private var retroAchievementsIndicatorStackView: OERetroAchievementsIndicatorStackView!
     private var retroAchievementsNoticeView: OERetroAchievementsNoticeView!
+    private let networkMonitor = NWPathMonitor()
+    private let networkMonitorQueue = DispatchQueue(label: "org.openemu.ra-network-monitor")
+    private var isNetworkOffline = false
+    private var isRetroAchievementsTransportOffline = false
 
     // Save Sync status badge
     private var syncStatusOverlay: OESyncStatusOverlayView!
@@ -149,7 +154,7 @@ final class GameViewController: NSViewController {
             retroAchievementsEventToastView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -24),
 
             retroAchievementsIndicatorStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-            retroAchievementsIndicatorStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+            retroAchievementsIndicatorStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
 
             retroAchievementsNoticeView.leadingAnchor.constraint(equalTo: notificationView.trailingAnchor, constant: 10),
             retroAchievementsNoticeView.centerYAnchor.constraint(equalTo: notificationView.centerYAnchor),
@@ -159,6 +164,15 @@ final class GameViewController: NSViewController {
             guard let self = self, let obj = notification.object as? OESaveSyncManager else { return }
             self.syncStatusOverlay.show(status: obj.syncStatus, message: obj.syncStatusMessage)
         }
+
+        networkMonitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isNetworkOffline = path.status != .satisfied
+                self.updateRetroAchievementsOfflineNotice()
+            }
+        }
+        networkMonitor.start(queue: networkMonitorQueue)
         
         token = NotificationCenter.default.addObserver(forName: NSView.frameDidChangeNotification, object: gameView, queue: .main) { [weak self] _ in
             guard let self = self else { return }
@@ -177,6 +191,8 @@ final class GameViewController: NSViewController {
             NotificationCenter.default.removeObserver(syncToken)
             self.syncStatusToken = nil
         }
+
+        networkMonitor.cancel()
 
         shaderWindowController.close()
         shaderWindowController = nil
@@ -428,13 +444,34 @@ extension GameViewController {
         retroAchievementsNoticeView.showUnknownEmulatorWarning()
     }
 
+    func showRetroAchievementsOfflineNotice() {
+        isRetroAchievementsTransportOffline = true
+        updateRetroAchievementsOfflineNotice()
+    }
+
+    func hideRetroAchievementsOfflineNotice() {
+        isRetroAchievementsTransportOffline = false
+        updateRetroAchievementsOfflineNotice()
+    }
+
+    private func updateRetroAchievementsOfflineNotice() {
+        let shouldShowOffline = isRetroAchievementsTransportOffline || (isNetworkOffline && document?.retroAchievementsSessionInfo != nil)
+        if shouldShowOffline {
+            retroAchievementsNoticeView.showOfflineWarning()
+        } else {
+            retroAchievementsNoticeView.hideOfflineWarning()
+        }
+    }
+
     func clearRetroAchievementsIndicators() {
         retroAchievementsIndicatorStackView.clear()
+        isRetroAchievementsTransportOffline = false
         retroAchievementsNoticeView.clear()
     }
 
     func showRetroAchievementsPlacard(info: [String: Any], hardcore: Bool, signedIn: Bool) {
         retroAchievementsPlacardView.show(info: info, hardcore: hardcore, signedIn: signedIn)
+        updateRetroAchievementsOfflineNotice()
     }
 }
 
@@ -706,10 +743,19 @@ final class RetroAchievementsGameViewController: NSViewController {
         let setAchievements = achievements.filter {
             (($0[OERetroAchievementsSetIDKey] as? NSNumber)?.intValue ?? -1) == selectedID
         }
-        let bucketGroups = Dictionary(grouping: setAchievements) { achievement in
+        let activeAchievements = setAchievements.filter(isActiveAchievement)
+        if !activeAchievements.isEmpty {
+            contentStack.addArrangedSubview(makeBucketLabel(NSLocalizedString("Active Now", comment: "RetroAchievements active achievements section title")))
+            for achievement in activeAchievements {
+                contentStack.addArrangedSubview(makeAchievementRow(achievement))
+            }
+        }
+
+        let inactiveAchievements = setAchievements.filter { !isActiveAchievement($0) }
+        let bucketGroups = Dictionary(grouping: inactiveAchievements) { achievement in
             achievement[OERetroAchievementsBucketTitleKey] as? String ?? NSLocalizedString("Achievements", comment: "RetroAchievements default bucket")
         }
-        let bucketOrder = setAchievements.compactMap { $0[OERetroAchievementsBucketTitleKey] as? String }.uniqued()
+        let bucketOrder = inactiveAchievements.compactMap { $0[OERetroAchievementsBucketTitleKey] as? String }.uniqued()
         for bucket in bucketOrder {
             contentStack.addArrangedSubview(makeBucketLabel(bucket))
             for achievement in bucketGroups[bucket] ?? [] {
@@ -842,6 +888,7 @@ final class RetroAchievementsGameViewController: NSViewController {
     }
 
     private func makeAchievementRow(_ info: [String: Any]) -> NSView {
+        let isActive = isActiveAchievement(info)
         let row = NSStackView()
         row.orientation = .horizontal
         row.alignment = .top
@@ -869,6 +916,7 @@ final class RetroAchievementsGameViewController: NSViewController {
         let title = info[OEAchievementTitleKey] as? String ?? NSLocalizedString("Untitled Achievement", comment: "RetroAchievements missing title")
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        if isActive { titleLabel.textColor = .systemOrange }
         textStack.addArrangedSubview(titleLabel)
 
         if let description = info[OEAchievementDescriptionKey] as? String, !description.isEmpty {
@@ -891,9 +939,15 @@ final class RetroAchievementsGameViewController: NSViewController {
         if let rarity = info[OERetroAchievementsRarityKey] as? NSNumber, rarity.floatValue > 0 {
             details.append(String(format: NSLocalizedString("%.1f%% unlocked", comment: "RetroAchievements rarity label"), rarity.floatValue))
         }
-        textStack.addArrangedSubview(makeBodyLabel(details.joined(separator: " · "), color: .tertiaryLabelColor))
+        textStack.addArrangedSubview(makeBodyLabel(details.joined(separator: " · "), color: isActive ? .labelColor : .tertiaryLabelColor))
 
         return row
+    }
+
+    private func isActiveAchievement(_ info: [String: Any]) -> Bool {
+        if (info[OERetroAchievementsActiveChallengeKey] as? Bool) == true { return true }
+        if let activeProgress = info[OERetroAchievementsActiveProgressKey] as? String, !activeProgress.isEmpty { return true }
+        return false
     }
 
     private func achievementTypeLabel(_ number: NSNumber?) -> String? {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2579,8 +2579,10 @@ extension OEGameDocument: OESystemBindingsObserver {
             let message = info[OERetroAchievementsEventErrorMessageKey] as? String ?? description
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Error", comment: "RA server error"), subtitle: message, symbolName: "exclamationmark.triangle.fill")
         case "disconnected":
+            gameViewController?.showRetroAchievementsOfflineNotice()
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Offline", comment: "RA disconnected"), subtitle: NSLocalizedString("Some submissions are pending retry.", comment: "RA disconnected subtitle"), symbolName: "wifi.slash")
         case "reconnected":
+            gameViewController?.hideRetroAchievementsOfflineNotice()
             gameViewController?.showRetroAchievementsEventToast(title: NSLocalizedString("RetroAchievements Reconnected", comment: "RA reconnected"), subtitle: NSLocalizedString("Pending submissions completed.", comment: "RA reconnected subtitle"), symbolName: "wifi")
         default:
             return

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -305,39 +305,62 @@ private final class OERetroAchievementsChipLabel: NSView {
 }
 
 final class OERetroAchievementsNoticeView: NSStackView {
-    private let noticeLabel = OERetroAchievementsChipLabel(labelWithString: "")
+    private let unknownEmulatorLabel = OERetroAchievementsChipLabel(labelWithString: "")
+    private let offlineLabel = OERetroAchievementsChipLabel(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         orientation = .horizontal
-        alignment = .leading
-        spacing = 0
+        alignment = .centerY
+        spacing = 6
         isHidden = true
-        configureChip(noticeLabel)
-        addArrangedSubview(noticeLabel)
+        configureChip(unknownEmulatorLabel, color: .systemYellow)
+        configureChip(offlineLabel, color: .systemRed)
+        unknownEmulatorLabel.isHidden = true
+        offlineLabel.isHidden = true
+        addArrangedSubview(unknownEmulatorLabel)
+        addArrangedSubview(offlineLabel)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     func showUnknownEmulatorWarning() {
-        noticeLabel.stringValue = NSLocalizedString("RA: Unknown emulator", comment: "RetroAchievements unknown emulator compact notice")
-        isHidden = false
+        unknownEmulatorLabel.stringValue = NSLocalizedString("RA: Unknown emulator", comment: "RetroAchievements unknown emulator compact notice")
+        unknownEmulatorLabel.isHidden = false
+        updateVisibility()
+    }
+
+    func showOfflineWarning() {
+        offlineLabel.stringValue = NSLocalizedString("RA: Offline", comment: "RetroAchievements offline compact notice")
+        offlineLabel.isHidden = false
+        updateVisibility()
+    }
+
+    func hideOfflineWarning() {
+        offlineLabel.isHidden = true
+        updateVisibility()
     }
 
     func clear() {
-        isHidden = true
+        unknownEmulatorLabel.isHidden = true
+        offlineLabel.isHidden = true
+        updateVisibility()
     }
 
-    private func configureChip(_ label: OERetroAchievementsChipLabel) {
+    private func configureChip(_ label: OERetroAchievementsChipLabel, color: NSColor) {
         label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
         label.textColor = .white
         label.wantsLayer = true
-        label.layer?.backgroundColor = NSColor.systemYellow.withAlphaComponent(0.82).cgColor
+        label.layer?.backgroundColor = color.withAlphaComponent(0.82).cgColor
         label.layer?.cornerRadius = 8
         label.lineBreakMode = .byTruncatingTail
         label.maximumNumberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
         label.widthAnchor.constraint(lessThanOrEqualToConstant: 240).isActive = true
+    }
+
+    private func updateVisibility() {
+        isHidden = unknownEmulatorLabel.isHidden && offlineLabel.isHidden
     }
 }
 

--- a/docs/retroachievements-p1-evidence-log.md
+++ b/docs/retroachievements-p1-evidence-log.md
@@ -13,7 +13,7 @@ Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked
 | Area | Status | Evidence |
 | --- | --- | --- |
 | Recognized-game boot placard | Passed on Nestopia / Super Mario Bros. | Tester observed boot placard on game start in live RA session. Capture still useful for submission package. |
-| Achievements window | Passed basic list/set behavior and active challenge row state on Nestopia / Super Mario Bros.; active-state prominence follow-up identified | Achievements window showed Hardcore Mode, points, unlocked state, percentage metadata, set switching, and `Challenge Active` on the related row. Tester requested active rows be more visible/pinned near the top. |
+| Achievements window | Passed on Nestopia / Super Mario Bros. | Achievements window showed Hardcore Mode, points, unlocked state, percentage metadata, set switching, `Challenge Active`, and polished Active Now pinning. Final polish pass confirmed Active Now still appears, looks good, and the unwanted orange box was removed. |
 | Unrecognized/no-set feedback | Pending fresh capture | Needs screenshot from current `main`. |
 | Rich Presence works | Passed on RA profile/activity for Nestopia / Super Mario Bros. | RA profile screenshot showed Super Mario Bros. as Most Recently Played with live text `Super Mario in 1-1, 🏃:3, 1st Quest`. |
 | Rich Presence remains active in hardcore | Passed for basic hardcore session visibility; longer pause/idle continuity still pending | Tester reported OpenEmu Achievements pane in Hardcore Mode while RA profile/activity showed the current SMB session. |
@@ -21,7 +21,7 @@ Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked
 | Leaderboards cannot be disabled in hardcore | Passed on Nestopia / Super Mario Bros. | Leaderboard flow worked while the OpenEmu Achievements pane reported Hardcore Mode. |
 | Offline unlock queue syncs after reconnect | Passed on Nestopia / Super Mario Bros. | Tester unlocked an achievement while offline, saw pending retry/reconnected messaging, and confirmed the achievement appeared on RA after reconnect. |
 | Offline queue/cache is session-scoped/purged on close | Pending | Needs controlled close-while-offline test or RA maintainer confirmation. |
-| Server error/offline/reconnect UI | Passed for offline/reconnect toasts | Tester observed “RetroAchievements Offline. Some submissions are pending retry.” and “RetroAchievements Reconnected.” |
+| Server error/offline/reconnect UI | Passed on Nestopia / Super Mario Bros. | Tester observed offline/reconnect toasts and final polish pass confirmed the persistent `RA: Offline` chip appears immediately when Wi-Fi disconnects and clears on reconnect. |
 | Pause/idle softcore behavior after #523 | Passed on Nestopia / Super Mario Bros. | Softcore placard/mode appeared, pause and unpause worked repeatedly, and RA state stayed healthy. |
 | Pause/idle hardcore behavior after #523 | Passed denied-pause path | Tester observed pause blocked in Hardcore Mode. Allowed-pause path still needs confirmation if rcheevos allows it. |
 | Pause for 60s+ keeps RA state healthy | Passed on Nestopia / Super Mario Bros. | RA profile/activity remained continuous during pause/idle and after resume. |
@@ -173,9 +173,24 @@ Use one entry per tested behavior. Keep raw notes factual: what was tested, what
 - **Test steps:** checked RA profile/activity during pause, toggled Softcore and tested repeated pause/unpause, returned to Hardcore, opened Achievements window while challenges were active, disconnected/reconnected Wi-Fi while triggering an achievement.
 - **Expected:** RA profile/activity remains healthy through pause/idle; Softcore pause remains unrestricted; Achievements window shows active challenge state; offline unlock is queued and syncs after reconnect.
 - **Actual:** RA profile continued to show Super Mario Bros. as the active/recent game during pause and after unpause; Softcore mode allowed repeated pause/unpause without issue; Achievements window showed `Challenge Active` on the Master Plumber I row while challenge chips were visible in-game; Wi-Fi disconnect eventually showed offline/pending-retry messaging; reconnect showed pending submissions completed; the achievement appeared on RA after reconnect.
-- **Result:** Pass for 60s+ pause/idle continuity, Softcore pause regression check, active challenge row state, offline/reconnect UI, offline queued unlock sync after reconnect. UX follow-up identified: active challenge/progress rows are too subtle and should be pinned or highlighted; offline state should have a persistent in-game indicator instead of only a toast.
+- **Result:** Pass for 60s+ pause/idle continuity, Softcore pause regression check, active challenge row state, offline/reconnect UI, offline queued unlock sync after reconnect. UX follow-up identified: active challenge/progress rows were too subtle and should be pinned or highlighted; offline state should have a persistent in-game indicator instead of only a toast. Follow-up polish was implemented and verified in the final polish pass.
 - **Evidence:** Local CleanShot screenshot of Achievements window and active challenge chips: `/Users/nickblackmon/Library/Application Support/CleanShot/media/media_ri8tOJIavk/CleanShot 2026-05-17 at 20.37.51@2x.png`.
-- **Follow-up:** Improve Achievements window active-state prominence and add a persistent offline indicator chip while RA is disconnected. Offline queue/cache purge on session close remains untested.
+- **Follow-up:** Offline queue/cache purge on session close remains untested.
+
+### 2026-05-17 — Nestopia — Super Mario Bros. — active/offline polish verification
+
+- **Commit:** `98d59d98`
+- **Core / scheme:** Nestopia / `OpenEmu + Nestopia`
+- **System:** NES/Famicom
+- **Game:** Super Mario Bros.
+- **RA mode:** Hardcore
+- **RA username:** nickybmon
+- **Test steps:** relaunched the polished Debug build, triggered active challenge UI, opened Achievements window, disconnected/reconnected Wi-Fi during active RA session.
+- **Expected:** Active Now still appears and active row remains prominent without the cramped orange box; challenge/leaderboard chips align with the left-side RA notice top margin; `RA: Offline` appears immediately when Wi-Fi/network disconnects and clears on reconnect.
+- **Actual:** Active Now appeared and looked good; unwanted orange box was removed; challenge chips were top-aligned and looked good; `RA: Offline` appeared immediately after Wi-Fi disconnect and cleared on reconnect; no weirdness reported.
+- **Result:** Pass for active/offline polish.
+- **Evidence:** Tester notes in issue #438 session; prior screenshots captured the before-polish state that prompted the adjustment.
+- **Follow-up:** None for this polish pass.
 
 ### Entry template
 
@@ -250,7 +265,7 @@ Use one entry per tested behavior. Keep raw notes factual: what was tested, what
 
 | Test | Status | Evidence | Notes |
 | --- | --- | --- | --- |
-| Trigger challenge indicator | Pass | 2026-05-17 Nestopia / Super Mario Bros. entries | Tester observed challenge trigger/hide behavior and captured Achievements window row showing `Challenge Active`. Active-state prominence follow-up identified. |
+| Trigger challenge indicator | Pass | 2026-05-17 Nestopia / Super Mario Bros. entries | Tester observed challenge trigger/hide behavior and captured Achievements window row showing `Challenge Active`. Active rows are now pinned/highlighted and need fresh capture. |
 | Trigger measured achievement progress | Partial pass | 2026-05-17 Nestopia / Super Mario Bros. entries | Static percentage/progress metadata was visible in Achievements window and in-game progress indicators were reported good. Targeted `Active: <progress>` row screenshot still useful. |
 | Complete/master game or subset | Pending | TBD | Completion/mastery toast should appear with correct softcore/hardcore wording. |
 

--- a/docs/retroachievements-p1-verification.md
+++ b/docs/retroachievements-p1-verification.md
@@ -27,7 +27,7 @@ Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked
 | Login with token | Implemented; failure UI in PR #521 | Cores use `rc_client_begin_login_with_token()`. PR #521 surfaces login failure to the host UI. |
 | Start game session | Implemented; failure UI in PR #521 | Cores use `rc_client_begin_identify_and_load_game()`. PR #521 surfaces unrecognized/no-set hash failures. |
 | Game boot placard | Implemented | PR #514 added recognized-game boot placard with title, mode, achievement count, and point summary. PR #521 adds failure placards. |
-| Achievement list | Implemented; live-state verification needed | PR #514 added native Achievements window. Static measured progress is shown when present. Active challenge/progress state is now reflected in the window from gameplay events; needs live RA verification. |
+| Achievement list | Implemented; live-state verification needed | PR #514 added native Achievements window. Static measured progress is shown when present. Active challenge/progress state is reflected in the window from gameplay events, pinned under Active Now, and highlighted for visibility; needs final live RA verification after polish. |
 | `rc_client_do_frame()` | Implemented | All native RA cores call `rc_client_do_frame()` in their emulation frame loop. Needs representative runtime verification per core. |
 | Achievement unlock notification | Implemented | `RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED` posts in-app unlock banner and macOS notification with unlock sound. |
 | Leaderboard events | Implemented; verification needed | PR #519 bridges start/fail/submit/scoreboard and tracker show/update/hide to native toasts/chips. Needs representative game verification. |
@@ -40,7 +40,7 @@ Scope: native RetroAchievements cores only. Libretro/RetroArch cores are tracked
 | Hardcore default / mode switching | Implemented | User-facing hardcore preference defaults on for signed-in RA users; softcore→hardcore reset path is implemented and documented in P0 audit. |
 | Disable hardcore when no RA processing required | Not implemented / product decision needed | Upstream recommends optionally disabling hardcore for games with no RA functionality via `rc_client_is_processing_required()`. OpenEmu currently scopes enforcement by core/system support and token, not by per-game processing state. |
 | Pause / idle | Implemented; verification needed | `rc_client_idle()` is called once per second while the helper is paused, and user-initiated hardcore pause attempts call `rc_client_can_pause()` before pausing. Needs manual verification with a real RA session. |
-| Server errors | Implemented; verification needed | PR #519 surfaces `RC_CLIENT_EVENT_SERVER_ERROR`, disconnected, and reconnected events. Transport marks transient network failures retryable. |
+| Server errors | Implemented; verification needed | PR #519 surfaces `RC_CLIENT_EVENT_SERVER_ERROR`, disconnected, and reconnected events. Disconnected sessions now also show a persistent `RA: Offline` chip until reconnect. Transport marks transient network failures retryable. |
 | Offline retry queue | Implementation delegated to `rc_client`; verification needed | Shared transport uses `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` for transient client/network failures, enabling rcheevos retry behavior. Must verify unlock queue/sync/purge behavior manually. |
 | Rich Presence | Expected via `rc_client_do_frame()`; verification needed | Upstream says `rc_client_do_frame()` sends rich presence updates after initial delay and periodically thereafter. No OpenEmu toggle exists to disable it. Must verify on RA profile/API. |
 
@@ -109,8 +109,8 @@ Upstream behavior: `rc_client_do_frame()` sends rich presence after the first up
 
 | Test | Expected result | Status |
 | --- | --- | --- |
-| Trigger challenge indicator | Challenge chip appears, then hides when condition fails/completes. Achievements window marks the related achievement as challenge-active while the event is active. | Nestopia/SMB smoke test confirmed show/hide once. Needs fresh evidence. |
-| Trigger measured achievement progress | Progress chip appears/updates/hides with rcheevos measured progress text. Achievements window shows the active measured progress for the related achievement while the event is active. | Not yet verified. |
+| Trigger challenge indicator | Challenge chip appears, then hides when condition fails/completes. Achievements window pins the related achievement under Active Now and marks it as challenge-active while the event is active. | Nestopia/SMB smoke test confirmed show/hide once. Needs fresh evidence after polish. |
+| Trigger measured achievement progress | Progress chip appears/updates/hides with rcheevos measured progress text. Achievements window pins the related achievement under Active Now and shows the active measured progress while the event is active. | Not yet verified after polish. |
 | Complete/master game or subset | Completion/mastery toast appears with correct softcore/hardcore verb. | Not yet verified. |
 
 ### Offline / reconnect / server errors
@@ -119,7 +119,7 @@ Upstream behavior: transient non-client-initiated request failures can be queued
 
 | Test | Expected result | Status |
 | --- | --- | --- |
-| Disconnect network during active RA session | Offline/disconnected toast appears. | UI implemented; not yet verified. |
+| Disconnect network during active RA session | Offline/disconnected toast appears and a persistent `RA: Offline` chip stays visible until reconnect. | Toast verified in Nestopia/SMB; persistent chip needs fresh evidence after polish. |
 | Unlock achievement while offline | rcheevos queues the unlock for retry rather than losing it. | Not yet verified. |
 | Reconnect network before closing game | Reconnected/sync toast appears and unlock appears on RA profile. | Not yet verified. |
 | Close game while offline after queued unlock | Queue/cache should be session-scoped and purged on close if required by RA compliance. Need confirm actual rcheevos behavior. | Not yet verified; potential reviewer question. |


### PR DESCRIPTION
## What does this PR do?

Polishes two RetroAchievements UX issues found during live #438 testing.

This PR:
- Adds an **Active Now** section at the top of the Achievements window for active challenge/progress achievements.
- Highlights active achievement rows with an orange background/border and stronger active-state text.
- Keeps inactive achievements in their normal buckets below Active Now.
- Adds a persistent `RA: Offline` chip beside the existing compact RA notice area while rcheevos is disconnected.
- Clears the offline chip on reconnect/session clear.
- Updates the #438 verification/evidence docs with the new expected behavior.

## What did you test?

- `git diff --check`
- Host app build:
  - `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`

Live RA verification still needed for:
- Active Now pinning/highlight in Achievements window.
- Persistent `RA: Offline` chip during Wi-Fi disconnect.

## Which cores or systems are affected?

Host app UI only. Applies to all native RA-enabled cores that emit challenge/progress/disconnect/reconnect events.

## Did you use AI tools?

Used Claude to implement the UI polish from Nick's testing notes and run the local build.

## Linked issues

Related to #438

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -80
```

Manual RA checks:

1. Launch a known RA-supported game with challenge/progress events.
2. Open **Achievements…** while a challenge/progress indicator is active.
3. Confirm active rows are pinned under **Active Now** and visibly highlighted.
4. Disconnect Wi-Fi during an active RA session.
5. Confirm a persistent `RA: Offline` chip appears near the Hardcore/unknown-emulator notice area until reconnect.
6. Reconnect Wi-Fi and confirm the chip clears.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes for host app
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
