### PR TITLE
fix: append core name/version to RA User-Agent + add slowMotion to policy enum

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/HardcoreModePolicy.swift
+++ b/OpenEmu-SDK/OpenEmuBase/HardcoreModePolicy.swift
@@ -31,6 +31,7 @@ public enum HardcoreModeAction {
     case loadState
     case rewind
     case fastForward
+    case slowMotion
     case frameStep
     case cheats
     case saveState
@@ -49,7 +50,7 @@ public enum HardcoreModePolicy {
         guard hardcoreEnabled else { return true }
 
         switch action {
-        case .loadState, .rewind, .fastForward, .frameStep, .cheats:
+        case .loadState, .rewind, .fastForward, .slowMotion, .frameStep, .cheats:
             return false
         case .saveState:
             // Saving is permitted; RA only restricts restoring prior state.

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -229,13 +229,27 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
     char rcClause[64] = {0};
     rc_client_get_user_agent_clause(client, rcClause, sizeof(rcClause));
 
+    // rc_client userdata is always the OEGameCore subclass instance.
+    // Append core name + version so RA can identify the client per their spec.
+    void *userdata = rc_client_get_userdata(client);
+    NSString *coreSuffix = @"";
+    if (userdata) {
+        id coreObject = (__bridge id)userdata;
+        NSBundle *coreBundle = [NSBundle bundleForClass:[coreObject class]];
+        NSString *name = [coreBundle.bundlePath.lastPathComponent stringByDeletingPathExtension];
+        NSString *version = coreBundle.infoDictionary[@"CFBundleShortVersionString"] ?: @"0.0.0";
+        if (name.length > 0) {
+            coreSuffix = [NSString stringWithFormat:@" %@/%@", name, version];
+        }
+    }
+
     // RA expects an identifying User-Agent so they can correlate traffic to the host app.
-    // Format: OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<...>
+    // Format: OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<...> <Core>/<ver>
     NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
     NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
     NSString *osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld", (long)osv.majorVersion, (long)osv.minorVersion, (long)osv.patchVersion];
-    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %@) %@",
-                            hostVersion, osVersion, [NSString stringWithUTF8String:rcClause]];
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %@) %@%@",
+                            hostVersion, osVersion, [NSString stringWithUTF8String:rcClause], coreSuffix];
     [urlRequest setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
     if (request->post_data) {


### PR DESCRIPTION
## What does this PR do?

Appends the active core name and version to every RA HTTP request's User-Agent string (e.g. `OpenEmu-Silicon/1.2.2 (macOS 15.4.0) rcheevos/11.5.0 Nestopia/1.53.0`). This is the one blocking item Wes flagged before conditional approval — RA needs to identify the client to grant hardcore credit.

Also adds `slowMotion` to `HardcoreModeAction` and blocks it in `HardcoreModePolicy.allows()`, closing Gap 2 from the compliance audit. The enforcement at `OEGameCore.m:676` was already correct; this makes the policy enum the complete source of truth.

## What did you test?

Built and smoke-launched successfully via `verify.sh --launch`. All checks passed (build, static analyzer, plist lint, codesign, 5s launch with no faults or new crash reports). UA string construction verified by reading the code path — in-game HTTP log capture to confirm the live format is noted as a follow-up for the RA submission evidence doc.

## Which cores or systems are affected?

All 9 native RA cores (Nestopia, FCEU, BSNES, SNES9x, Gambatte, GenesisPlus, mGBA, Mupen64Plus, Mednafen). No change to libretro bridge cores.

## Did you use AI tools?

Used Claude to draft the implementation and run verification. Reviewed and tested the output.

## Linked issues

Related to #537, #538, #539

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 586 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [ ] No build logs, binaries, or credentials committed
- [ ] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

**Block (rebutted):** Reviewer flagged `(__bridge id)userdata` on a background thread as a potential dangling-pointer risk if OEGameCore is deallocated while a request is in flight. Rebuttal: `(__bridge void *)self` stored as rc_client userdata is the established pattern in all 9 cores (e.g. `MupenGameCore.m:554`, `GenPlusGameCore.m:452`). Our code accesses `userdata` synchronously at the top of `oeRetroAchievementsServerCall` before any async work — rcheevos only calls this function while the `rc_client_t` is alive, and `rc_client_destroy` is called from `stopEmulation` (an instance method, so `self` is guaranteed alive). No new risk introduced.

**Notes (surfaced, not blocking):**
- No guard that the resolved bundle path ends in `.oecoreplugin` — a hypothetical host-side OEGameCore subclass would silently produce a wrong UA suffix. All production cores are always loaded from plugin bundles; this is a latent risk only.
- `HardcoreModePolicy.allows(.slowMotion)` is not yet wired to the enforcement point at `OEGameCore.m:676`. The enum addition makes the policy type complete; the wiring is a follow-up refactor.