### PR TITLE
fix: stop release crash loops

### DIFF
--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -46,8 +46,9 @@ class GameDocumentController: NSDocumentController {
     
     override func removeDocument(_ document: NSDocument) {
         
-        if let document = document as? OEGameDocument {
-            gameDocuments.remove(at: gameDocuments.firstIndex(of: document)!)
+        if let document = document as? OEGameDocument,
+           let index = gameDocuments.firstIndex(of: document) {
+            gameDocuments.remove(at: index)
         }
         
         super.removeDocument(document)

--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -45,13 +45,16 @@ class GameDocumentController: NSDocumentController {
     }
     
     override func removeDocument(_ document: NSDocument) {
+        let isKnownDocument = documents.contains { $0 === document }
         
         if let document = document as? OEGameDocument,
            let index = gameDocuments.firstIndex(of: document) {
             gameDocuments.remove(at: index)
         }
         
-        super.removeDocument(document)
+        if isKnownDocument {
+            super.removeDocument(document)
+        }
     }
     
     private func sendDelegateCallback(toTarget target: AnyObject, selector: Selector, documentController: NSDocumentController, didReviewAll: Bool, contextInfo: UnsafeMutableRawPointer?) {

--- a/OpenEmu/OELibraryDatabase.swift
+++ b/OpenEmu/OELibraryDatabase.swift
@@ -686,7 +686,11 @@ final class OELibraryDatabase: NSObject {
                     gameInfo.removeValue(forKey: "boxImageURL")
                     
                     let game = OEDBGame.object(with: objectID, in: context)
-                    game?.setValuesForKeys(gameInfo)
+                    if let game = game {
+                        let allowedAttributeKeys = Set(game.entity.attributesByName.keys)
+                        let safeGameInfo = gameInfo.filter { allowedAttributeKeys.contains($0.key) }
+                        game.setValuesForKeys(safeGameInfo)
+                    }
                     
                     if let imageDictionary = imageDictionary,
                        let game = game {

--- a/OpenEmu/OELibraryDatabase.swift
+++ b/OpenEmu/OELibraryDatabase.swift
@@ -688,6 +688,10 @@ final class OELibraryDatabase: NSObject {
                     let game = OEDBGame.object(with: objectID, in: context)
                     if let game = game {
                         let allowedAttributeKeys = Set(game.entity.attributesByName.keys)
+                        let droppedKeys = Set(gameInfo.keys).subtracting(allowedAttributeKeys)
+                        if !droppedKeys.isEmpty {
+                            DLog("Ignoring unsupported OpenVGDB sync keys for Game: \(droppedKeys.sorted().joined(separator: ", "))")
+                        }
                         let safeGameInfo = gameInfo.filter { allowedAttributeKeys.contains($0.key) }
                         game.setValuesForKeys(safeGameInfo)
                     }

--- a/OpenEmu/OELibraryDatabase.swift
+++ b/OpenEmu/OELibraryDatabase.swift
@@ -698,7 +698,7 @@ final class OELibraryDatabase: NSObject {
                     
                     if let imageDictionary = imageDictionary,
                        let game = game {
-                        let image = OEDBImage.createImage(with: imageDictionary)
+                        let image = OEDBImage.createImage(with: imageDictionary, in: context)
                         if let previousImage = game.boxImage {
                             previousBoxImages.append(previousImage.permanentID)
                         }


### PR DESCRIPTION
## What does this PR do?

Fixes two crash loops reported right after the 1.2.0 release:

- SNES launch failure could remove the same game document twice and hit a forced unwrap in `GameDocumentController.removeDocument(_:)`.
- Startup OpenVGDB sync could pass unsafe metadata into Core Data or create artwork in the wrong managed-object context, causing uncaught Core Data exceptions during background library sync.

## What did you test?

- Symbolicated both attached crash logs locally against the 1.2.0 archive/binary.n- Reviewed Sentry release `openemu-silicon@1.2.0+16` and fixed the matching OpenVGDB artwork context crash.
- Ran a Debug app build.
- Ran `./Scripts/verify.sh`.

## Which cores or systems are affected?

General app/library handling. Issue #557 was reported while launching SNES games, but the fixed document-removal crash path is frontend-level. Issue #558 is frontend/library metadata sync.

## Did you use AI tools?

Used Claude/pi to triage crash logs, symbolicate stack traces, make the surgical fix, and run local verification.

## Linked issues

Fixes #557
Fixes #558

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 559 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

PR-specific checks:

1. Import or keep a few games with missing metadata so OpenVGDB sync runs on launch.
2. Launch the app and confirm it stays open past the previous ~4 second crash window.
3. Launch an SNES game with SNES9x/BSNES. If the core setup fails, OpenEmu should show the normal failure path instead of crashing in document cleanup.

---

## PR checklist

- [x] Branched from current local `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon via local build verification
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header