### PR TITLE
fix: distinguish Dreamcast GDI imports by track content

### DIFF
--- a/OpenEmu/ImportOperation.swift
+++ b/OpenEmu/ImportOperation.swift
@@ -696,22 +696,7 @@ final class ImportOperation: Operation, NSCopying, @unchecked Sendable {
         let url = extractedFileURL ?? url
         
         do {
-            let md5: String
-            if let gdiHash = dreamcastGDIContentHash(at: url) {
-                // Pre-fix Dreamcast GDI imports were stored under the descriptor
-                // file's MD5. Keep that lookup path so existing libraries don't
-                // accept a one-time duplicate import after upgrading.
-                let descriptorHash = try FileManager.default.hashFile(at: url).lowercased()
-                if let context = importer.context,
-                   let existingROM = try? OEDBRom.rom(withMD5HashString: descriptorHash, in: context),
-                   existingROM != nil {
-                    md5 = descriptorHash
-                } else {
-                    md5 = gdiHash
-                }
-            } else {
-                md5 = try FileManager.default.hashFile(at: url)
-            }
+            let md5 = try importHash(for: url)
             
             md5Hash = md5.lowercased()
             
@@ -728,7 +713,44 @@ final class ImportOperation: Operation, NSCopying, @unchecked Sendable {
         }
     }
 
-    private func dreamcastGDIContentHash(at url: URL) -> String? {
+    private func importHash(for url: URL) throws -> String {
+        guard let gdiHash = Self.dreamcastGDIContentHash(at: url) else {
+            return try FileManager.default.hashFile(at: url)
+        }
+
+        // Pre-fix Dreamcast GDI imports were stored under the descriptor file's
+        // MD5. Keep that lookup only when it points at the same track content.
+        // Different games can ship identical descriptor text, so descriptor MD5
+        // alone is not enough to prove the ROM is already in the library.
+        let descriptorHash = try FileManager.default.hashFile(at: url).lowercased()
+        if let context = importer.context,
+           let existingROM = try? OEDBRom.rom(withMD5HashString: descriptorHash, in: context),
+           shouldUseLegacyDreamcastGDIHash(for: existingROM, newContentHash: gdiHash) {
+            return descriptorHash
+        }
+
+        return gdiHash
+    }
+
+    private func shouldUseLegacyDreamcastGDIHash(for existingROM: OEDBRom, newContentHash: String) -> Bool {
+        guard let existingURL = existingROM.url else {
+            // Let performImportStepCheckHash remove the stale legacy row.
+            return true
+        }
+
+        guard (try? existingURL.checkResourceIsReachable()) == true else {
+            // Let performImportStepCheckHash remove the stale legacy row.
+            return true
+        }
+
+        guard let existingContentHash = Self.dreamcastGDIContentHash(at: existingURL) else {
+            return true
+        }
+
+        return existingContentHash == newContentHash.lowercased()
+    }
+
+    static func dreamcastGDIContentHash(at url: URL) -> String? {
         guard url.pathExtension.caseInsensitiveCompare("gdi") == .orderedSame else { return nil }
         guard let descriptor = try? OEDreamcastGDI(fileURL: url) else { return nil }
 

--- a/OpenEmu/OpenEmuTests/ROMImporterTests.swift
+++ b/OpenEmu/OpenEmuTests/ROMImporterTests.swift
@@ -26,38 +26,81 @@ import XCTest
 @testable import OpenEmu
 
 class ROMImporterTests: XCTestCase {
-    
+
+    func testDreamcastGDIContentHashUsesReferencedTracks() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenEmu-GDIHashTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let firstGDI = try makeDreamcastGDITestFolder(at: rootURL.appendingPathComponent("Crazy Taxi", isDirectory: true), trackPayload: "crazy taxi")
+        let secondGDI = try makeDreamcastGDITestFolder(at: rootURL.appendingPathComponent("18 Wheeler", isDirectory: true), trackPayload: "18 wheeler")
+
+        XCTAssertEqual(try FileManager.default.hashFile(at: firstGDI), try FileManager.default.hashFile(at: secondGDI))
+        XCTAssertNotEqual(ImportOperation.dreamcastGDIContentHash(at: firstGDI), ImportOperation.dreamcastGDIContentHash(at: secondGDI))
+    }
+
+    func testDreamcastGDIContentHashMatchesIdenticalTrackContent() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenEmu-GDIHashTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let firstGDI = try makeDreamcastGDITestFolder(at: rootURL.appendingPathComponent("First", isDirectory: true), trackPayload: "same game")
+        let secondGDI = try makeDreamcastGDITestFolder(at: rootURL.appendingPathComponent("Second", isDirectory: true), trackPayload: "same game")
+
+        XCTAssertEqual(ImportOperation.dreamcastGDIContentHash(at: firstGDI), ImportOperation.dreamcastGDIContentHash(at: secondGDI))
+    }
+
+    private func makeDreamcastGDITestFolder(at folderURL: URL, trackPayload: String) throws -> URL {
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+
+        let gdiURL = folderURL.appendingPathComponent("disc.gdi")
+        let descriptor = """
+        3
+        1 0 4 2048 track01.bin 0
+        2 450 0 2352 track02.raw 0
+        3 45150 4 2048 track03.bin 0
+        """
+        try descriptor.write(to: gdiURL, atomically: true, encoding: .utf8)
+        try "common metadata".data(using: .utf8)!.write(to: folderURL.appendingPathComponent("track01.bin"))
+        try trackPayload.data(using: .utf8)!.write(to: folderURL.appendingPathComponent("track02.raw"))
+        try "more common metadata".data(using: .utf8)!.write(to: folderURL.appendingPathComponent("track03.bin"))
+
+        return gdiURL
+    }
+
     func testArchiveUnarchiveOperationQueue() {
         let ri = ROMImporter(database: OELibraryDatabase.default!)
-        
+
         let data: Data!
         let url1 = URL(string: "file://url/op1")!
         let url2 = URL(string: "file://url/op2")!
-        
+
         do {
             var ops: [ImportOperation] = []
             var op: ImportOperation
-            
+
             op = ImportOperation(url: url1, sourceURL: url1)
             ops.append(op)
-            
+
             op = ImportOperation(url: url2, sourceURL: url2)
             ops.append(op)
-            
+
             data = ri._data(forOperationQueue: ops)
             XCTAssertNotNil(data)
         }
-        
+
         do {
             let ops: [ImportOperation]! = ri._operationQueue(from: data)
             XCTAssertNotNil(ops)
             XCTAssertEqual(ops.count, 2)
             var op: ImportOperation
-            
+
             op = ops[0]
             XCTAssertEqual(op.url.absoluteString, url1.absoluteString)
             XCTAssertEqual(op.sourceURL.absoluteString, url1.absoluteString)
-            
+
             op = ops[1]
             XCTAssertEqual(op.url.absoluteString, url2.absoluteString)
             XCTAssertEqual(op.sourceURL.absoluteString, url2.absoluteString)


### PR DESCRIPTION
## What does this PR do?

Fixes Dreamcast GDI imports that were incorrectly blocked as already in the library when two different games shared identical `.gdi` descriptor text.

The import path now:

- hashes the referenced GDI track contents for Dreamcast `.gdi` imports;
- keeps the legacy descriptor-hash duplicate path only when the existing ROM's track content matches the new import;
- allows different games with identical descriptor text, such as Crazy Taxi and 18 Wheeler, to import separately;
- still blocks re-importing the exact same GDI game as a duplicate.

## What did you test?

- Built Debug OpenEmu successfully:

```bash
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build
```

- Manual local validation:
  - Imported Crazy Taxi `.gdi`.
  - Imported 18 Wheeler `.gdi` afterward.
  - Confirmed both imported as separate Dreamcast games.
  - Re-imported the same 18 Wheeler `.gdi` and confirmed duplicate blocking still works.

Targeted unit-test run was attempted, but the existing test target currently fails before running tests because it cannot resolve `XADMaster` / `OpenEmuKitPrivate` test dependencies.

## Which cores or systems are affected?

- Dreamcast imports using GDI descriptor files.
- No Flycast core rebuild is required; this is app import logic.

## Did you use AI tools?

Used an AI coding assistant to inspect the import path, implement the hash fallback guard, and summarize verification.

## Linked issues

Fixes #501

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 566 --repo nickybmon/OpenEmu-Silicon

xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30

open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

Manual check:

1. Import a Dreamcast GDI game such as Crazy Taxi.
2. Import another Dreamcast GDI game with identical descriptor text but different track content, such as 18 Wheeler.
3. Confirm the second game imports instead of being blocked as already in the library.
4. Import the same second `.gdi` again.
5. Confirm the exact duplicate is still blocked.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes with `xcodebuild` Debug app build
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
