### PR TITLE
fix: load mismatched save states from alert

### DIFF
--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2161,7 +2161,7 @@ final class OEGameDocument: NSDocument {
                     alert.beginSheetModal(for: win) { [weak self] response in
                         guard let self else { return }
                         if response == .alertFirstButtonReturn {
-                            self.loadState()
+                            loadState()
                         } else {
                             self.startEmulation()
                         }


### PR DESCRIPTION
## What does this PR do?

Fixes the “Load Anyway” button in the save-state version mismatch sheet. The sheet callback was calling the parameterless `loadState()` action instead of the local closure that loads the selected save state, so clicking the button did not actually load the chosen old-version state.

## What did you test?

- Ran `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- Ran `./Scripts/verify.sh`

## Which cores or systems are affected?

General app save-state flow. Reported with NES / Famicom using Nestopia.

## Did you use AI tools?

Used pi/Claude to inspect the issue, identify the callback bug, make the one-line fix, and run verification.

## Linked issues

Fixes #564

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

To verify the specific fix:

1. Use a save state whose saved core version differs from the installed core version.
2. Launch that save state so the “Save State Version Mismatch” alert appears.
3. Click “Load Anyway”.
4. Confirm OpenEmu attempts to load that selected save state instead of returning to/stalling in the normal load-state action path.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header