### PR TITLE
feat: add Genesis Sonic & Knuckles lock-on launch

### DIFF
--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -378,6 +378,35 @@ static __weak GenPlusGameCore *_current;
 
     [self configureOptions];
 
+    if (self.lockOnRomURL != nil && [self.systemIdentifier isEqualToString:@"openemu.system.sg"])
+    {
+        config.lock_on = TYPE_SK;
+        snprintf(SK_ROM, sizeof(SK_ROM), "%s", self.lockOnRomURL.path.fileSystemRepresentation);
+        if (self.lockOnUpmemURL != nil)
+        {
+            snprintf(SK_UPMEM, sizeof(SK_UPMEM), "%s", self.lockOnUpmemURL.path.fileSystemRepresentation);
+        }
+        else
+        {
+            NSArray<NSString *> *candidateNames = @[@"sk_upmem.bin", @"Sonic & Knuckles (World) (Lock-on).bin"];
+            SK_UPMEM[0] = '\0';
+            for (NSString *candidateName in candidateNames)
+            {
+                NSString *candidatePath = [self.biosDirectoryPath stringByAppendingPathComponent:candidateName];
+                if ([NSFileManager.defaultManager isReadableFileAtPath:candidatePath])
+                {
+                    snprintf(SK_UPMEM, sizeof(SK_UPMEM), "%s", candidatePath.fileSystemRepresentation);
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        SK_ROM[0] = '\0';
+        SK_UPMEM[0] = '\0';
+    }
+
     if (!load_rom((char *)path.fileSystemRepresentation))
         return NO;
 

--- a/GenesisPlus/genplusgx_source/cart_hw/md_cart.c
+++ b/GenesisPlus/genplusgx_source/cart_hw/md_cart.c
@@ -749,24 +749,25 @@ void md_cart_init(void)
         /* check ROM header */
         if (!memcmp(cart.rom + 0x400000 + 0x120, "SONIC & KNUCKLES",16))
         {
-          /* try to load Sonic 2 & Knuckles upmem ROM file (256KB) */
-          if (load_archive(SK_UPMEM, cart.rom + 0x600000, 0x40000, NULL) == 0x40000)
+          int sk_upmem_loaded = (load_archive(SK_UPMEM, cart.rom + 0x600000, 0x40000, NULL) == 0x40000);
+
+          /* $000000-$1FFFFF is mapped to S&K ROM */
+          for (i=0x00; i<0x20; i++)
           {
-            /* $000000-$1FFFFF is mapped to S&K ROM */
-            for (i=0x00; i<0x20; i++)
-            {
-              m68k.memory_map[i].base = cart.rom + 0x400000 + (i << 16);
-            }
+            m68k.memory_map[i].base = cart.rom + 0x400000 + (i << 16);
+          }
 
 #ifdef LSB_FIRST
-            for (i=0; i<0x200000; i+=2)
-            {
-              /* Byteswap ROM */
-              uint8 temp = cart.rom[i + 0x400000];
-              cart.rom[i + 0x400000] = cart.rom[i + 0x400000 + 1];
-              cart.rom[i + 0x400000 + 1] = temp;
-            }
+          for (i=0; i<0x200000; i+=2)
+          {
+            /* Byteswap ROM */
+            uint8 temp = cart.rom[i + 0x400000];
+            cart.rom[i + 0x400000] = cart.rom[i + 0x400000 + 1];
+            cart.rom[i + 0x400000 + 1] = temp;
+          }
 
+          if (sk_upmem_loaded)
+          {
             for (i=0; i<0x40000; i+=2)
             {
               /* Byteswap ROM */
@@ -774,9 +775,9 @@ void md_cart_init(void)
               cart.rom[i + 0x600000] = cart.rom[i + 0x600000 + 1];
               cart.rom[i + 0x600000 + 1] = temp;
             }
-#endif
-            cart.special |= HW_LOCK_ON;
           }
+#endif
+          cart.special |= HW_LOCK_ON;
         }
       }
       break;

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -249,6 +249,8 @@ OE_EXPORTED_CLASS
 @property(nonatomic, copy)     NSString                      *ROMMD5 NS_SWIFT_NAME(romMD5);
 @property(nonatomic, copy)     NSString                      *ROMHeader;
 @property(nonatomic, copy)     NSString                      *ROMSerial;
+@property(nonatomic, copy, nullable) NSURL                    *lockOnRomURL;
+@property(nonatomic, copy, nullable) NSURL                    *lockOnUpmemURL;
 
 /** The current value for each display mode preference key. Used to fetch the
  *  initial display mode state after the core is initialized.

--- a/OpenEmu/GameDocumentController.swift
+++ b/OpenEmu/GameDocumentController.swift
@@ -176,8 +176,8 @@ class GameDocumentController: NSDocumentController {
     }
     
     override func openGameDocument(with game: OEDBGame, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
-        // Bring an already-running document for this game to front rather than opening a second copy.
-        if let existing = gameDocuments.first(where: { $0.rom?.game == game }) {
+        // Bring an already-running normal document for this game to front rather than opening a second copy.
+        if let existing = gameDocuments.first(where: { $0.rom?.game == game && $0.lockOnROMURL == nil }) {
             existing.gameWindowController?.window?.makeKeyAndOrderFront(nil)
             completionHandler(existing, nil)
             return
@@ -191,13 +191,28 @@ class GameDocumentController: NSDocumentController {
     }
     
     override func openGameDocument(with game: OEDBGame, core: OECorePlugin, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
-        if let existing = gameDocuments.first(where: { $0.rom?.game == game }) {
+        if let existing = gameDocuments.first(where: { $0.rom?.game == game && $0.lockOnROMURL == nil }) {
             existing.gameWindowController?.window?.makeKeyAndOrderFront(nil)
             completionHandler(existing, nil)
             return
         }
         do {
             let document = try OEGameDocument(game: game, core: core)
+            setUpGameDocument(document, display: displayDocument, fullScreen: fullScreen, completionHandler: completionHandler)
+        } catch {
+            completionHandler(nil, error)
+        }
+    }
+
+    override func openGameDocument(with game: OEDBGame, core: OECorePlugin, lockOnROM: OEDBRom, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
+        let lockOnURL = lockOnROM.url
+        if let existing = gameDocuments.first(where: { $0.rom?.game == game && $0.lockOnROMURL == lockOnURL }) {
+            existing.gameWindowController?.window?.makeKeyAndOrderFront(nil)
+            completionHandler(existing, nil)
+            return
+        }
+        do {
+            let document = try OEGameDocument(game: game, core: core, lockOnROM: lockOnROM)
             setUpGameDocument(document, display: displayDocument, fullScreen: fullScreen, completionHandler: completionHandler)
         } catch {
             completionHandler(nil, error)

--- a/OpenEmu/LibraryController.swift
+++ b/OpenEmu/LibraryController.swift
@@ -441,6 +441,16 @@ final class LibraryController: NSTabViewController, NSMenuItemValidation {
         else { return }
         delegate?.libraryController?(self, didSelectGame: game, withCore: core)
     }
+
+    @objc(startSelectedGameLockedOnToSonicKnuckles:)
+    @IBAction func startSelectedGameLockedOnToSonicKnuckles(_ sender: NSMenuItem) {
+        guard let lockOnGame = sender.representedObject as? OEDBGame else { return }
+        guard
+            let ctl = tabView.selectedTabViewItem?.viewController as? LibrarySubviewControllerGameSelection,
+            let game = ctl.selectedGames.first
+        else { return }
+        delegate?.libraryController?(self, didSelectGame: game, lockedOnTo: lockOnGame)
+    }
     
     @objc(startSelectedGameWithSaveState:)
     @IBAction func startSelectedGame(saveState sender: NSMenuItem) {
@@ -481,6 +491,7 @@ extension LibraryController {
 protocol LibraryControllerDelegate {
     @objc optional func libraryController(_ controller: LibraryController, didSelectGame: OEDBGame)
     @objc optional func libraryController(_ controller: LibraryController, didSelectGame: OEDBGame, withCore: OECorePlugin)
+    @objc optional func libraryController(_ controller: LibraryController, didSelectGame: OEDBGame, lockedOnTo: OEDBGame)
     @objc optional func libraryController(_ controller: LibraryController, didSelectRom: OEDBRom)
     @objc optional func libraryController(_ controller: LibraryController, didSelectSaveState: OEDBSaveState)
 }

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -242,13 +242,25 @@ extension MainWindowController: LibraryControllerDelegate {
     func libraryController(_ controller: LibraryController, didSelectGame game: OEDBGame, withCore core: OECorePlugin) {
         openGameDocument(with: game, core: core, saveState: nil)
     }
+
+    func libraryController(_ controller: LibraryController, didSelectGame game: OEDBGame, lockedOnTo lockOnGame: OEDBGame) {
+        guard game.system?.systemIdentifier == "openemu.system.sg",
+              lockOnGame.system?.systemIdentifier == "openemu.system.sg",
+              let genesisPlus = OECorePlugin.corePlugin(bundleIdentifier: "org.openemu.GenesisPlus"),
+              let lockOnROM = lockOnGame.defaultROM,
+              lockOnROM.filesAvailable else {
+            NSSound.beep()
+            return
+        }
+        openGameDocument(with: game, core: genesisPlus, saveState: nil, secondAttempt: false, lockOnROM: lockOnROM, disableAutoReload: true)
+    }
     
     func libraryController(_ controller: LibraryController, didSelectSaveState saveState: OEDBSaveState) {
         openGameDocument(with: nil, saveState: saveState)
     }
     
     @available(macOS, deprecated: 10.15, message: "Remove 'or \"User Reports\"' from alert (~line 392) and localizations, the term is not used in Catalina and above.")
-    private func openGameDocument(with game: OEDBGame?, core: OECorePlugin? = nil, saveState state: OEDBSaveState?, secondAttempt retry: Bool = false, disableAutoReload noAutoReload: Bool = false) {
+    private func openGameDocument(with game: OEDBGame?, core: OECorePlugin? = nil, saveState state: OEDBSaveState?, secondAttempt retry: Bool = false, lockOnROM: OEDBRom? = nil, disableAutoReload noAutoReload: Bool = false) {
         
         guard let window = window else { return assertionFailure("MainWindow is nil") }
         
@@ -391,6 +403,8 @@ extension MainWindowController: LibraryControllerDelegate {
         
         if openWithSaveState {
             NSDocumentController.shared.openGameDocument(with: state!, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
+        } else if let core, let lockOnROM {
+            NSDocumentController.shared.openGameDocument(with: game!, core: core, lockOnROM: lockOnROM, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
         } else if let core {
             NSDocumentController.shared.openGameDocument(with: game!, core: core, display: openInSeparateWindow, fullScreen: fullScreen, completionHandler: openDocument)
         } else {

--- a/OpenEmu/NSDocumentController+Additions.swift
+++ b/OpenEmu/NSDocumentController+Additions.swift
@@ -52,6 +52,10 @@ extension NSDocumentController {
     @objc func openGameDocument(with game: OEDBGame, core: OECorePlugin, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
         fatalError("Method must be implemented by a subclass.")
     }
+
+    @objc func openGameDocument(with game: OEDBGame, core: OECorePlugin, lockOnROM: OEDBRom, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {
+        fatalError("Method must be implemented by a subclass.")
+    }
     
     @objc(openGameDocumentWithRom:display:fullScreen:completionHandler:)
     func openGameDocument(with rom: OEDBRom, display displayDocument: Bool, fullScreen: Bool, completionHandler: @escaping (OEGameDocument?, Error?) -> Void) {

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -592,6 +592,67 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
 }
 
 #pragma mark - Context Menu
+
+- (BOOL)OE_isGenesisGame:(OEDBGame *)game
+{
+    return [[game.system systemIdentifier] isEqualToString:@"openemu.system.sg"];
+}
+
+- (BOOL)OE_isSonicKnucklesROM:(OEDBRom *)rom
+{
+    if(![rom filesAvailable]) return NO;
+
+    NSString *header = [rom header] ?: @"";
+    NSString *serial = [rom serial] ?: @"";
+    if([header rangeOfString:@"SONIC & KNUCKLES" options:NSCaseInsensitiveSearch].location != NSNotFound ||
+       [serial rangeOfString:@"MK-1563" options:NSCaseInsensitiveSearch].location != NSNotFound)
+        return YES;
+
+    NSURL *url = [rom URL];
+    NSFileHandle *handle = url != nil ? [NSFileHandle fileHandleForReadingFromURL:url error:nil] : nil;
+    if(handle != nil)
+    {
+        [handle seekToFileOffset:0x120];
+        NSData *data = [handle readDataOfLength:16];
+        [handle closeFile];
+        NSString *romHeader = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+        if([romHeader rangeOfString:@"SONIC & KNUCKLES" options:NSCaseInsensitiveSearch].location != NSNotFound)
+            return YES;
+    }
+
+    return NO;
+}
+
+- (BOOL)OE_isSonicKnucklesGame:(OEDBGame *)game
+{
+    if(![self OE_isGenesisGame:game]) return NO;
+
+    for(OEDBRom *rom in [game roms])
+    {
+        if([self OE_isSonicKnucklesROM:rom]) return YES;
+    }
+
+    return NO;
+}
+
+- (OEDBGame *)OE_sonicKnucklesGameForLockOnGame:(OEDBGame *)game
+{
+    if(![self OE_isGenesisGame:game]) return nil;
+
+    NSManagedObjectContext *context = [game managedObjectContext];
+    if(context == nil) return nil;
+
+    NSFetchRequest *request = [OEDBGame fetchRequest];
+    request.predicate = [NSPredicate predicateWithFormat:@"system == %@", game.system];
+    NSArray<OEDBGame *> *games = [context executeFetchRequest:request error:nil];
+    for(OEDBGame *candidate in games)
+    {
+        if(candidate == game || ![self OE_isSonicKnucklesGame:candidate]) continue;
+        return candidate;
+    }
+    return nil;
+}
+
 - (NSMenu *)menuForItemsAtIndexes:(NSIndexSet*)indexes
 {
     NSMenu *menu = [[NSMenu alloc] init];
@@ -620,6 +681,17 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
             NSMenuItem *coreMenuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Play With\u2026", @"Submenu listing available cores for this system") action:NULL keyEquivalent:@""];
             [coreMenuItem setSubmenu:coreSubmenu];
             [menu addItem:coreMenuItem];
+        }
+
+        if([self OE_isGenesisGame:game] && ![self OE_isSonicKnucklesGame:game])
+        {
+            NSMenuItem *lockOnMenuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Play locked on to Sonic & Knuckles", @"Launch a Genesis game using Sonic & Knuckles lock-on technology") action:@selector(startSelectedGameLockedOnToSonicKnuckles:) keyEquivalent:@""];
+            OEDBGame *lockOnGame = [self OE_sonicKnucklesGameForLockOnGame:game];
+            if(lockOnGame != nil)
+                [lockOnMenuItem setRepresentedObject:lockOnGame];
+            else
+                [lockOnMenuItem setEnabled:NO];
+            [menu addItem:lockOnMenuItem];
         }
 
         // Create Save State Menu

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -151,7 +151,9 @@ final class OEGameDocument: NSDocument {
     private(set) var romFileURL: URL!
     private(set) var corePlugin: OECorePlugin!
     private(set) var systemPlugin: OESystemPlugin!
-    
+    private(set) var lockOnROMURL: URL?
+    private(set) var lockOnUPMEMURL: URL?
+
     private(set) var gameViewController: GameViewController!
     
     private(set) var cheats: [Cheat] = []
@@ -305,6 +307,20 @@ final class OEGameDocument: NSDocument {
     init(game: OEDBGame, core: OECorePlugin?) throws {
         super.init()
         do {
+            try setUpDocument(with: game.defaultROM!, using: core)
+        } catch {
+            throw error
+        }
+    }
+
+    init(game: OEDBGame, core: OECorePlugin?, lockOnROM: OEDBRom) throws {
+        super.init()
+        do {
+            lockOnROMURL = lockOnROM.url
+            let upmemNames = ["sk_upmem.bin", "Sonic & Knuckles (World) (Lock-on).bin"]
+            lockOnUPMEMURL = upmemNames
+                .map { BIOSFile.biosFolderURL.appendingPathComponent($0) }
+                .first { FileManager.default.isReadableFile(atPath: $0.path) }
             try setUpDocument(with: game.defaultROM!, using: core)
         } catch {
             throw error
@@ -842,7 +858,9 @@ final class OEGameDocument: NSDocument {
                                      shaderURL: preset.shader.url,
                                      shaderParameters: params,
                                      corePluginURL: corePlugin.url,
-                                     systemPluginURL: systemPlugin.url)
+                                     systemPluginURL: systemPlugin.url,
+                                     lockOnRomURL: lockOnROMURL,
+                                     lockOnUpmemURL: lockOnUPMEMURL)
         
         if let managerClassName = UserDefaults.standard.string(forKey: OEGameCoreManagerModePreferenceKey),
            let managerClass = NSClassFromString(managerClassName),
@@ -1949,7 +1967,7 @@ final class OEGameDocument: NSDocument {
     // MARK: - Saving States
     
     var supportsSaveStates: Bool {
-        return !corePlugin.saveStatesNotSupported(forSystemIdentifier: systemPlugin.systemIdentifier)
+        return lockOnROMURL == nil && !corePlugin.saveStatesNotSupported(forSystemIdentifier: systemPlugin.systemIdentifier)
     }
     
     @objc private func saveState(_ sender: Any?) {
@@ -2242,6 +2260,7 @@ extension OEGameDocument {
     override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
         case #selector(quickLoad(_:)):
+            guard lockOnROMURL == nil else { return false }
             let slot = menuItem.representedObject != nil ? (menuItem.representedObject as? Int) ?? 0 : menuItem.tag
             return rom.quickSaveState(inSlot: slot) != nil
         case #selector(quickSave(_:)):

--- a/OpenEmuKit/Source/OEGameStartupInfo.swift
+++ b/OpenEmuKit/Source/OEGameStartupInfo.swift
@@ -36,12 +36,15 @@ import Foundation
     public let shaderParameters: [String: Double]
     public let corePluginURL: URL
     public let systemPluginURL: URL
+    public let lockOnRomURL: URL?
+    public let lockOnUpmemURL: URL?
     
     public init(romURL: URL, romMD5: String, romHeader: String, romSerial: String,
                 systemRegion: String,
                 displayModeInfo: [String: Any]?,
                 shaderURL: URL, shaderParameters: [String: Double],
-                corePluginURL: URL, systemPluginURL: URL) {
+                corePluginURL: URL, systemPluginURL: URL,
+                lockOnRomURL: URL? = nil, lockOnUpmemURL: URL? = nil) {
         self.romURL = romURL
         self.romMD5 = romMD5
         self.romHeader = romHeader
@@ -52,6 +55,8 @@ import Foundation
         self.shaderParameters = shaderParameters
         self.corePluginURL = corePluginURL
         self.systemPluginURL = systemPluginURL
+        self.lockOnRomURL = lockOnRomURL
+        self.lockOnUpmemURL = lockOnUpmemURL
     }
     
     // MARK: - NSSecureCoding
@@ -83,6 +88,8 @@ import Foundation
         self.shaderParameters = shaderParameters
         self.corePluginURL = corePluginURL
         self.systemPluginURL = systemPluginURL
+        self.lockOnRomURL = coder.decodeObject(of: NSURL.self, forKey: CodingKeys.lockOnRomURL.rawValue) as? URL
+        self.lockOnUpmemURL = coder.decodeObject(of: NSURL.self, forKey: CodingKeys.lockOnUpmemURL.rawValue) as? URL
     }
     
     public func encode(with coder: NSCoder) {
@@ -96,6 +103,8 @@ import Foundation
         coder.encode(shaderParameters, forKey: CodingKeys.shaderParameters.rawValue)
         coder.encode(corePluginURL, forKey: CodingKeys.corePluginURL.rawValue)
         coder.encode(systemPluginURL, forKey: CodingKeys.systemPluginURL.rawValue)
+        coder.encode(lockOnRomURL, forKey: CodingKeys.lockOnRomURL.rawValue)
+        coder.encode(lockOnUpmemURL, forKey: CodingKeys.lockOnUpmemURL.rawValue)
     }
     
     private enum CodingKeys: String {
@@ -103,5 +112,6 @@ import Foundation
         case systemRegion, displayModeInfo
         case shaderURL, shaderParameters
         case corePluginURL, systemPluginURL
+        case lockOnRomURL, lockOnUpmemURL
     }
 }

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -287,6 +287,8 @@ extension OSLog {
         gameCore.romMD5             = info.romMD5
         gameCore.romHeader          = info.romHeader
         gameCore.romSerial          = info.romSerial
+        gameCore.lockOnRomURL       = info.lockOnRomURL
+        gameCore.lockOnUpmemURL     = info.lockOnUpmemURL
         gameCore.hardcoreEnabled    = _hardcoreEnabled
         
         _systemResponder.client                 = gameCore


### PR DESCRIPTION
## What does this PR do?

Adds a Genesis-only library context-menu action to launch games locked on to an imported Sonic & Knuckles ROM.

The new menu item appears as **Play locked on to Sonic & Knuckles** only for Sega Genesis / Mega Drive games when an imported Sonic & Knuckles ROM is present. It passes the Sonic & Knuckles ROM path through the app launch path into Genesis Plus GX and enables the core's existing lock-on mode.

For Sonic 2 & Knuckles, Genesis Plus GX also looks for the optional 256KB lock-on/UPMEM firmware in OpenEmu's BIOS folder as either:

- `sk_upmem.bin`
- `Sonic & Knuckles (World) (Lock-on).bin`

## What did you test?

- Built `OpenEmu + GenesisPlus` successfully.
- Installed the rebuilt GenesisPlus core with `./Scripts/install-core.sh GenesisPlus`.
- Verified the installed core with `./Scripts/verify-core-installed.sh GenesisPlus`.
- Ran `./Scripts/verify.sh` successfully.
- Imported Sonic & Knuckles and launched Sonic 2 through **Play locked on to Sonic & Knuckles**.
- Confirmed Sonic 2 & Knuckles boots when `sk_upmem.bin` is present in the BIOS folder.

## Which cores or systems are affected?

- Sega Genesis / Mega Drive
- Genesis Plus GX

## Did you use AI tools?

Used Claude/Pi to trace the launch path, implement the plumbing, and run build/install checks.

## Linked issues

Fixes #457

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 570 --repo nickybmon/OpenEmu-Silicon
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme "OpenEmu + GenesisPlus" \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -30
./Scripts/install-core.sh GenesisPlus
./Scripts/verify-core-installed.sh GenesisPlus
./Scripts/launch-debug.sh
```

PR-specific setup:

1. Import a normal Sonic & Knuckles Genesis ROM.
2. For Sonic 2 & Knuckles, place the 256KB lock-on/UPMEM firmware at:

```bash
~/Library/Application Support/OpenEmu/BIOS/sk_upmem.bin
```

3. Right-click another Genesis game, such as Sonic 2.
4. Choose **Play locked on to Sonic & Knuckles**.
5. Confirm the combined game boots.
6. Right-click a non-Genesis game and confirm the lock-on menu item is not shown.
7. Right-click Sonic & Knuckles itself and confirm the lock-on menu item is not shown.
8. Optional: temporarily move `sk_upmem.bin` aside and confirm non-Sonic-2 lock-on paths still launch instead of requiring UPMEM.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme "OpenEmu + GenesisPlus" -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- [x] Verification passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
