### PR TITLE
fix: show running core in game window title

### DIFF
--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -476,6 +476,9 @@ final class OEGameDocument: NSDocument {
             // The latter uses Cocoa document architecture and relies on documents having URLs,
             // including untitled (new) documents.
             var displayName = rom.game?.displayName ?? ""
+            if let coreName = corePlugin?.displayName, !coreName.isEmpty {
+                displayName += " (\(coreName))"
+            }
             #if DEBUG
             displayName += " (DEBUG BUILD)"
             #endif


### PR DESCRIPTION
## What does this PR do?

Shows the active core in the game window title, so users can tell which core is running when multiple cores are installed for the same system.

Example: `Golf (Beetle VB)`.

## What did you test?

Built the main OpenEmu app successfully with `xcodebuild`.

## Which cores or systems are affected?

General app UI. No core code changed.

## Did you use AI tools?

Used Claude/Pi to make the small code change and run the build check.

## Linked issues

Fixes #496

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 569 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

After launch, open a game and confirm the window title shows the game name followed by the running core name in parentheses.

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
