### PR TITLE
fix: guard rom.url access in deinit against invalidated MOC

### DIFF
--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -454,7 +454,12 @@ final class OEGameDocument: NSDocument {
     }
     
     deinit {
-        if let url = romFileURL, url != rom.url {
+        // rom is a Core Data object — its context may already be torn down during quit.
+        // Guard against a faulted/invalidated object before accessing the URL.
+        if let url = romFileURL,
+           rom.managedObjectContext != nil,
+           !rom.isDeleted,
+           url != rom.url {
             try? FileManager.default.removeItem(at: url)
         }
     }


### PR DESCRIPTION
## What does this PR do?

Guards `rom.url` access in `OEGameDocument.deinit` against a crash that occurs when the Core Data managed object context is torn down before the document is deallocated during app quit.

## What did you test?

Quit OpenEmu while a game was open. Build passes; crash was confirmed via Sentry symbolication of OPENEMU-SILICON-6N — no reproduction steps needed as the fix is a defensive guard on two properties Apple documents as safe to call on any managed object regardless of context state.

## Which cores or systems are affected?

General app change — any core/system where the ROM is loaded from an archive (decompressed temp file path differs from `rom.url`).

## Did you use AI tools?

Used Claude to identify the crash site via symbolication and write the fix.

## Linked issues

Fixes #561

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 562 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header