### PR TITLE
fix: resolve launch retry and RA/save-state release bugs

### DIFF
--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -142,6 +142,7 @@ class GameDocumentController: NSDocumentController {
                 completionHandler?(document, nil)
                 NotificationCenter.default.post(name: .OEGameDocumentSetupDidFinish, object: nil)
             } else {
+                self.removeDocument(document)
                 completionHandler?(nil, error as NSError?)
             }
         }

--- a/OpenEmu/OEDBSaveState.swift
+++ b/OpenEmu/OEDBSaveState.swift
@@ -249,7 +249,6 @@ final class OEDBSaveState: OEDBItem {
             return nil
         }
         
-        saveState.save()
         return saveState
     }
     

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2047,7 +2047,6 @@ final class OEGameDocument: NSDocument {
                 return
             }
             
-            state.save()
             let mainContext = state.managedObjectContext
             mainContext?.perform {
                 try? mainContext?.save()

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -93,6 +93,7 @@ extension OSLog {
     // RetroAchievements token received from the main app via XPC.
     // Stored here so the core can pick it up at load time and on mid-session token delivery.
     var _retroAchievementsToken: String?
+    var _retroAchievementsUsername: String?
 
     // RA hardcore mode flag received from the main app via XPC. Defaults to true
     // (RA's recommended default); cores read this at load time and on mid-session toggles.
@@ -319,6 +320,7 @@ extension OSLog {
                 gameCoreOwner.setDisplayModes(displayModes)
             }
             loadedRom = true
+            replayRetroAchievementsTokenIfAvailable()
         } catch {
             gameCore = nil
             
@@ -559,10 +561,9 @@ extension OSLog {
         }
     }
 
-    public func setRetroAchievementsToken(_ token: String?, username: String?) {
-        _retroAchievementsToken = token
+    private func postRetroAchievementsTokenDidChange() {
         var userInfo: [String: Any]? = nil
-        if let token = token, let username = username {
+        if let token = _retroAchievementsToken, let username = _retroAchievementsUsername {
             userInfo = [OERetroAchievementsTokenKey: token,
                         OERetroAchievementsUsernameKey: username]
         }
@@ -571,6 +572,17 @@ extension OSLog {
             object: nil,
             userInfo: userInfo
         )
+    }
+
+    private func replayRetroAchievementsTokenIfAvailable() {
+        guard _retroAchievementsToken != nil, _retroAchievementsUsername != nil else { return }
+        postRetroAchievementsTokenDidChange()
+    }
+
+    public func setRetroAchievementsToken(_ token: String?, username: String?) {
+        _retroAchievementsToken = token
+        _retroAchievementsUsername = username
+        postRetroAchievementsTokenDidChange()
     }
 
     public func setHardcoreEnabled(_ enabled: Bool) {


### PR DESCRIPTION
## What does this PR do?

Fixes three release-stability issues before the next app release:

- #425 — replays cached RetroAchievements credentials after helper-side ROM load, so slow-loading cores do not miss the token notification.
- #516 — removes failed game documents from `NSDocumentController`, so a failed Arcade/core launch does not block retrying the same game with another core.
- #526 — removes synchronous Core Data saves from the gameplay save-state creation path, avoiding main-thread hangs on the writer context.

## What changed

- `OpenEmuHelperApp` now caches both RA token and username, centralizes notification posting, and replays credentials after `loadFile(at:)` succeeds.
- `GameDocumentController` now removes a document if `setUpGame` fails before showing a window.
- Gameplay save-state creation now relies on the existing async context save instead of calling `OEDBItem.save()` synchronously.

## What did you test?

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -40
```

Result: build succeeded.

Manual runtime checks still recommended before closing the issues:

- #425: launch a known slow-loading RA ROM such as BSNES + Donkey Kong Country with existing RA credentials and confirm `[rcheevos]` login/identify logs appear without signing out/in.
- #516: intentionally fail an Arcade ROM with one core, then immediately retry the same game with another core without restarting OpenEmu.
- #526: create a save state during gameplay while library/VGDB activity is active and confirm UI does not hang.

## Which cores or systems are affected?

- Main app launch/session management
- RetroAchievements credential delivery to native cores
- Save-state metadata persistence
- Arcade retry behavior

## Linked issues

Fixes #425
Fixes #516
Fixes #526

---

## How to test locally

```bash
gh pr checkout <N> --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Then run the three manual scenarios listed above.

## PR checklist

- [x] Branched from `main`
- [x] Build passes locally
- [x] No build logs, binaries, or credentials committed
