### PR TITLE
docs: fix broken links after retro-achievements folder move

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You don't need to write code to make a meaningful contribution.
 |------|-----------------|--------------|
 | **Issue Triager** | Applying labels, asking for repro steps, closing duplicates, flagging `good first issue` candidates | Engage with a few issues, then ask the maintainer for triage permissions |
 | **Compatibility Tester** | Testing games on the latest build, documenting results in the wiki | Open a Discussion and introduce yourself |
-| **RetroAchievements Liaison** | Testing RA integration per-core, filing upstream RA tickets, maintaining the compatibility table | See [docs/retroachievements-community-guide.md](../docs/retroachievements-community-guide.md) |
+| **RetroAchievements Liaison** | Testing RA integration per-core, filing upstream RA tickets, maintaining the compatibility table | See [docs/retro-achievements/retroachievements-community-guide.md](../docs/retro-achievements/retroachievements-community-guide.md) |
 | **Wiki / Docs Maintainer** | Keeping installation guides, core pages, and build instructions accurate | Open a PR or comment on a docs issue |
 | **Code Contributor** | Bug fixes, feature work, core updates | Read on |
 
@@ -123,9 +123,9 @@ Comment on an issue before you start work to avoid duplicates.
 
 ## Working on RetroAchievements Integration
 
-RA core integration is tracked in [issue #258](https://github.com/nickybmon/OpenEmu-Silicon/issues/258). The implementation pattern and known pitfalls are documented in [docs/retroachievements-implementation-guide.md](../docs/retroachievements-implementation-guide.md). Read that before wiring up a new core.
+RA core integration is tracked in [issue #258](https://github.com/nickybmon/OpenEmu-Silicon/issues/258). The implementation pattern and known pitfalls are documented in [docs/retro-achievements/retroachievements-implementation-guide.md](../docs/retro-achievements/retroachievements-implementation-guide.md). Read that before wiring up a new core.
 
-For testing RA as a user or tester rather than as a developer, see [docs/retroachievements-community-guide.md](../docs/retroachievements-community-guide.md).
+For testing RA as a user or tester rather than as a developer, see [docs/retro-achievements/retroachievements-community-guide.md](../docs/retro-achievements/retroachievements-community-guide.md).
 
 ---
 
@@ -154,7 +154,7 @@ The compatibility list lives in the [project wiki](https://github.com/nickybmon/
 
 ### RetroAchievements Testing
 
-See [docs/retroachievements-community-guide.md](../docs/retroachievements-community-guide.md) for how to test achievement behavior per-core and how to file upstream RA tickets.
+See [docs/retro-achievements/retroachievements-community-guide.md](../docs/retro-achievements/retroachievements-community-guide.md) for how to test achievement behavior per-core and how to file upstream RA tickets.
 
 ---
 

--- a/docs/TRIAGE_GUIDE.md
+++ b/docs/TRIAGE_GUIDE.md
@@ -167,7 +167,7 @@ This is how RPCS3 grew its team.
 
 ## RetroAchievements-Specific Triage
 
-RA issues require different handling. See [retroachievements-community-guide.md](retroachievements-community-guide.md) for full context. Short version:
+RA issues require different handling. See [retroachievements-community-guide.md](retro-achievements/retroachievements-community-guide.md) for full context. Short version:
 
 - **Achievement not triggering / triggering incorrectly:** Apply `retro-achievements` + the relevant core label. Ask: is this core in the supported list? If not, link to the [RA rollout issue (#258)](https://github.com/nickybmon/OpenEmu-Silicon/issues/258). If yes, ask for game title, achievement name, and whether it reproduces with RA disabled.
 - **RA vs. emulator bug:** Many RA bugs belong upstream in the RetroAchievements issue tracker or in rcheevos, not here. When the achievement set itself is wrong (wrong memory address, wrong trigger condition), file an RA-side ticket and link it from the issue here.

--- a/docs/progress-report-template.md
+++ b/docs/progress-report-template.md
@@ -109,7 +109,7 @@ New to the project? Here's where to start:
 - [`good first issue`](https://github.com/nickybmon/OpenEmu-Silicon/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — well-scoped bugs and improvements with pointers to the relevant code
 - [`help wanted`](https://github.com/nickybmon/OpenEmu-Silicon/issues?q=is%3Aopen+label%3A%22help+wanted%22) — things the maintainer wants help with but can't prioritize right now
 - [CONTRIBUTING.md](../.github/CONTRIBUTING.md) — how to set up a build, submit a PR, and the AI contribution policy
-- [RetroAchievements Community Guide](retroachievements-community-guide.md) — if you're an RA user or achievement set developer
+- [RetroAchievements Community Guide](retro-achievements/retroachievements-community-guide.md) — if you're an RA user or achievement set developer
 
 Questions? Open a [Discussion](https://github.com/nickybmon/OpenEmu-Silicon/discussions).
 


### PR DESCRIPTION
Three RA docs were moved into docs/retro-achievements/ but CONTRIBUTING.md,
TRIAGE_GUIDE.md, and progress-report-template.md still referenced the old
top-level docs/ paths.

https://claude.ai/code/session_01ENNyUysCGuTDmpkL9HNgZG