### PR TITLE
chore: 4DO 2.3.7 + GenesisPlus 1.7.5.4 — cores-v1.3.4

### DIFF
--- a/4DO/Info.plist
+++ b/4DO/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.6</string>
+	<string>2.3.7</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Appcasts/4do.xml
+++ b/Appcasts/4do.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>4DO</title>
-                        <item>
+                            <item>
+      <title>4DO 2.3.7</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.4/4DO.oecoreplugin.zip"
+        sparkle:version="2.3.7"
+        sparkle:shortVersionString="2.3.7"
+        length="73844"
+        sparkle:edSignature="pO4QO647ZuE4kx3TKNjsymreATT36c6BIFLF0MyCB6QFq/j6oEV5si+/UibGMj8gzBt5QDC3vXxhoJ4Fr2hVAg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>4DO 2.3.6</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/genesisplus.xml
+++ b/Appcasts/genesisplus.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>GenesisPlus</title>
-                <item>
+                    <item>
+      <title>Genesis Plus GX 1.7.5.4</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.4/GenesisPlus.oecoreplugin.zip"
+        sparkle:version="1.7.5.4"
+        sparkle:shortVersionString="1.7.5.4"
+        length="643072"
+        sparkle:edSignature="xgoFgn02j8OSiFz/SeK/GcJsc53dIJWj7BRwr7ViZ5Cf+4FQqpfI6t7+/IDYvvNlp6Lv3squ9MDJHrvDoHVKBg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>Genesis Plus GX 1.7.5.3</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.5.3</string>
+	<string>1.7.5.4</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>


### PR DESCRIPTION
## What does this PR do?

Bumps two cores and updates their appcasts for the `cores-v1.3.4` release. Both were built, signed, notarized, and uploaded to the GitHub prerelease before this PR.

## What did you test?

- Release build verified for both cores via `package-core.sh` (CFBundleVersion confirmed in zip, codesign passed, dSYMs uploaded to Sentry)
- Appcast XML validated with `xmllint`; new entries confirmed at top with non-empty `sparkle:edSignature`

## Which cores or systems are affected?

- **4DO** (3DO) — 2.3.6 → 2.3.7: MADAM matrix math now uses integer arithmetic, matching 3DO hardware behavior
- **GenesisPlus** (Genesis, Sega CD, SMS, Game Gear, SG-1000) — 1.7.5.3 → 1.7.5.4: Sonic & Knuckles lock-on support; launch Sonic 1, 2, or 3 through Sonic & Knuckles for the combined cartridge experience

## Did you use AI tools?

Yes — Claude Code handled build, packaging, appcast update, and PR creation.

## Linked issues

Related to #570
Related to #567

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh 4DO
./Scripts/install-core.sh GenesisPlus
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

To verify the update pipeline once merged: open Preferences → Cores and confirm 4DO and GenesisPlus show the new versions.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: Release build succeeded for both cores
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header