### PR TITLE
fix: eliminate main-thread hang during game library search

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -1212,6 +1212,7 @@ extension AppDelegate: NSMenuDelegate {
         UNUserNotificationCenter.current().delegate = self
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
 
+        OEDBGame.startObservingDisplayPreference()
         validateDefaultPluginAssignments()
         migrateStaleRACoreDefaults()
         logCorePluginInventory()

--- a/OpenEmu/OEDBGame.swift
+++ b/OpenEmu/OEDBGame.swift
@@ -46,6 +46,7 @@ final class OEDBGame: OEDBItem {
     private static var _prefObserver: NSObjectProtocol?
 
     static func startObservingDisplayPreference() {
+        guard _prefObserver == nil else { return }
         _prefObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil,

--- a/OpenEmu/OEDBGame.swift
+++ b/OpenEmu/OEDBGame.swift
@@ -41,7 +41,20 @@ final class OEDBGame: OEDBItem {
     }
     
     static let displayGameTitleKey = "displayGameTitle"
-    
+
+    private static var _showGameTitle: Bool = UserDefaults.standard.bool(forKey: displayGameTitleKey)
+    private static var _prefObserver: NSObjectProtocol?
+
+    static func startObservingDisplayPreference() {
+        _prefObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            _showGameTitle = UserDefaults.standard.bool(forKey: displayGameTitleKey)
+        }
+    }
+
     private var romDownload: Download?
     
     // MARK: - CoreDataProperties
@@ -198,14 +211,10 @@ final class OEDBGame: OEDBItem {
     
     var displayName: String {
         get {
-            if UserDefaults.standard.bool(forKey: OEDBGame.displayGameTitleKey) {
-                return gameTitle ?? name
-            } else {
-                return name
-            }
+            return OEDBGame._showGameTitle ? (gameTitle ?? name) : name
         }
         set {
-            if UserDefaults.standard.bool(forKey: OEDBGame.displayGameTitleKey) {
+            if OEDBGame._showGameTitle {
                 if gameTitle != nil {
                     gameTitle = newValue
                 } else {

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -333,7 +333,10 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
     {
         if(token.length > 0)
         {
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"displayName contains[cd] %@", token];
+            NSPredicate *predicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[
+                [NSPredicate predicateWithFormat:@"name contains[cd] %@", token],
+                [NSPredicate predicateWithFormat:@"gameTitle contains[cd] %@", token],
+            ]];
             [predarray addObject:predicate];
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes 2000ms+ main-thread hangs on macOS 26 Tahoe when typing in the search field with a large game library. The root cause was a filter predicate that called `OEDBGame.displayName` for every game in memory, each of which triggered a synchronous `UserDefaults` read via `_CFPreferencesWithSearchList` — which blocks while holding an IPC lock on Tahoe.

Two-part fix: replace the in-memory `displayName` predicate with a stored-attribute compound OR (`name` OR `gameTitle`), and cache the `displayGameTitle` preference in a static bool updated by a `NotificationCenter` observer so `displayName` reads no longer hit `UserDefaults` on every call.

## What did you test?

Ran `/verify --launch`. App builds clean, codesign passes, no crash reports. Confirmed search field does not produce the hangs reproduced by Sentry events OPENEMU-SILICON-74 and OPENEMU-SILICON-6X.

## Which cores or systems are affected?

General app change — game library search. No cores affected.

## Did you use AI tools?

Used Claude to draft the fix, reviewed and tested it myself.

## Linked issues

Related to OPENEMU-SILICON-74, OPENEMU-SILICON-6X (Sentry)

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 582 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## Adversarial review

Two block findings were raised and addressed:

**Block 1 — `gameTitle contains[cd] %@` throws on nil LHS (adversarial claim)**
Rebutted. `nil contains[cd] %@` returns `0` (false) in NSPredicate in-memory evaluation — no exception. Verified with a compiled test: `clang -framework Foundation` + `[NSPredicate predicateWithFormat:@"self contains[cd] %@", @"foo"]` evaluated against a nil object returns `0` without throwing.

**Block 2 — Double observer registration leaks old token**
Fixed. Added `guard _prefObserver == nil else { return }` to `startObservingDisplayPreference()`.

---

## PR checklist

- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [ ] No build logs, binaries, or credentials committed
- [ ] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header