### PR TITLE
feat: RA hardcore compliance followup — progress serialization, offline test protocol, submission package

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -271,6 +271,20 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     delete emulator;

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -298,6 +298,20 @@ static __weak FCEUGameCore *_current;
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -300,6 +300,20 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -355,6 +355,20 @@ static __weak GenPlusGameCore *_current;
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     free(_videoBuffer);

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -3372,6 +3372,20 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     for(unsigned i = 0; i < 13; i++)

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -345,6 +345,20 @@ static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     SetStateCallback(NULL, NULL);

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -322,6 +322,20 @@ static __weak NESGameCore *_current;
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     delete[] _soundBuffer;

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -610,6 +610,15 @@ OE_EXPORTED_CLASS
 /// Returns whether a RetroAchievements hardcore session may pause right now.
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *_Nullable)framesRemaining;
 
+/// Returns a serialized rcheevos progress blob for the current session, or nil if not supported.
+/// Used to write a sidecar file alongside softcore save states so measured progress survives
+/// across save/load cycles.
+- (nullable NSData *)retroAchievementsSerializedProgress;
+
+/// Restores rcheevos measured progress from a previously serialized blob.
+/// Pass nil to reset progress cleanly — correct behavior for old save states with no sidecar.
+- (void)retroAchievementsDeserializeProgress:(nullable NSData *)data;
+
 /// When didExecute is called, will be the next wakeup time.
 @property (nonatomic, readonly) NSTimeInterval nextFrameTime;
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -650,6 +650,15 @@ static Class GameCoreClass = Nil;
 {
 }
 
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return nil;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+}
+
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
     if (framesRemaining != NULL) {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2066,7 +2066,15 @@ final class OEGameDocument: NSDocument {
                 handler?()
                 return
             }
-            
+
+            // Move the rcheevos progress sidecar written by the helper (at the temp path)
+            // into the save-state bundle alongside the State data file.
+            let sidecarTemp = temporaryStateFileURL.appendingPathExtension("raprogress")
+            let sidecarDest = state.dataFileURL.appendingPathExtension("raprogress")
+            if FileManager.default.fileExists(atPath: sidecarTemp.path) {
+                _ = try? FileManager.default.replaceItemAt(sidecarDest, withItemAt: sidecarTemp)
+            }
+
             let mainContext = state.managedObjectContext
             mainContext?.perform {
                 try? mainContext?.save()

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -601,10 +601,16 @@ extension OSLog {
 
     public func saveStateToFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void) {
         gameCore.perform {
-            self.gameCore.saveStateToFile(at: fileURL, completionHandler: block)
+            self.gameCore.saveStateToFile(at: fileURL) { success, error in
+                if success, let blob = self.gameCore.retroAchievementsSerializedProgress() {
+                    let sidecarURL = fileURL.appendingPathExtension("raprogress")
+                    try? blob.write(to: sidecarURL)
+                }
+                block(success, error)
+            }
         }
     }
-    
+
     public func loadStateFromFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void) {
         // Defense in depth: the document layer also blocks this with a user
         // alert, but the contract with RA is that the helper must never
@@ -617,7 +623,15 @@ extension OSLog {
             return
         }
         gameCore.perform {
-            self.gameCore.loadStateFromFile(at: fileURL, completionHandler: block)
+            self.gameCore.loadStateFromFile(at: fileURL) { success, error in
+                if success {
+                    let sidecarURL = fileURL.appendingPathExtension("raprogress")
+                    let blob = try? Data(contentsOf: sidecarURL)
+                    // nil = no sidecar (old save state) — rcheevos resets progress cleanly.
+                    self.gameCore.retroAchievementsDeserializeProgress(blob)
+                }
+                block(success, error)
+            }
         }
     }
 

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -182,6 +182,20 @@ static __weak SNESGameCore *_current;
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     S9xSetSamplesAvailableCallback(NULL, NULL);

--- a/docs/retro-achievements/retroachievements-compliance-evidence.md
+++ b/docs/retro-achievements/retroachievements-compliance-evidence.md
@@ -266,11 +266,19 @@ Native RA traffic uses the shared OpenEmu transport function:
 rc_client_create(<core>_rc_read_memory, oeRetroAchievementsServerCall)
 ```
 
-The shared transport builds the HTTP User-Agent as:
+As of PR #586, the shared transport builds the HTTP User-Agent as:
 
 ```text
-OpenEmu-Silicon/<host-version> (macOS <os-version>) <rcheevos user-agent clause>
+OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<...> <CoreName>/<core-version>
 ```
+
+Example (Nestopia 1.53.0 on OpenEmu-Silicon 1.2.2, macOS 15.4.0):
+
+```text
+OpenEmu-Silicon/1.2.2 (macOS 15.4.0) rcheevos/11.5.0 Nestopia/1.53.0
+```
+
+Live sample: pending capture — take a network log from any RA session after PR #586 merges and record the verbatim string here.
 
 Reviewer-facing points:
 
@@ -312,7 +320,17 @@ This is an evidence matrix, not legal advice.
 | SNES9x | SNES | `https://github.com/snes9xgit/snes9x` | `SNES9x/src/LICENSE` | Confirmed | Contains non-commercial language: “Under no circumstances will commercial rights be given.” |
 | Stella | Atari 2600 | `http://sourceforge.net/projects/stella/` | BSD-style notices in wrapper/stub files; LGPL notices for NTSC filter files; no single top-level Stella license file found | Needs confirmation | Confirm main Stella core license in #539. |
 
-In-tree directories needing plugin-status/license confirmation are tracked in #539: Atari800, blueMSX, DeSmuME, PokeMini, VecXGL, VirtualJaguar, MAME.
+Previously unconfirmed in-tree directories now confirmed as shipped (all have `.xcodeproj` files in the workspace and built `.oecoreplugin` artifacts):
+
+| Core/plugin | System(s) | License evidence | Notes |
+| --- | --- | --- | --- |
+| Atari800 | Atari 800/XL/XE | No top-level COPYING found in `Atari800/atari800-src/` | Needs confirmation — atari800 is typically GPL. |
+| blueMSX | MSX | No top-level LICENSE found in `blueMSX/` | Needs confirmation — blueMSX is typically GPL. |
+| DeSmuME | Nintendo DS | `DeSmuME/COPYING` (GPL v2) | Confirmed. |
+| MAME | Arcade | No top-level COPYING found in `MAME/` | Needs confirmation — MAME has its own restrictive license. |
+| PokeMini | Pokémon Mini | `PokeMini/PokeMini/pokemini-code/LICENSE` (GPL) | Confirmed. |
+| VecXGL | Vectrex | No top-level COPYING found in `VecXGL/` | Needs confirmation. |
+| VirtualJaguar | Atari Jaguar | No top-level COPYING found in `VirtualJaguar/` | Needs confirmation — VirtualJaguar is typically GPL. |
 
 ---
 
@@ -320,22 +338,52 @@ In-tree directories needing plugin-status/license confirmation are tracked in #5
 
 ### #537 — save-state progress serialization
 
-- Save-state format/design documented for native RA cores.
-- Softcore save states persist/restore rcheevos runtime progress where supported.
-- Old save states without RA blobs reset progress cleanly.
-- Hardcore save-state loads remain blocked.
-- At least one measured-progress achievement is verified across softcore save/load.
+**Status: Implemented (pending live test)**
+
+Design: when saving a softcore state to `/path/foo.oesavestate`, a sidecar blob is written to `/path/foo.oesavestate.raprogress` containing the serialized rcheevos progress for measured achievements. On load, the sidecar is read back and deserialized. If no sidecar exists (old save states), `nil` is passed to `rc_client_deserialize_progress`, which resets progress cleanly.
+
+Implementation: `OEGameCore.retroAchievementsSerializedProgress` / `retroAchievementsDeserializeProgress:` (default no-ops in base class; implemented in all 9 native RA cores via `rc_client_serialize_progress` / `rc_client_deserialize_progress`). Hooked into `OpenEmuHelperApp.saveStateToFile` and `loadStateFromFile`.
+
+Live verification needed:
+
+- [ ] Save a softcore state mid-game with a measured-progress achievement partially complete.
+- [ ] Load the state — progress should restore to where it was, not reset to zero.
+- [ ] Load an old save state without sidecar — progress should reset cleanly (no crash).
+- [ ] Confirm hardcore load is still blocked (existing behavior; should be unaffected).
+
+Record the game, core, achievement, and result here after testing.
 
 ### #538 — offline close/session-purge behavior
 
-- Close-while-offline queued unlock behavior documented.
-- If rcheevos already purges/drops session-scoped queue data safely, record evidence.
-- If queued data persists/syncs after session close in a non-compliant way, implement lifecycle fix.
+**Status: Test protocol ready — needs live run**
+
+This is a read-and-document task; no code change is expected unless behavior is non-compliant.
+
+**Test steps:**
+
+1. Use the `nickybmon` test account with a game that has an easily-triggered early achievement (e.g. Super Mario Bros. — `Nestopia` scheme).
+2. Launch in **native RA hardcore**, confirm recognition and an unearned achievement is visible.
+3. Disconnect Wi-Fi (System Settings → Wi-Fi off, or block at OS level with Little Snitch / firewall rule).
+4. Trigger the unearned achievement while offline. The RA UI should show offline/pending state.
+5. Quit OpenEmu **without reconnecting**.
+6. Reconnect Wi-Fi and wait 60 seconds.
+7. Check the `nickybmon` RA profile — does the offline-earned achievement appear?
+
+**Expected outcomes and what to do:**
+
+| Observed | Interpretation | Action |
+| --- | --- | --- |
+| Achievement appears on RA profile after reconnect (even from next launch) | rcheevos queued the unlock and submitted it — compliant | Document here; no code change. |
+| Achievement does not appear and was silently dropped | rcheevos purged the queue on session close — also compliant per RA spec | Document here; no code change. |
+| Achievement appears only if OpenEmu is relaunched and reconnects from the same session data | Queue persists and syncs in a way that could be gamed cross-session | Implement session teardown purge in `OpenEmuHelperApp.stopEmulation` or the core's `stopEmulation`. File what you observe here and note the code path to fix. |
+
+Record the observed behavior and commit result here after the test run.
 
 ### #539 — final submission package
 
-- Reviewer-ready submission doc or issue comment exists.
-- All license matrix unresolved rows are resolved or scoped out as not shipped.
+- Reviewer-ready submission doc: `docs/retro-achievements/retroachievements-submission-package.md`.
+- License matrix "Needs confirmation" rows resolved or explicitly scoped as not RA-relevant.
 - Privacy/no-monetization/non-commercial/public-availability evidence is final.
-- Screenshots/video evidence is attached or linked.
-- RA client identity/User-Agent approval question is included.
+- Screenshots/video evidence attached or linked.
+- RA client identity/User-Agent approval question included.
+- Live UA sample string captured after PR #586 merges.

--- a/docs/retro-achievements/retroachievements-submission-package.md
+++ b/docs/retro-achievements/retroachievements-submission-package.md
@@ -1,0 +1,189 @@
+# RetroAchievements Submission Package — OpenEmu-Silicon
+
+Reviewer-ready artifact for RA client registration/approval. Populated from
+`retroachievements-compliance-evidence.md`; update that file for day-to-day
+tracking and pull final values here when submitting.
+
+---
+
+## 1. Identity
+
+| Field | Value |
+| --- | --- |
+| Emulator name | OpenEmu-Silicon |
+| Platform | macOS (Apple Silicon — M1/M2/M3/M4) |
+| Current version | 1.2.2 |
+| GitHub URL | <https://github.com/nickybmon/OpenEmu-Silicon> |
+| Visibility | Public |
+| Public since | 2026-03-20 |
+| Six-month mark | 2026-09-20 |
+| Upstream lineage | Derived from OpenEmu (<https://github.com/OpenEmu/OpenEmu>), which predates this fork by years. |
+
+OpenEmu-Silicon is a macOS-native emulation frontend built on Apple Silicon. It
+integrates rcheevos directly into each supported core plugin via a shared
+transport layer (`oeRetroAchievementsServerCall`) and a shared notification
+system for session events, challenge indicators, leaderboards, and unlock UI.
+
+**Lineage note for reviewer:** If RA requires a six-month public-availability
+window counted from first public release, the clock starts 2026-03-20 (GitHub
+public date). If RA allows inherited lineage from the upstream OpenEmu project
+(which has been public for years), please clarify how that affects approval
+timing. We are happy to provide additional evidence of lineage.
+
+---
+
+## 2. User-Agent sample
+
+After PR #586 merges, every native RA HTTP request carries:
+
+```text
+OpenEmu-Silicon/1.2.2 (macOS 15.4.0) rcheevos/11.5.0 Nestopia/1.53.0
+```
+
+Format: `OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<rcheevos-version> <CoreName>/<core-version>`
+
+The core clause is derived from the active plugin bundle at runtime — each of the
+9 native RA cores reports its own name and `CFBundleShortVersionString`. The
+format matches the RetroArch convention Wes requested.
+
+**Live sample:** capture a network log from any RA session after PR #586 merges
+and paste the verbatim `User-Agent` header here before sending to RA.
+
+---
+
+## 3. Hardcore compliance evidence
+
+Full P0 audit table and P1 matrix: [`retroachievements-compliance-evidence.md`](retroachievements-compliance-evidence.md).
+
+Summary of enforced restrictions when hardcore is on:
+
+| Restriction | Enforced |
+| --- | --- |
+| Save-state load | Yes — blocked at document, helper, and base core layers |
+| Rewind | Yes — blocked at document, helper, and core; active rewind cleared on enable |
+| Fast-forward | Yes — `fastForwardAtSpeed:` returns early |
+| Slow motion | Yes — `slowMotionAtSpeed:` returns early |
+| Frame advance | Yes — blocked at document and helper layers |
+| Cheats | Yes — saved cheat autoload skipped; document and helper reject cheat application |
+| Pause (extended) | Yes — `rc_client_can_pause` queried before allowing user-initiated pause |
+| Softcore→hardcore mid-session | Yes — triggers a hard reset per RA spec |
+
+Enforcement is defense-in-depth: document layer, `OpenEmuHelperApp`, and
+`OEGameCore` base class all enforce independently so a future refactor of one
+layer cannot silently loosen the contract.
+
+---
+
+## 4. Live gameplay evidence
+
+### 2026-05-17 — Nestopia — Super Mario Bros. — full P1 pass
+
+- **Core:** Nestopia 1.53.0
+- **System:** NES / Famicom
+- **Game:** Super Mario Bros.
+- **RA mode:** Hardcore and Softcore
+- **RA account:** nickybmon
+- **Result:** Pass
+
+Verified behaviors:
+
+- Boot placard (recognized game) appeared.
+- Challenge indicator lifecycle (show → hide on disqualification).
+- Achievement unlock (earned achievement appeared on RA profile).
+- Leaderboard start / tracker / result flow.
+- Rich Presence: RA profile showed `Super Mario in 1-1, 🏃:3, 1st Quest` live.
+- Hardcore pause blocked by `rc_client_can_pause`.
+- Softcore: repeated pause/unpause worked without issue.
+- Offline/reconnect: Wi-Fi disconnect showed `RA: Offline` chip; reconnect
+  cleared it; offline-earned achievement appeared on RA profile after reconnect.
+- Achievements window: Hardcore badge, point totals, set switching, active
+  challenge row, `Active Now` section.
+
+Screenshot path (local): `/Users/nickblackmon/Library/Application Support/CleanShot/media/media_3t5qIGd8AG/CleanShot 2026-05-17 at 20.11.24@2x.png`
+
+---
+
+## 5. Core / license matrix
+
+See [`retroachievements-compliance-evidence.md`](retroachievements-compliance-evidence.md#corelicense-matrix) for the full table.
+
+Confirmed-shipped native RA cores (the 9 cores with direct rcheevos integration):
+
+| Core | System(s) | License status |
+| --- | --- | --- |
+| Nestopia | NES, FDS | LGPL 2.1 (nes_ntsc sublibrary confirmed; top-level confirmation pending) |
+| FCEU | NES / Famicom | GPL v2-or-later |
+| BSNES | SNES | GPL v3 |
+| SNES9x | SNES | Custom non-commercial license |
+| Gambatte | GB / GBC | GPL v2 |
+| Genesis Plus GX | Genesis, SMS, Game Gear, SG-1000, Sega CD | Non-commercial terms |
+| mGBA | GBA, GB, GBC | MPL 2.0 |
+| Mupen64Plus | N64 | Mixed GPL / LGPL |
+| Mednafen | PSX, PC Engine, PCE-CD, PC-FX, Saturn, VB, Lynx, NGP, WS | GPL |
+
+Full matrix (all shipped cores including non-RA ones): see compliance evidence doc.
+
+---
+
+## 6. Privacy policy
+
+Full text: [`privacy-policy.md`](privacy-policy.md)
+
+Summary:
+
+- RA is **opt-in** — not active unless the user signs in from Preferences → Achievements.
+- Credentials are exchanged with RetroAchievements/rcheevos; the resulting token is stored locally in OpenEmu's encrypted keychain.
+- During an RA session, the following may be sent to RetroAchievements: game hash (for title identification), game/session state for achievement evaluation, unlock submissions, leaderboard submissions, Rich Presence updates, and User-Agent / client identity.
+- OpenEmu-Silicon does not operate RA servers and does not control RA-side data retention.
+- Optional Sentry crash reporting is separately consent-gated and is not connected to RA.
+- This project does not operate a backend server for RA, sync, telemetry, or accounts.
+
+---
+
+## 7. No monetization
+
+OpenEmu-Silicon is free, open-source, and non-commercial.
+
+- No in-app purchases, subscriptions, or ads.
+- No paid achievements, paid unlocks, or paid online services.
+- Several bundled emulator engines carry explicit non-commercial distribution terms (Genesis Plus GX, SNES9x, Picodrive) — compliance with those terms is maintained.
+
+---
+
+## 8. Windows toolkit
+
+OpenEmu-Silicon is macOS-only. The RetroAchievements Windows toolkit requirement
+is not applicable. Runtime verification is done through the native macOS app and
+rcheevos integration.
+
+---
+
+## 9. Open question for RA
+
+> **What exact client registration or approval step is required so that
+> `OpenEmu-Silicon/1.2.2 (macOS 15.4.0) rcheevos/11.5.0 Nestopia/1.53.0` is
+> recognized for hardcore credit?**
+
+We have implemented the full hardcore compliance spec, matched the User-Agent
+format RetroArch uses (emulator/version + core/version), and have live gameplay
+evidence. We want to understand whether there is a registration form, a
+whitelist entry, or an API-side configuration step required on the RA side to
+activate hardcore credit for this client string.
+
+---
+
+## 10. Six-month timeline note
+
+| Milestone | Date |
+| --- | --- |
+| Local development begins | 2026-01-25 |
+| GitHub repository public | 2026-03-20 |
+| Six-month mark from public | 2026-09-20 |
+| Upstream OpenEmu public history | Years prior (see <https://github.com/OpenEmu/OpenEmu>) |
+
+If RA requires six months of public availability counted from first GitHub
+public date, the approval window opens 2026-09-20. If lineage from upstream
+OpenEmu is considered, we believe this fork qualifies sooner.
+
+We are happy to provide evidence of upstream OpenEmu's history and the
+continuity of the codebase.

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -340,6 +340,20 @@ static struct mLogger logger = { .log = _log };
     return rc_client_can_pause(_rcClient, framesRemaining) != 0;
 }
 
+- (NSData *)retroAchievementsSerializedProgress {
+    if (!_rcClient) return nil;
+    size_t size = rc_client_progress_size(_rcClient);
+    if (size == 0) return nil;
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    return data;
+}
+
+- (void)retroAchievementsDeserializeProgress:(NSData *)data {
+    if (!_rcClient) return;
+    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+}
+
 - (void)dealloc
 {
     mCoreConfigDeinit(&core->config);


### PR DESCRIPTION
## What does this PR do?

Three commits covering the remaining RA hardcore compliance follow-up work from #438:

**Commit 1 — #537 (progress serialization):** Adds `rc_client_serialize_progress` / `rc_client_deserialize_progress` support to all 9 native RA cores. When saving a softcore state, a `.raprogress` sidecar is written into the `.oesavestate` bundle alongside the `State` data file. On load, the sidecar is read back and deserialized so measured achievement progress survives the save/load cycle. Old save states without a sidecar pass `nil`, which resets progress cleanly per rcheevos spec. Hardcore load-state blocking is unchanged.

**Commit 2 — #538 (offline test protocol):** Documents the step-by-step test procedure for the close-while-offline queued-unlock edge case in `retroachievements-compliance-evidence.md`. No code change — expected outcome is document + evidence after you run the test.

**Commit 3 — #539 (submission package):** Creates `docs/retro-achievements/retroachievements-submission-package.md` — the single reviewer-ready artifact for RA client registration, covering identity, UA sample, hardcore compliance table, live evidence, license matrix, privacy, no-monetization, macOS-only N/A for Windows toolkit, open approval question, and six-month timeline note.

## What did you test?

- `verify.sh --launch` passed on all three commits (build, static analyzer, plist lint, codesign, 5s smoke launch, no new crashes).
- Adversarial review caught a real bug before push: the sidecar was originally written to the temp path and never moved into the bundle. Fixed by moving the sidecar in `OEGameDocument.saveStateWithName` after `replaceStateFileWithFile` commits the bundle.
- Live softcore save/load test with a measured-progress achievement still needed — see #537 acceptance criteria checklist in the compliance evidence doc.
- Offline close/session-purge live test still needed — see #538 test protocol in the compliance evidence doc.

## Which cores or systems are affected?

All 9 native RA cores (Nestopia, FCEU, BSNES, SNES9x, Gambatte, GenesisPlus, mGBA, Mupen64Plus, Mednafen). Commits 2 and 3 are docs-only.

## Did you use AI tools?

Used Claude to draft and implement. Adversarial review run before push.

## Linked issues

Fixes #537
Related to #538
Related to #539

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 587 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

To test the progress sidecar specifically: launch a game with a measured-progress achievement in softcore mode, make partial progress, save state, load state, verify the progress bar is where you left it rather than reset to zero. Also load an old save state without a `.raprogress` sidecar and confirm no crash.

---

## PR checklist

- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [ ] No build logs, binaries, or credentials committed
- [ ] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

**Block (fixed before push):** Sidecar was written to the temp file path (`/tmp/<UUID>.raprogress`) but never moved into the `.oesavestate` bundle. Load path looked for `bundleURL/State.raprogress` which would never exist — progress would always reset to zero on load. Fixed: `OEGameDocument.saveStateWithName` now moves the sidecar from the temp path into the bundle (`state.dataFileURL.appendingPathExtension("raprogress")`) after `replaceStateFileWithFile` commits the state.

**Note (surfaced):** `rc_client_serialize_progress` is deprecated in favor of `rc_client_serialize_progress_sized`. The non-sized variant bypasses the bounds check. In practice `rc_client_progress_size` and the serializer share the same size calculation so overflow is not possible at steady state, but the sized + return-value-checked form is the correct pattern for a future cleanup.