### PR TITLE
chore: release prep for 1.2.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release receives security fixes. Older versions are not patched.
 
 | Version | Supported |
 |---------|-----------|
-| 1.1.2 (latest) | ✅ |
-| < 1.1.2 | ❌ |
+| 1.2.0 (latest) | ✅ |
+| < 1.2.0 | ❌ |
 
 ## Reporting a Vulnerability
 

--- a/OpenEmu/OpenEmu-Info.plist
+++ b/OpenEmu/OpenEmu-Info.plist
@@ -122,7 +122,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -143,7 +143,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -8364,7 +8364,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.OpenEmu.debug;
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
@@ -8404,7 +8404,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.$(PRODUCT_NAME:identifier)";
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_OBJC_BRIDGING_HEADER = "OpenEmu-Bridging-Header.h";

--- a/Releases/notes-1.2.0.md
+++ b/Releases/notes-1.2.0.md
@@ -1,0 +1,23 @@
+## What's New in 1.2.0
+
+- **Nintendo DS** — OpenEmu now includes a native DeSmuME core for Nintendo DS. DS games run natively on Apple Silicon with full dual-screen support, save states, and controller input. Import your .nds files and they'll appear in a new Nintendo DS library automatically.
+- **Arcade (experimental)** — A native MAME core is now bundled for Arcade games. Sprite-based classics like Donkey Kong, Pac-Man, and Street Fighter II work well. Polygonal 3D hardware (Sega Model 1/2/3) has known rendering limitations — tracked in [#551](https://github.com/nickybmon/OpenEmu-Silicon/issues/551).
+- **RetroAchievements UI** — The in-game achievements experience is substantially improved. An achievement list panel shows your progress mid-session, gameplay event indicators appear on-screen when achievements unlock or are close to triggering, and online/offline status is shown at a glance. Games not recognized by RetroAchievements now surface a clear explanation rather than silently doing nothing.
+- **Core updates (cores-v1.3.3)** — All RetroAchievements-capable cores were rebuilt and updated. Cores that previously needed the RA token before launch now initialize correctly on the first try.
+
+## Bug Fixes
+
+- Fixed a RetroAchievements token race on app launch that could prevent achievement tracking from starting until the app was restarted.
+- Fixed a hang when creating or loading save states that could occur when the Core Data save was dispatched synchronously on the game thread.
+- Fixed the "retry with another core" flow for Arcade ROMs — after a failed launch, retrying with a different core now works correctly instead of getting stuck in a broken state.
+- Fixed keychain prompts appearing after the credential migration from the old macOS Keychain store to the encrypted file store.
+- Fixed a duplicate core list startup error that appeared in the console on first launch.
+- Fixed DeSmuME display layout switching — toggling between stacked and side-by-side screen arrangements no longer leaves a gap or misaligns the touch screen.
+- Fixed 3DO video rendering in Release builds (4DO core) — games no longer show a black screen on release-config launches.
+- Fixed 3DO libretro import path issue that prevented some 3DO ROMs from loading via the libretro bridge.
+- Fixed app hang reports (AppHang in Sentry) caused by VGDB sync and RetroAchievements core scanning running on the main thread — both are now dispatched asynchronously.
+- Fixed an en-GB partial localization causing string fallback issues on systems set to British English.
+
+## Known Limitations
+
+- **MAME polygonal 3D** — Games relying on Sega Model 1/2/3 or other polygonal 3D hardware have rendering and audio issues. Tracked in [#551](https://github.com/nickybmon/OpenEmu-Silicon/issues/551).


### PR DESCRIPTION
## What does this PR do?

Bumps the app version to 1.2.0 (build 16), updates MARKETING_VERSION in the Xcode project, updates the security policy supported versions table, and adds release notes for 1.2.0.

## What did you test?

- `verify.sh --launch` — PASS (build, analyze, plist lint, codesign)
- `check-core-feed-urls.sh` — PASS (all SUFeedURLs resolve)
- Release build clean (`xcodebuild -configuration Release` — BUILD SUCCEEDED)
- Manual smoke: DeSmuME, MAME, RA login/achievement list, save state, failed launch retry — all passing

Note: Debug config codesign fails due to `OpenEmuTests.xctest` having no signing team configured — pre-existing issue unrelated to this change.

## Which cores or systems are affected?

General app change — no core or system plugin changes.

## Did you use AI tools?

Yes — used Claude Code to run verification, draft release notes, and prepare the version bump files.

## Linked issues

Related to #551 (MAME known limitation documented in release notes)

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: Release config builds clean
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header