### PR TITLE
fix: serialize rcheevos client state via OERetroAchievementsBridge

### DIFF
--- a/FCEU/FCEU.xcodeproj/project.pbxproj
+++ b/FCEU/FCEU.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		C62301A61712264100576081 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120EF171130A200E868A8 /* OpenEmuBase.framework */; };
 		OE0FCEU0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0FCEU0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0FCEU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0FCEU0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0FCEU0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0FCEU0FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -681,6 +682,8 @@
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		OE0FCEU0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0FCEU0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0FCEU0FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0FCEU0FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1307,6 +1310,7 @@
 				82EC40A30FD9EC5A0017FC19 /* FCEUGameCore.mm in Sources */,
 				OE0FCEU0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0FCEU0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0FCEU0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 				949BBB381A9EFF4A007B49CC /* asm.cpp in Sources */,
 				8F28FD5129FD3E7D008FC4A9 /* coolgirl.cpp in Sources */,
 				949BBB391A9EFF4A007B49CC /* cart.cpp in Sources */,

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -43,6 +43,7 @@
 #include <rc_client.h>
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
+#import "OERetroAchievementsBridge.h"
 
 extern uint8 *XBuf;
 static uint32_t palette[256];
@@ -75,16 +76,11 @@ static uint32_t palette[256];
     BOOL      _isVertOverscanCropped;
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
-    rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+    OERetroAchievementsBridge *_raBridge;
     NSString *_romPath;
 }
 
 - (void)loadDisplayModeOptions;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -107,56 +103,9 @@ static uint32_t fceu_rc_read_memory(uint32_t address, uint8_t *buffer,
     return num_bytes;
 }
 
-static void fceu_rc_log(const char *message, const rc_client_t *client)
-{
-    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
-}
 
-static void fceu_rc_load_game_callback(int result, const char *error_message,
-                                        rc_client_t *client, void *userdata)
-{
-    FCEUGameCore *self = (__bridge FCEUGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-FCEU] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
 
-static void fceu_rc_login_callback(int result, const char *error_message,
-                                    rc_client_t *client, void *userdata)
-{
-    FCEUGameCore *s = (__bridge FCEUGameCore *)userdata;
-    if (result == RC_OK) {
-        [s _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-FCEU] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
 
-static void fceu_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          @(ach->id),
-        OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
-        OEAchievementPointsKey:      @(ach->points),
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-    FCEUGameCore *core = (__bridge FCEUGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
 
 @implementation FCEUGameCore
 
@@ -174,142 +123,24 @@ static __weak FCEUGameCore *_current;
 	return self;
 }
 
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romPath) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           RC_CONSOLE_NINTENDO,
-                                           _romPath.fileSystemRepresentation,
-                                           NULL, 0,
-                                           fceu_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
-            const rc_client_subset_t *subset = subsetList->subsets[i];
-            if (!subset) { continue; }
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url)
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
-        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t b = 0; b < list->num_buckets; b++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[b];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
-                const rc_client_achievement_t *ach = bucket.achievements[a];
-                if (!ach) { continue; }
-                NSNumber *subsetID = @(bucket.subset_id);
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url)
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                if (ach->badge_locked_url)
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
-}
-
-
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -443,50 +274,11 @@ static __weak FCEUGameCore *_current;
         [self loadDisplayModeOptions];
     }
 
-    _rcClient = rc_client_create(fceu_rc_read_memory, oeRetroAchievementsServerCall);
-    if (_rcClient) {
-        rc_client_set_userdata(_rcClient, (__bridge void *)self);
-        rc_client_set_event_handler(_rcClient, fceu_rc_event_handler);
-        _raHardcoreEnabled = YES;
-        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-        rc_client_set_allow_background_memory_reads(_rcClient, 0);
-        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, fceu_rc_log);
-
-        __weak FCEUGameCore *weakSelf = self;
-        _raTokenObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            FCEUGameCore *s = weakSelf;
-            if (!s || !s->_rcClient) { return; }
-            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-            if (token && username) {
-                rc_client_begin_login_with_token(s->_rcClient,
-                                                 username.UTF8String,
-                                                 token.UTF8String,
-                                                 fceu_rc_login_callback,
-                                                 (__bridge void *)s);
-            } else {
-                rc_client_logout(s->_rcClient);
-            }
-        }];
-
-        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OEHardcoreModeDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-            if (enabled) {
-                self->_raHardcoreEnabled = enabled.boolValue;
-                if (self->_rcClient) {
-                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                }
-            }
-        }];
-    }
+    _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                        memoryReader:fceu_rc_read_memory
+                                                           consoleID:(uint32_t)RC_CONSOLE_NINTENDO];
+    [_raBridge startWithROMPath:_romPath ?: @""];
+    [_raBridge markROMReady];
 
     return YES;
 }
@@ -510,8 +302,7 @@ static __weak FCEUGameCore *_current;
                 dst[y * 256 + x] = palette[*src];
     }
 
-    if (_rcClient)
-        rc_client_do_frame(_rcClient);
+    [_raBridge doFrame];
 
     for (int i = 0; i < _soundSize; i++)
         _soundBuffer[i] = (_soundBuffer[i] << 16) | (_soundBuffer[i] & 0xffff);
@@ -521,26 +312,14 @@ static __weak FCEUGameCore *_current;
 
 - (void)resetEmulation
 {
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
     ResetNES();
 }
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-    if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
 
     FCEUI_CloseGame();
     FCEUI_Kill();
@@ -660,8 +439,8 @@ static __weak FCEUGameCore *_current;
     
     delete emuFile;
 
-    if (result && _rcClient)
-        rc_client_reset(_rcClient);
+    if (result)
+        [_raBridge reset];
 
     return result;
 }

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -40,6 +40,7 @@
 #include <rc_client.h>
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
+#import "OERetroAchievementsBridge.h"
 
 #define OptionDefault(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @YES, }
 #define Option(_NAME_, _PREFKEY_) @{ OEGameCoreDisplayModeNameKey : _NAME_, OEGameCoreDisplayModePrefKeyNameKey : _PREFKEY_, OEGameCoreDisplayModeStateKey : @NO, }
@@ -70,10 +71,7 @@ public:
     double _sampleRate;
     NSMutableDictionary <NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
-    rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+    OERetroAchievementsBridge *_raBridge;
     NSString *_romPath;
     int _rcConsole;
 }
@@ -86,9 +84,6 @@ public:
 - (void)loadPalette;
 - (void)loadPaletteDefault;
 - (void)changePalette:(NSString *)palette;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
-
 @end
 
 // rcheevos memory callback.
@@ -111,57 +106,6 @@ static uint32_t gambatte_rc_read_memory(uint32_t address, uint8_t *buffer,
     return num_bytes;
 }
 
-static void gambatte_rc_log(const char *message, const rc_client_t *client)
-{
-    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
-}
-
-static void gambatte_rc_load_game_callback(int result, const char *error_message,
-                                            rc_client_t *client, void *userdata)
-{
-    GBGameCore *self = (__bridge GBGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-Gambatte] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
-
-static void gambatte_rc_login_callback(int result, const char *error_message,
-                                        rc_client_t *client, void *userdata)
-{
-    GBGameCore *s = (__bridge GBGameCore *)userdata;
-    if (result == RC_OK) {
-        [s _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-Gambatte] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
-
-static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          @(ach->id),
-        OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
-        OEAchievementPointsKey:      @(ach->points),
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-    GBGameCore *core = (__bridge GBGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
-
 @implementation GBGameCore
 
 - (id)init
@@ -176,142 +120,24 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
 	return self;
 }
 
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romPath) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           (uint32_t)_rcConsole,
-                                           _romPath.fileSystemRepresentation,
-                                           NULL, 0,
-                                           gambatte_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
-            const rc_client_subset_t *subset = subsetList->subsets[i];
-            if (!subset) { continue; }
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url)
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
-        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t b = 0; b < list->num_buckets; b++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[b];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
-                const rc_client_achievement_t *ach = bucket.achievements[a];
-                if (!ach) { continue; }
-                NSNumber *subsetID = @(bucket.subset_id);
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url)
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                if (ach->badge_locked_url)
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
-}
-
-
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -359,50 +185,11 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     _romPath = path;
     _rcConsole = gb.isCgb() ? RC_CONSOLE_GAMEBOY_COLOR : RC_CONSOLE_GAMEBOY;
 
-    _rcClient = rc_client_create(gambatte_rc_read_memory, oeRetroAchievementsServerCall);
-    if (_rcClient) {
-        rc_client_set_userdata(_rcClient, (__bridge void *)self);
-        rc_client_set_event_handler(_rcClient, gambatte_rc_event_handler);
-        _raHardcoreEnabled = YES;
-        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-        rc_client_set_allow_background_memory_reads(_rcClient, 0);
-        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, gambatte_rc_log);
-
-        __weak GBGameCore *weakSelf = self;
-        _raTokenObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            GBGameCore *s = weakSelf;
-            if (!s || !s->_rcClient) { return; }
-            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-            if (token && username) {
-                rc_client_begin_login_with_token(s->_rcClient,
-                                                 username.UTF8String,
-                                                 token.UTF8String,
-                                                 gambatte_rc_login_callback,
-                                                 (__bridge void *)s);
-            } else {
-                rc_client_logout(s->_rcClient);
-            }
-        }];
-
-        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OEHardcoreModeDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-            if (enabled) {
-                self->_raHardcoreEnabled = enabled.boolValue;
-                if (self->_rcClient) {
-                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                }
-            }
-        }];
-    }
+    _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                        memoryReader:gambatte_rc_read_memory
+                                                           consoleID:(uint32_t)_rcConsole];
+    [_raBridge startWithROMPath:path];
+    [_raBridge markROMReady];
 
     return YES;
 }
@@ -416,34 +203,21 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
         samples = 2064;
     }
 
-    if (_rcClient)
-        rc_client_do_frame(_rcClient);
+    [_raBridge doFrame];
 
     [self outputAudio:samples];
 }
 
 - (void)resetEmulation
 {
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
     gb.reset();
 }
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-    if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
 
     gb.saveSavedata();
 
@@ -519,8 +293,8 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     // Notify the rcheevos client that emulator state has been externally replaced.
     // Without this, the RA library keeps evaluating achievement conditions against
     // stale pre-load state. Matches the reset already present in deserializeState:.
-    if (success == 1 && _rcClient)
-        rc_client_reset(_rcClient);
+    if (success == 1)
+        [_raBridge reset];
     if(block) block(success==1, nil);
 }
 
@@ -558,8 +332,7 @@ static void gambatte_rc_event_handler(const rc_client_event_t *event, rc_client_
     stream.write(bytes, size);
 
     if(gb.deserializeState(stream)) {
-        if (_rcClient)
-            rc_client_reset(_rcClient);
+        [_raBridge reset];
         return YES;
     }
 

--- a/Gambatte/Gambatte.xcodeproj/project.pbxproj
+++ b/Gambatte/Gambatte.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		C6D120EE1711308C00E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120ED1711308C00E868A8 /* OpenEmuBase.framework */; };
 		OE0GAMB0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0GAMB0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0GAMB0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0GAMB0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0GAMB0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0GAMB0FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -229,6 +230,8 @@
 		C6D120ED1711308C00E868A8 /* OpenEmuBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OE0GAMB0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0GAMB0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0GAMB0FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0GAMB0FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -584,6 +587,7 @@
 				94ABD7DA16534BE800035061 /* GBGameCore.mm in Sources */,
 				OE0GAMB0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0GAMB0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0GAMB0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 				9499B5D81AB242B200276D21 /* chainresampler.cpp in Sources */,
 				9499B5D91AB242B200276D21 /* i0.cpp in Sources */,
 				9499B5DA1AB242B200276D21 /* kaiser50sinc.cpp in Sources */,

--- a/Mednafen/Mednafen.xcodeproj/project.pbxproj
+++ b/Mednafen/Mednafen.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		94FD853218C7F53C001B426D /* pcecd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94FD853018C7F53C001B426D /* pcecd.cpp */; };
 		OE0MDFN0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0MDFN0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0MDFN0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0MDFN0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0MDFN0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0MDFN0FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1747,6 +1748,8 @@
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		OE0MDFN0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0MDFN0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0MDFN0FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0MDFN0FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4457,6 +4460,7 @@
 				824088360FFDDCF400F0FE7D /* MednafenGameCore.mm in Sources */,
 				OE0MDFN0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0MDFN0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0MDFN0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 				8CB3E10B17F2169A0090372A /* video.cpp in Sources */,
 				872FC2BC22A9713200AF67DE /* VirtualFS.cpp in Sources */,
 				8CB3DE9E17F1DE5E0090372A /* negcon.cpp in Sources */,

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -50,6 +50,7 @@
 #include <os/log.h>
 #define RC_CLIENT_SUPPORTS_HASH 1
 #include <rc_client.h>
+#import "OERetroAchievementsBridge.h"
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
 
@@ -107,18 +108,21 @@ namespace MDFN_IEN_VB
     NSMutableArray *_allCueSheetFiles;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
 
-    rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+    OERetroAchievementsBridge *_raBridge;
     NSString *_romPath;
     int _rcConsole;
     BOOL _isSystemPCECD;
+    // Owned C-string copy of the active console module name (e.g. "psx", "pce").
+    // Read from the RA memory-reader trampoline on the bridge's serial queue
+    // without holding ObjC refs, so we can't use _mednafenCoreModule.UTF8String
+    // directly — that pointer's lifetime is tied to autorelease-pool drains and
+    // could dangle silently if the backing NSString is ever built dynamically.
+    // strdup'd at loadFileAtPath; freed in stopEmulation and dealloc.
+    char *_cachedModule;
 }
 - (NSString *)mednafenCoreModule;
 - (BOOL)isSystemPCECD;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
+- (const char *)oeRACachedModule;
 
 - (void)initializeMednafen;
 - (void)loadDisplayModeOptions;
@@ -149,11 +153,13 @@ static __weak MednafenGameCore *_current;
 static uint32_t mednafen_rc_read_memory(uint32_t address, uint8_t *buffer,
                                         uint32_t num_bytes, rc_client_t *client)
 {
-    MednafenGameCore *c = (__bridge MednafenGameCore *)rc_client_get_userdata(client);
-    NSString *mod = [c mednafenCoreModule];
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    MednafenGameCore *c = (MednafenGameCore *)bridge.core;
+    if (!c) { return 0; }
+    const char *mod = [c oeRACachedModule];
     if (!mod) { return 0; }
 
-    if ([mod isEqualToString:@"psx"]) {
+    if (strcmp(mod, "psx") == 0) {
         for (uint32_t i = 0; i < num_bytes; i++) {
             uint32_t a = address + i;
             if (a < 0x200000) {
@@ -168,14 +174,14 @@ static uint32_t mednafen_rc_read_memory(uint32_t address, uint8_t *buffer,
         }
         return num_bytes;
     }
-    if ([mod isEqualToString:@"pce"] && ![c isSystemPCECD]) {
+    if (strcmp(mod, "pce") == 0 && ![c isSystemPCECD]) {
         for (uint32_t i = 0; i < num_bytes; i++) {
             if (address + i >= 0x2000) { return i; }
             buffer[i] = MDFN_IEN_PCE::PCE_PeekMainRAM(address + i);
         }
         return num_bytes;
     }
-    if ([mod isEqualToString:@"pce"] && [c isSystemPCECD]) {
+    if (strcmp(mod, "pce") == 0 && [c isSystemPCECD]) {
         uint8_t *cdram     = MDFNPCE_GetCDRAMPointer();      // 64 KB,  may be NULL
         uint8_t *syscard   = MDFNPCE_GetSysCardRAMPointer(); // 192 KB, may be NULL
         uint8_t *saveram   = MDFNPCE_GetSaveRAMPointer();    // 2 KB,   always present
@@ -197,7 +203,7 @@ static uint32_t mednafen_rc_read_memory(uint32_t address, uint8_t *buffer,
         }
         return num_bytes;
     }
-    if ([mod isEqualToString:@"lynx"]) {
+    if (strcmp(mod, "lynx") == 0) {
         uint8_t *ram = MDFNLynx_GetRAMPointer();
         if (!ram) { return 0; }
         for (uint32_t i = 0; i < num_bytes; i++) {
@@ -206,7 +212,7 @@ static uint32_t mednafen_rc_read_memory(uint32_t address, uint8_t *buffer,
         }
         return num_bytes;
     }
-    if ([mod isEqualToString:@"ngp"]) {
+    if (strcmp(mod, "ngp") == 0) {
         uint8_t *ram = MDFNNGP_GetRAMPointer();
         if (!ram) { return 0; }
         for (uint32_t i = 0; i < num_bytes; i++) {
@@ -218,173 +224,11 @@ static uint32_t mednafen_rc_read_memory(uint32_t address, uint8_t *buffer,
     return 0;
 }
 
-static void mednafen_rc_log(const char *message, const rc_client_t *client)
-{
-    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
-}
-
-static void mednafen_rc_load_game_callback(int result, const char *error_message,
-                                            rc_client_t *client, void *userdata)
-{
-    MednafenGameCore *self = (__bridge MednafenGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-Mednafen] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
-
-static void mednafen_rc_login_callback(int result, const char *error_message,
-                                        rc_client_t *client, void *userdata)
-{
-    MednafenGameCore *s = (__bridge MednafenGameCore *)userdata;
-    if (result == RC_OK) {
-        [s _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-Mednafen] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
-
-static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    os_log(OS_LOG_DEFAULT, "[RA-Mednafen] achievement triggered: id=%u title=%{public}s", ach->id, ach->title ?: "");
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          @(ach->id),
-        OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name),
-        OEAchievementPointsKey:      @(ach->points),
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-    MednafenGameCore *core = (__bridge MednafenGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
-
 @implementation MednafenGameCore
 
 - (NSString *)mednafenCoreModule { return _mednafenCoreModule; }
 - (BOOL)isSystemPCECD { return _isSystemPCECD; }
-
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romPath) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           (uint32_t)_rcConsole,
-                                           _romPath.fileSystemRepresentation,
-                                           NULL, 0,
-                                           mednafen_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
-            const rc_client_subset_t *subset = subsetList->subsets[i];
-            if (!subset) { continue; }
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url)
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
-        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t b = 0; b < list->num_buckets; b++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[b];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
-                const rc_client_achievement_t *ach = bucket.achievements[a];
-                if (!ach) { continue; }
-                NSNumber *subsetID = @(bucket.subset_id);
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url)
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                if (ach->badge_locked_url)
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
-}
+- (const char *)oeRACachedModule { return _cachedModule; }
 
 - (void)initializeMednafen
 {
@@ -3361,29 +3205,22 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
 
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -3392,6 +3229,9 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
         free(_inputBuffer[i]);
 
     delete surf;
+
+    // Defensive: stopEmulation normally frees this; cover paths that bypass it.
+    if (_cachedModule) { free(_cachedModule); _cachedModule = NULL; }
 }
 
 # pragma mark - Execution
@@ -3760,54 +3600,13 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
 
     if (_rcConsole > 0) {
         _romPath = path;
-        _rcClient = rc_client_create(mednafen_rc_read_memory, oeRetroAchievementsServerCall);
-        if (_rcClient) {
-            rc_client_set_userdata(_rcClient, (__bridge void *)self);
-            rc_client_set_event_handler(_rcClient, mednafen_rc_event_handler);
-            _raHardcoreEnabled = YES;
-            rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-            // Defer address validation to executeFrame so emulated RAM is live before rcheevos
-            // validates achievement memrefs. Without this, activation runs on the HTTP callback
-            // thread before Mednafen's core is fully started, returning 0 for every address and
-            // silently deactivating all achievements before the game begins.
-            rc_client_set_allow_background_memory_reads(_rcClient, 0);
-            rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_WARN, mednafen_rc_log);
-
-            __weak MednafenGameCore *weakSelf = self;
-            _raTokenObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *note) {
-                MednafenGameCore *s = weakSelf;
-                if (!s || !s->_rcClient) { return; }
-                NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-                NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-                if (token && username) {
-                    rc_client_begin_login_with_token(s->_rcClient,
-                                                     username.UTF8String,
-                                                     token.UTF8String,
-                                                     mednafen_rc_login_callback,
-                                                     (__bridge void *)s);
-                } else {
-                    rc_client_logout(s->_rcClient);
-                }
-            }];
-
-            _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:OEHardcoreModeDidChangeNotification
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *note) {
-                NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-                if (enabled) {
-                    self->_raHardcoreEnabled = enabled.boolValue;
-                    if (self->_rcClient) {
-                        rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                    }
-                }
-            }];
-        }
+        const char *modCStr = _mednafenCoreModule.UTF8String;
+        if (modCStr) { _cachedModule = strdup(modCStr); }
+        _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                            memoryReader:mednafen_rc_read_memory
+                                                               consoleID:(uint32_t)_rcConsole];
+        [_raBridge startWithROMPath:path];
+        [_raBridge markROMReady];
     }
 
     return YES;
@@ -3840,9 +3639,7 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
 
     MDFNI_Emulate(&spec);
 
-    if (_rcClient) {
-        rc_client_do_frame(_rcClient);
-    }
+    [_raBridge doFrame];
 
     _mednafenCoreTiming = _masterClock / spec.MasterCycles;
 
@@ -3870,26 +3667,14 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
     }
 
     MDFNI_Reset();
-    if (_rcClient) {
-        rc_client_reset(_rcClient);
-    }
+    [_raBridge reset];
 }
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-    if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
+    if (_cachedModule) { free(_cachedModule); _cachedModule = NULL; }
     MDFNI_CloseGame();
 
     [super stopEmulation];
@@ -3960,8 +3745,8 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
 - (void)loadStateFromFileAtPath:(NSString *)fileName completionHandler:(void (^)(BOOL, NSError *))block
 {
     BOOL ok = MDFNI_LoadState(fileName.fileSystemRepresentation, "");
-    if (ok && _rcClient) {
-        rc_client_reset(_rcClient);
+    if (ok) {
+        [_raBridge reset];
     }
     block(ok, nil);
 }
@@ -4017,9 +3802,7 @@ static void mednafen_rc_event_handler(const rc_client_event_t *event, rc_client_
     }
     else
     {
-        if (_rcClient) {
-            rc_client_reset(_rcClient);
-        }
+        [_raBridge reset];
         return true;
     }
 }

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -36,6 +36,7 @@
 #include <rc_client.h>
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
+#import "OERetroAchievementsBridge.h"
 
 #include <NstBase.hpp>
 #include <NstApiEmulator.hpp>
@@ -88,16 +89,11 @@ static void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event,
 
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
-    rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+    OERetroAchievementsBridge *_raBridge;
     int _rcConsole;
 }
 
 - (void)loadDisplayModeOptions;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
 - (const uint8_t *)_nesRamBytesForRC;
 
 @end
@@ -110,7 +106,9 @@ static void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event,
 static uint32_t nestopia_rc_read_memory(uint32_t address, uint8_t *buffer,
                                          uint32_t num_bytes, rc_client_t *client)
 {
-    NESGameCore *s = (__bridge NESGameCore *)rc_client_get_userdata(client);
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    NESGameCore *s = (NESGameCore *)bridge.core;
+    if (!s) { return 0; }
     const uint8_t *ram = [s _nesRamBytesForRC];
     if (!ram) { return 0; }
     for (uint32_t i = 0; i < num_bytes; i++) {
@@ -123,56 +121,9 @@ static uint32_t nestopia_rc_read_memory(uint32_t address, uint8_t *buffer,
     return num_bytes;
 }
 
-static void nestopia_rc_log(const char *message, const rc_client_t *client)
-{
-    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
-}
 
-static void nestopia_rc_load_game_callback(int result, const char *error_message,
-                                            rc_client_t *client, void *userdata)
-{
-    NESGameCore *self = (__bridge NESGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-Nestopia] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
 
-static void nestopia_rc_login_callback(int result, const char *error_message,
-                                        rc_client_t *client, void *userdata)
-{
-    NESGameCore *s = (__bridge NESGameCore *)userdata;
-    if (result == RC_OK) {
-        [s _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-Nestopia] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
 
-static void nestopia_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          @(ach->id),
-        OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
-        OEAchievementPointsKey:      @(ach->points),
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-    NESGameCore *core = (__bridge NESGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
 
 @implementation NESGameCore
 
@@ -198,142 +149,24 @@ static __weak NESGameCore *_current;
     return (const uint8_t *)machine.cpu.GetRam();
 }
 
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romURL) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           (uint32_t)_rcConsole,
-                                           _romURL.fileSystemRepresentation,
-                                           NULL, 0,
-                                           nestopia_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
-            const rc_client_subset_t *subset = subsetList->subsets[i];
-            if (!subset) { continue; }
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url)
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
-        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t b = 0; b < list->num_buckets; b++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[b];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
-                const rc_client_achievement_t *ach = bucket.achievements[a];
-                if (!ach) { continue; }
-                NSNumber *subsetID = @(bucket.subset_id);
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url)
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                if (ach->badge_locked_url)
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
-}
-
-
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -441,50 +274,11 @@ static __weak NESGameCore *_current;
         ? RC_CONSOLE_FAMICOM_DISK_SYSTEM
         : RC_CONSOLE_NINTENDO;
 
-    _rcClient = rc_client_create(nestopia_rc_read_memory, oeRetroAchievementsServerCall);
-    if (_rcClient) {
-        rc_client_set_userdata(_rcClient, (__bridge void *)self);
-        rc_client_set_event_handler(_rcClient, nestopia_rc_event_handler);
-        _raHardcoreEnabled = YES;
-        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-        rc_client_set_allow_background_memory_reads(_rcClient, 0);
-        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, nestopia_rc_log);
-
-        __weak NESGameCore *weakSelf = self;
-        _raTokenObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            NESGameCore *s = weakSelf;
-            if (!s || !s->_rcClient) { return; }
-            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-            if (token && username) {
-                rc_client_begin_login_with_token(s->_rcClient,
-                                                 username.UTF8String,
-                                                 token.UTF8String,
-                                                 nestopia_rc_login_callback,
-                                                 (__bridge void *)s);
-            } else {
-                rc_client_logout(s->_rcClient);
-            }
-        }];
-
-        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OEHardcoreModeDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-            if (enabled) {
-                self->_raHardcoreEnabled = enabled.boolValue;
-                if (self->_rcClient) {
-                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                }
-            }
-        }];
-    }
+    _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                        memoryReader:nestopia_rc_read_memory
+                                                           consoleID:(uint32_t)_rcConsole];
+    [_raBridge startWithROMPath:path];
+    [_raBridge markROMReady];
 
     return YES;
 }
@@ -549,16 +343,14 @@ static __weak NESGameCore *_current;
 {
     _emu.Execute(_nesVideo, _nesSound, _controls);
 
-    if (_rcClient)
-        rc_client_do_frame(_rcClient);
+    [_raBridge doFrame];
 
     [[self audioBufferAtIndex:0] write:_soundBuffer maxLength:self.channelCount * _bufFrameSize * sizeof(int16_t)];
 }
 
 - (void)resetEmulation
 {
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
 
     Nes::Api::Machine machine(_emu);
     machine.Reset(true);
@@ -574,19 +366,8 @@ static __weak NESGameCore *_current;
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-    if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
 
     Nes::Api::Machine machine(_emu);
     //machine.Power(false);
@@ -766,8 +547,7 @@ static __weak NESGameCore *_current;
     // Notify the rcheevos client that emulator state has been externally replaced.
     // Without this, the RA library keeps evaluating achievement conditions against
     // stale pre-load state. Matches the reset already present in deserializeState:.
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
     block(YES, nil);
 }
 
@@ -856,8 +636,7 @@ static __weak NESGameCore *_current;
         return NO;
     }
 
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
 
     return YES;
 }

--- a/Nestopia/Nestopia.xcodeproj/project.pbxproj
+++ b/Nestopia/Nestopia.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		C6D120F91711313900E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120F81711313900E868A8 /* OpenEmuBase.framework */; };
 		OE0NEST0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0NEST0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0NEST0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0NEST0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0NEST0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0NEST0FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1040,6 +1041,8 @@
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		OE0NEST0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0NEST0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0NEST0FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0NEST0FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2239,6 +2242,7 @@
 				82789B710E70D27D00C01C82 /* NESGameCore.mm in Sources */,
 				OE0NEST0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0NEST0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0NEST0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -145,6 +145,10 @@ final class GameViewController: NSViewController {
             achievementBannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -24),
 
             retroAchievementsPlacardView.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.82),
+            // Absolute width cap: long warning copy wraps inside the placard
+            // instead of stretching it to whatever the host frame allows. Keeps
+            // the rendered game frame ratio stable.
+            retroAchievementsPlacardView.widthAnchor.constraint(lessThanOrEqualToConstant: 520),
             retroAchievementsPlacardView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             retroAchievementsPlacardView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
 
@@ -441,7 +445,14 @@ extension GameViewController {
     }
 
     func showRetroAchievementsUnknownEmulatorNotice() {
-        retroAchievementsNoticeView.showUnknownEmulatorWarning()
+        // Replaces the older on-screen chip overlay (which overlapped the game
+        // video; see #579) with a placard that explains the consequence in
+        // plain language and auto-hides. RA attaches a "warning achievement"
+        // (id >= 101000001) when the connecting emulator isn't on its
+        // hardcore-compliant allowlist — server-side this means hardcore
+        // unlocks for the session save as Softcore until OpenEmu-Silicon is
+        // approved.
+        retroAchievementsPlacardView.showEmulatorUnrecognizedWarning()
     }
 
     func showRetroAchievementsOfflineNotice() {
@@ -503,13 +514,26 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         imageView.layer?.masksToBounds = true
 
         titleLabel.font = .systemFont(ofSize: 20, weight: .semibold)
-        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.maximumNumberOfLines = 2
+        titleLabel.cell?.wraps = true
+        titleLabel.cell?.isScrollable = false
+        titleLabel.preferredMaxLayoutWidth = 380
         titleLabel.textColor = .labelColor
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
         summaryLabel.font = .systemFont(ofSize: 14, weight: .medium)
         summaryLabel.textColor = .labelColor
         summaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        // Wrap long warning copy (e.g. emulator-unrecognized notice) to at most
+        // 3 lines so the placard width stays bounded and doesn't push the
+        // surrounding layout. preferredMaxLayoutWidth seeds the intrinsic size
+        // calculation; the hard width cap on the placard itself does the rest.
+        summaryLabel.maximumNumberOfLines = 3
+        summaryLabel.lineBreakMode = .byWordWrapping
+        summaryLabel.cell?.wraps = true
+        summaryLabel.cell?.isScrollable = false
+        summaryLabel.preferredMaxLayoutWidth = 380
 
         modeLabel.font = .systemFont(ofSize: 14, weight: .bold)
         modeLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -523,18 +547,34 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         addSubview(imageView)
         addSubview(textStack)
 
+        // textStack drives placard height when text wraps to multiple lines;
+        // when the summary is short (e.g. boot placard "Logged in · …"), the
+        // minimum-height constraint below keeps the placard at least tall
+        // enough for the 72pt imageView plus padding. Using .defaultHigh on
+        // the `equalTo` pins lets AutoLayout relax them gracefully when the
+        // minimum height wins instead of triggering an unsatisfiable-
+        // constraints warning. Surfaced by the second adversarial-review pass.
+        let textTop = textStack.topAnchor.constraint(equalTo: topAnchor, constant: 12)
+        textTop.priority = .defaultHigh
+        let textBottom = textStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+        textBottom.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
+            // Placard height floor: 72pt image + 12pt top + 12pt bottom.
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 96),
+
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            imageView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
             imageView.widthAnchor.constraint(equalToConstant: 72),
             imageView.heightAnchor.constraint(equalToConstant: 72),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             textStack.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
             textStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            textStack.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
+            textStack.centerYAnchor.constraint(equalTo: centerYAnchor),
             textStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 12),
             textStack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -12),
+            textTop,
+            textBottom,
         ])
     }
 
@@ -590,6 +630,39 @@ private final class OERetroAchievementsPlacardView: NSVisualEffectView {
         }
         hideWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0, execute: workItem)
+    }
+
+    /// Public placard variant for the RA "unknown emulator" warning, surfaced
+    /// when rcheevos sends a warning achievement (id >= 101000001). Auto-hides
+    /// like the boot placard. See #579 for why this replaces the chip overlay.
+    func showEmulatorUnrecognizedWarning() {
+        hideWorkItem?.cancel()
+        isHidden = false
+        imageView.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
+        titleLabel.stringValue = NSLocalizedString(
+            "Emulator Awaiting Approval",
+            comment: "RetroAchievements unknown emulator placard title")
+        summaryLabel.stringValue = NSLocalizedString(
+            "Hardcore unlocks will save as Softcore until OpenEmu-Silicon is approved by RetroAchievements.",
+            comment: "RetroAchievements unknown emulator placard explanation")
+        modeLabel.stringValue = NSLocalizedString("Softcore enforced", comment: "RetroAchievements unknown emulator mode label")
+        modeLabel.textColor = .systemYellow
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            animator().alphaValue = 1
+        }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.25
+                self?.animator().alphaValue = 0
+            } completionHandler: {
+                self?.isHidden = true
+            }
+        }
+        hideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0, execute: workItem)
     }
 
     private func sessionStatusTitle(_ status: String) -> String {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2460,8 +2460,18 @@ extension OEGameDocument: OESystemBindingsObserver {
         }
     }
 
+    func retroAchievementsEmulatorUnrecognized() {
+        DispatchQueue.main.async {
+            self.gameViewController?.showRetroAchievementsUnknownEmulatorNotice()
+        }
+    }
+
     func achievementUnlocked(id: UInt32, title: String, description: String, badgeURL: String, points: UInt32) {
         DispatchQueue.main.async {
+            // Defensive fallback: bridge intercepts id >= 101000001 and routes
+            // it via retroAchievementsEmulatorUnrecognized() instead, so this
+            // branch normally won't fire. Kept in case an older core ships the
+            // warning through the legacy path.
             if self.isRetroAchievementsUnknownEmulatorWarning(title: title) {
                 self.gameViewController?.showRetroAchievementsUnknownEmulatorNotice()
                 return

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -305,7 +305,6 @@ private final class OERetroAchievementsChipLabel: NSView {
 }
 
 final class OERetroAchievementsNoticeView: NSStackView {
-    private let unknownEmulatorLabel = OERetroAchievementsChipLabel(labelWithString: "")
     private let offlineLabel = OERetroAchievementsChipLabel(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
@@ -314,21 +313,17 @@ final class OERetroAchievementsNoticeView: NSStackView {
         alignment = .centerY
         spacing = 6
         isHidden = true
-        configureChip(unknownEmulatorLabel, color: .systemYellow)
         configureChip(offlineLabel, color: .systemRed)
-        unknownEmulatorLabel.isHidden = true
         offlineLabel.isHidden = true
-        addArrangedSubview(unknownEmulatorLabel)
         addArrangedSubview(offlineLabel)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func showUnknownEmulatorWarning() {
-        unknownEmulatorLabel.stringValue = NSLocalizedString("RA: Unknown emulator", comment: "RetroAchievements unknown emulator compact notice")
-        unknownEmulatorLabel.isHidden = false
-        updateVisibility()
-    }
+    // showUnknownEmulatorWarning() previously surfaced the "RA: Unknown
+    // emulator" chip here. The chip overlapped the video (see #579); the host
+    // now shows an auto-hiding placard via
+    // GameViewController.showRetroAchievementsUnknownEmulatorNotice() instead.
 
     func showOfflineWarning() {
         offlineLabel.stringValue = NSLocalizedString("RA: Offline", comment: "RetroAchievements offline compact notice")
@@ -342,7 +337,6 @@ final class OERetroAchievementsNoticeView: NSStackView {
     }
 
     func clear() {
-        unknownEmulatorLabel.isHidden = true
         offlineLabel.isHidden = true
         updateVisibility()
     }
@@ -360,7 +354,7 @@ final class OERetroAchievementsNoticeView: NSStackView {
     }
 
     private func updateVisibility() {
-        isHidden = unknownEmulatorLabel.isHidden && offlineLabel.isHidden
+        isHidden = offlineLabel.isHidden
     }
 }
 

--- a/OpenEmuKit/Source/OEGameCoreOwner.swift
+++ b/OpenEmuKit/Source/OEGameCoreOwner.swift
@@ -95,4 +95,12 @@ public typealias OEContextID = UInt32
     /// indicator changes, leaderboard tracker updates, mastery, or server state.
     /// The payload contains property-list-safe values using `OERetroAchievementsEvent*Key` constants.
     @objc optional func retroAchievementsEvent(_ info: [String: Any])
+
+    /// Called once when rcheevos fires the "warning achievement"
+    /// (id >= 101000001), indicating RetroAchievements does not yet recognize
+    /// OpenEmu-Silicon as a hardcore-compliant emulator. Hardcore unlocks for
+    /// this session will land server-side as Softcore. Hosts should surface
+    /// a single, dismissible notice; the bridge already suppresses the fake
+    /// unlock banner.
+    @objc optional func retroAchievementsEmulatorUnrecognized()
 }

--- a/OpenEmuKit/Source/OERetroAchievementsBridge.h
+++ b/OpenEmuKit/Source/OERetroAchievementsBridge.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+
+#ifndef OERetroAchievementsBridge_h
+#define OERetroAchievementsBridge_h
+
+#import <Foundation/Foundation.h>
+#ifndef RC_CLIENT_SUPPORTS_HASH
+#define RC_CLIENT_SUPPORTS_HASH 1
+#endif
+#include <rc_client.h>
+
+@class OEGameCore;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Per-core memory reader signature. Same prototype rcheevos uses.
+/// Implementations may assume the bridge has already gated for ROM readiness
+/// and shutdown, and that the call is serialized on the bridge queue.
+typedef uint32_t (*OERetroAchievementsMemoryReader)(uint32_t address,
+                                                    uint8_t  *buffer,
+                                                    uint32_t  num_bytes,
+                                                    rc_client_t *client);
+
+/// Owns an rc_client per game-core instance and serializes every interaction
+/// with it. All mutation of rc_client state happens on an internal serial
+/// queue; observers and URL-session completions hop onto that queue before
+/// touching the client. Replaces the inline RA wiring previously copied across
+/// each RA-enabled core.
+@interface OERetroAchievementsBridge : NSObject
+
+/// Designated initializer.
+/// - core: the owning OEGameCore. Held weakly internally except for the
+///         duration of in-flight async login/load callbacks. Each per-core
+///         reader can read `bridge.core` if it needs core-specific state.
+/// - reader: function pointer to the per-core memory reader. Bridge wraps
+///           this with a ROM-ready/shutdown gate before invoking.
+/// - consoleID: RC_CONSOLE_* value used by `rc_client_begin_identify_and_load_game`.
+- (instancetype)initWithGameCore:(OEGameCore *)core
+                    memoryReader:(OERetroAchievementsMemoryReader)reader
+                       consoleID:(uint32_t)consoleID NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// The owning game core. Per-core memory readers retrieve this via
+/// `(__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client)`
+/// and then `bridge.core`. Held weakly.
+@property (nonatomic, weak, readonly, nullable) OEGameCore *core;
+
+/// YES once `markROMReady` has been called. The memory reader returns 0
+/// until this becomes true. The setter on this is for the bridge itself.
+@property (atomic, readonly) BOOL romReady;
+
+/// YES while a shutdown is in progress. Memory reader and server-call
+/// trampoline both short-circuit when this is set.
+@property (atomic, readonly) BOOL shuttingDown;
+
+/// Mirrors the user's hardcore preference. Setter dispatches
+/// `rc_client_set_hardcore_enabled` onto the serial queue.
+@property (atomic, assign) BOOL hardcoreEnabled;
+
+/// Start the bridge: create rc_client, install hardcore + background-reads
+/// flags, register token/hardcore observers, kick off a login if a token is
+/// already cached. Safe to call from any thread. Idempotent — second calls
+/// are no-ops.
+- (void)startWithROMPath:(NSString *)romPath;
+
+/// Mark ROM data as ready to be read by rcheevos. Cores must call this after
+/// their `Memory.LoadROM`/equivalent succeeds — before this, the memory
+/// reader returns 0 for everything.
+- (void)markROMReady;
+
+/// Cancel in-flight URL tasks, drain pending serial-queue work, remove
+/// observers, and destroy rc_client. Safe to call from any thread.
+/// Subsequent calls are no-ops.
+- (void)shutdown;
+
+/// Wraps `rc_client_do_frame`. Must be called from the game-core thread.
+- (void)doFrame;
+
+/// Wraps `rc_client_idle`. Must be called from the game-core thread.
+- (void)idle;
+
+/// Wraps `rc_client_can_pause`. Returns YES if no client exists.
+- (BOOL)canPauseWithFramesRemaining:(uint32_t *)framesRemaining;
+
+/// Wraps `rc_client_reset`.
+- (void)reset;
+
+/// Serializes rcheevos progress for save-state sidecar storage (softcore only).
+/// Returns nil if no client / nothing to serialize / rc_client returns an error.
+- (nullable NSData *)serializeProgress;
+
+/// Restores rcheevos progress from save-state sidecar (softcore only).
+/// `data` may be nil — in that case rcheevos is told to reset progress
+/// (matches `_postRetroAchievementsSessionSnapshot` semantics).
+- (void)deserializeProgress:(nullable NSData *)data;
+
+/// Publish a session snapshot to the host (achievements list + summary).
+/// Cores call this in their `_postRetroAchievementsSessionSnapshot`-equivalent
+/// hooks. Free-threaded — internally dispatches to a background queue.
+- (void)postSessionSnapshot;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* OERetroAchievementsBridge_h */

--- a/OpenEmuKit/Source/OERetroAchievementsBridge.m
+++ b/OpenEmuKit/Source/OERetroAchievementsBridge.m
@@ -1,0 +1,726 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+
+#import "OERetroAchievementsBridge.h"
+#import "OERetroAchievementsTransport.h"
+#import <os/log.h>
+
+// Bridge owns its own copy of the OERetroAchievements* notification names
+// so per-core code doesn't have to import the transport header alongside the
+// bridge header.
+
+@interface OERetroAchievementsBridge ()
+@property (atomic, readwrite) BOOL romReady;
+@property (atomic, readwrite) BOOL shuttingDown;
+@end
+
+// Per-instance queue identity key. We set the bridge pointer as the specific
+// value on _serialQueue at init time. `dispatch_get_specific` returns it iff
+// the current dispatch context is *this bridge's* serial queue. Used to make
+// `shutdown` re-entrant from queued blocks (avoids dispatch_sync deadlock).
+static const void *const kOERABridgeQueueKey = &kOERABridgeQueueKey;
+
+@implementation OERetroAchievementsBridge
+{
+    rc_client_t                                *_rcClient;
+    OERetroAchievementsMemoryReader             _memoryReader;
+    uint32_t                                    _consoleID;
+    NSString                                   *_romPath;
+
+    dispatch_queue_t                            _serialQueue;
+    dispatch_queue_t                            _snapshotQueue;
+    NSURLSession                               *_urlSession;
+    NSMutableSet<NSURLSessionTask *>           *_inflightTasks;
+    NSLock                                     *_tasksLock;
+
+    id                                          _tokenObserver;
+    id                                          _hardcoreObserver;
+
+    BOOL                                        _started;
+    BOOL                                        _snapshotDirty;
+}
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithGameCore:(OEGameCore *)core
+                    memoryReader:(OERetroAchievementsMemoryReader)reader
+                       consoleID:(uint32_t)consoleID
+{
+    if ((self = [super init])) {
+        _core            = core;
+        _memoryReader    = reader;
+        _consoleID       = consoleID;
+        _serialQueue     = dispatch_queue_create("com.openemu.ra-bridge.serial", DISPATCH_QUEUE_SERIAL);
+        _snapshotQueue   = dispatch_queue_create("com.openemu.ra-bridge.snapshot", DISPATCH_QUEUE_SERIAL);
+        // Tag _serialQueue so we can detect "already running on this bridge's
+        // serial queue" from inside `shutdown` and skip the otherwise-fatal
+        // `dispatch_sync(_serialQueue, ...)` self-call (would deadlock).
+        dispatch_queue_set_specific(_serialQueue, kOERABridgeQueueKey, (__bridge void *)self, NULL);
+        _inflightTasks   = [NSMutableSet set];
+        _tasksLock       = [[NSLock alloc] init];
+        _hardcoreEnabled = YES;
+
+        NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        cfg.timeoutIntervalForRequest = 30.0;
+        _urlSession = [NSURLSession sessionWithConfiguration:cfg
+                                                    delegate:nil
+                                               delegateQueue:nil];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    // Safety net for paths that release the core without calling stopEmulation.
+    // shutdown is idempotent.
+    [self shutdown];
+}
+
+#pragma mark - Memory reader / server-call trampolines
+
+static uint32_t oe_ra_bridge_read_memory(uint32_t address, uint8_t *buffer,
+                                          uint32_t num_bytes, rc_client_t *client)
+{
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    if (!bridge || !bridge.romReady || bridge.shuttingDown) { return 0; }
+    OERetroAchievementsMemoryReader reader = bridge->_memoryReader;
+    if (!reader) { return 0; }
+    return reader(address, buffer, num_bytes, client);
+}
+
+static void oe_ra_bridge_log(const char *message, const rc_client_t *client)
+{
+    (void)client;
+    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
+}
+
+// rcheevos reserves achievement IDs >= 101000001 as "warning achievements"
+// attached to sessions running on emulator clients that aren't on RA's
+// recognized/hardcore-compliant list. They flow through the normal
+// ACHIEVEMENT_TRIGGERED path but should be surfaced as a one-time notice, not
+// as a fake unlock. Mirrors `RC_CLIENT_ACHIEVEMENT_WARNING_ID` in rcheevos.
+#ifndef OE_RA_WARNING_ACHIEVEMENT_MIN_ID
+#define OE_RA_WARNING_ACHIEVEMENT_MIN_ID 101000001u
+#endif
+
+static void oe_ra_bridge_event_handler(const rc_client_event_t *event, rc_client_t *client)
+{
+    // Always post the generic event notification — host UI consumes this for
+    // banners, leaderboard trackers, etc.
+    oeRetroAchievementsPostEventNotification(event, client);
+
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    if (!bridge) { return; }
+
+    if (event->type == RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) {
+        const rc_client_achievement_t *ach = event->achievement;
+        if (ach) {
+            if (ach->id >= OE_RA_WARNING_ACHIEVEMENT_MIN_ID) {
+                // Unknown-emulator warning. Suppress the unlock banner and
+                // fire a one-time notice so the host can show a placard
+                // explaining hardcore unlocks will save as Softcore until
+                // OpenEmu-Silicon is approved by RA. See PR refs #579.
+                [[NSNotificationCenter defaultCenter]
+                    postNotificationName:OERAEmulatorUnrecognizedNotification
+                                  object:nil
+                                userInfo:nil];
+            } else {
+                NSDictionary *info = @{
+                    OEAchievementIDKey:          @(ach->id),
+                    OEAchievementTitleKey:       @(ach->title       ?: ""),
+                    OEAchievementDescriptionKey: @(ach->description ?: ""),
+                    OEAchievementBadgeURLKey:    @(ach->badge_name  ?: ""),
+                    OEAchievementPointsKey:      @(ach->points),
+                };
+                [[NSNotificationCenter defaultCenter]
+                    postNotificationName:OEAchievementUnlockedNotification
+                                  object:nil
+                                userInfo:info];
+            }
+        }
+        // Snapshot will be rebuilt off the frame thread.
+        bridge->_snapshotDirty = YES;
+    }
+}
+
+#pragma mark - URL session bridge transport
+
+// callback_data carries the rcheevos-owned per-call pointer. The bridge's
+// transport task tracks its NSURLSessionTask so shutdown can cancel it.
+typedef struct {
+    rc_client_server_callback_t  callback;
+    void                        *callback_data;
+    __unsafe_unretained OERetroAchievementsBridge *bridge;  // not retained: bridge outlives task; if not, completion bails
+} oe_ra_transport_ctx_t;
+
+static void oe_ra_bridge_server_call(const rc_api_request_t *request,
+                                      rc_client_server_callback_t callback,
+                                      void *callback_data,
+                                      rc_client_t *client)
+{
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    [bridge _performServerCallURL:[NSString stringWithUTF8String:request->url ?: ""]
+                          postBody:request->post_data ? [NSString stringWithUTF8String:request->post_data] : nil
+                       contentType:request->content_type ? [NSString stringWithUTF8String:request->content_type] : nil
+                          callback:callback
+                      callbackData:callback_data];
+}
+
+- (void)_performServerCallURL:(NSString *)urlString
+                     postBody:(nullable NSString *)postBody
+                  contentType:(nullable NSString *)contentType
+                     callback:(rc_client_server_callback_t)callback
+                 callbackData:(void *)callbackData
+{
+    if (self.shuttingDown) {
+        // Best effort: report a client error synchronously so rcheevos releases
+        // callback_data. Safe — caller is on the rcheevos thread, not our queue.
+        rc_api_server_response_t err = { .body = "", .body_length = 0,
+                                          .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR };
+        callback(&err, callbackData);
+        return;
+    }
+
+    // URLWithString: throws NSInvalidArgumentException on nil. stringWithUTF8String
+    // can return nil if rcheevos ever hands us a non-UTF-8 byte sequence — paranoid
+    // guard since rcheevos URLs are ASCII in practice.
+    if (!urlString) {
+        rc_api_server_response_t err = { .body = "", .body_length = 0,
+                                          .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR };
+        callback(&err, callbackData);
+        return;
+    }
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) {
+        rc_api_server_response_t err = { .body = "", .body_length = 0,
+                                          .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR };
+        callback(&err, callbackData);
+        return;
+    }
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+
+    char rcClause[64] = {0};
+    rc_client_get_user_agent_clause(_rcClient, rcClause, sizeof(rcClause));
+    NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
+    NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %ld.%ld.%ld) %s",
+                            hostVersion, (long)osv.majorVersion, (long)osv.minorVersion,
+                            (long)osv.patchVersion, rcClause];
+    [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
+    if (postBody) {
+        req.HTTPMethod = @"POST";
+        req.HTTPBody   = [postBody dataUsingEncoding:NSUTF8StringEncoding];
+        [req setValue:(contentType ?: @"application/x-www-form-urlencoded")
+            forHTTPHeaderField:@"Content-Type"];
+    } else {
+        req.HTTPMethod = @"GET";
+    }
+
+    __weak __typeof(self) weakSelf = self;
+    __block NSURLSessionDataTask *task = nil;
+    task = [_urlSession dataTaskWithRequest:req
+                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        __typeof(self) strongSelf = weakSelf;
+        if (strongSelf) {
+            [strongSelf _untrackTask:task];
+        }
+
+        // Capture only block-safe values. The serial-queue block builds its
+        // own stack error buffer so we don't have to worry about array lifetime.
+        NSString *errMsg = error ? (error.localizedDescription ?: @"") : nil;
+        NSData *bodyCopy = (data && data.length > 0) ? data : nil;
+        long statusCode = 0;
+        BOOL isHTTP = [response isKindOfClass:NSHTTPURLResponse.class];
+        if (isHTTP) { statusCode = ((NSHTTPURLResponse *)response).statusCode; }
+        BOOL hadError = (error != nil);
+
+        if (!strongSelf) { return; }  // bridge gone; rcheevos already destroyed
+
+        // Strong-capture into the serial-queue block so the bridge is
+        // guaranteed alive when we run, regardless of whether the URL
+        // completion's outer scope was the last strong holder. Without this,
+        // weakSelf could nil out between dispatch_async enqueue and execution
+        // and we'd silently skip the callback() invocation, leaking
+        // callback_data on the shutdown path. Bridge itself does its own
+        // shuttingDown / _rcClient guards before touching rc_client state.
+        OERetroAchievementsBridge *captured = strongSelf;
+        dispatch_async(captured->_serialQueue, ^{
+            OERetroAchievementsBridge *s = captured;
+
+            // Shutdown path: rc_client may already be destroyed (or about to
+            // be on this same queue). Only invoke the rcheevos callback if
+            // rc_client is still alive — it's required to be invoked exactly
+            // once per request so rcheevos can free its callback_data.
+            // Serial-queue FIFO ordering means if we reach this block before
+            // shutdown's destroy block, _rcClient is still set; if we reach
+            // it after, _rcClient is NULL and a callback() into rcheevos
+            // would touch freed state, so we accept the (bounded) per-session
+            // callback_data leak in that case.
+            if (s.shuttingDown) {
+                if (s->_rcClient) {
+                    const char *m = "Request cancelled (shutting down)";
+                    rc_api_server_response_t err = {
+                        .body             = m,
+                        .body_length      = strlen(m),
+                        .http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR,
+                    };
+                    callback(&err, callbackData);
+                }
+                return;
+            }
+
+            if (hadError || !bodyCopy) {
+                char errBuf[256] = {0};
+                if (errMsg) {
+                    const char *u = errMsg.UTF8String;
+                    if (u) { strncpy(errBuf, u, sizeof(errBuf) - 1); }
+                }
+                rc_api_server_response_t err = {
+                    .body             = errBuf,
+                    .body_length      = strlen(errBuf),
+                    .http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR,
+                };
+                callback(&err, callbackData);
+                return;
+            }
+            if (!isHTTP) {
+                const char *m = "Invalid HTTP response";
+                rc_api_server_response_t err = {
+                    .body             = m,
+                    .body_length      = strlen(m),
+                    .http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR,
+                };
+                callback(&err, callbackData);
+                return;
+            }
+            rc_api_server_response_t resp = {
+                .body             = (const char *)bodyCopy.bytes,
+                .body_length      = bodyCopy.length,
+                .http_status_code = (int)statusCode,
+            };
+            callback(&resp, callbackData);
+        });
+    }];
+
+    [self _trackTask:task];
+    [task resume];
+}
+
+- (void)_trackTask:(NSURLSessionTask *)task
+{
+    if (!task) { return; }
+    [_tasksLock lock];
+    [_inflightTasks addObject:task];
+    [_tasksLock unlock];
+}
+
+- (void)_untrackTask:(NSURLSessionTask *)task
+{
+    if (!task) { return; }
+    [_tasksLock lock];
+    [_inflightTasks removeObject:task];
+    [_tasksLock unlock];
+}
+
+#pragma mark - Start / shutdown
+
+- (void)startWithROMPath:(NSString *)romPath
+{
+    if (_started) { return; }
+    _started = YES;
+    _romPath = [romPath copy];
+
+    dispatch_sync(_serialQueue, ^{
+        if (self->_rcClient) { return; }
+        self->_rcClient = rc_client_create(oe_ra_bridge_read_memory, oe_ra_bridge_server_call);
+        if (!self->_rcClient) { return; }
+
+        rc_client_set_userdata(self->_rcClient, (__bridge void *)self);
+        rc_client_set_event_handler(self->_rcClient, oe_ra_bridge_event_handler);
+        rc_client_set_hardcore_enabled(self->_rcClient, self.hardcoreEnabled ? 1 : 0);
+        rc_client_set_allow_background_memory_reads(self->_rcClient, 0);
+        rc_client_enable_logging(self->_rcClient, RC_CLIENT_LOG_LEVEL_INFO, oe_ra_bridge_log);
+    });
+
+    __weak __typeof(self) weakSelf = self;
+
+    _tokenObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:OERetroAchievementsTokenDidChangeNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification *note) {
+        // Hop onto the serial queue — observers fire on the XPC notification
+        // thread, which must never touch rc_client directly.
+        __typeof(self) outer = weakSelf;
+        if (!outer) { return; }
+        NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
+        NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
+        dispatch_async(outer->_serialQueue, ^{
+            __typeof(self) s = weakSelf;
+            if (!s || s.shuttingDown || !s->_rcClient) { return; }
+            if (token && username) {
+                rc_client_begin_login_with_token(s->_rcClient,
+                                                 username.UTF8String,
+                                                 token.UTF8String,
+                                                 oe_ra_bridge_login_cb,
+                                                 (__bridge void *)s);
+            } else {
+                rc_client_logout(s->_rcClient);
+            }
+        });
+    }];
+
+    _hardcoreObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:OEHardcoreModeDidChangeNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification *note) {
+        __typeof(self) outer = weakSelf;
+        if (!outer) { return; }
+        NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
+        if (!enabled) { return; }
+        BOOL hc = enabled.boolValue;
+        dispatch_async(outer->_serialQueue, ^{
+            __typeof(self) s = weakSelf;
+            if (!s || s.shuttingDown || !s->_rcClient) { return; }
+            s.hardcoreEnabled = hc;
+            rc_client_set_hardcore_enabled(s->_rcClient, hc ? 1 : 0);
+        });
+    }];
+}
+
+- (void)markROMReady
+{
+    self.romReady = YES;
+}
+
+- (void)shutdown
+{
+    if (self.shuttingDown) { return; }
+    self.shuttingDown = YES;
+
+    // 1. Remove observers first so no new XPC notification slips through.
+    if (_tokenObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_tokenObserver];
+        _tokenObserver = nil;
+    }
+    if (_hardcoreObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_hardcoreObserver];
+        _hardcoreObserver = nil;
+    }
+
+    // 2. Cancel in-flight URL tasks. Their completions will dispatch_async
+    //    onto _serialQueue and check shuttingDown — they'll early-exit.
+    NSSet *tasks;
+    [_tasksLock lock];
+    tasks = [_inflightTasks copy];
+    [_inflightTasks removeAllObjects];
+    [_tasksLock unlock];
+    for (NSURLSessionTask *t in tasks) { [t cancel]; }
+    [_urlSession invalidateAndCancel];
+
+    // 3. Drain pending serial-queue work. After this returns, no further
+    //    rc_client_* calls are in flight.
+    //
+    //    Re-entrance: if dealloc fires while we are already executing on
+    //    _serialQueue (e.g. the last strong ref was held by a queued URL
+    //    completion that finished and dropped its `s = weakSelf` strong),
+    //    dispatch_sync to the queue we're already on would deadlock. The
+    //    queue-specific tag lets us detect that and just run the destroy
+    //    block inline. Idempotent shutdown protects against double-destroy.
+    void (^destroyBlock)(void) = ^{
+        if (self->_rcClient) {
+            rc_client_unload_game(self->_rcClient);
+            rc_client_destroy(self->_rcClient);
+            self->_rcClient = NULL;
+        }
+    };
+    if (dispatch_get_specific(kOERABridgeQueueKey) == (__bridge void *)self) {
+        destroyBlock();
+    } else {
+        dispatch_sync(_serialQueue, destroyBlock);
+    }
+}
+
+#pragma mark - Login + game-load callbacks
+
+static void oe_ra_bridge_login_cb(int result, const char *error_message,
+                                   rc_client_t *client, void *userdata)
+{
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)userdata;
+    if (!bridge) { return; }
+    if (result != RC_OK) {
+        oeRetroAchievementsPostLoginFailure(result, error_message);
+        os_log(OS_LOG_DEFAULT, "[RA-bridge] login failed — result=%d error=%{public}s",
+               result, error_message ?: "(none)");
+        return;
+    }
+    // Already on the serial queue (server call completion dispatched here).
+    [bridge _beginLoadGame];
+}
+
+static void oe_ra_bridge_load_game_cb(int result, const char *error_message,
+                                       rc_client_t *client, void *userdata)
+{
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)userdata;
+    if (!bridge) { return; }
+    if (result != RC_OK) {
+        os_log(OS_LOG_DEFAULT, "[RA-bridge] game load failed — result=%d error=%{public}s",
+               result, error_message ?: "(none)");
+        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
+        return;
+    }
+    [bridge postSessionSnapshot];
+}
+
+- (void)_beginLoadGame
+{
+    if (!_rcClient || !_romPath || self.shuttingDown) { return; }
+    rc_client_begin_identify_and_load_game(_rcClient,
+                                           _consoleID,
+                                           _romPath.fileSystemRepresentation,
+                                           NULL, 0,
+                                           oe_ra_bridge_load_game_cb,
+                                           (__bridge void *)self);
+}
+
+#pragma mark - Frame loop hooks
+
+- (void)doFrame
+{
+    if (self.shuttingDown) { return; }
+    dispatch_sync(_serialQueue, ^{
+        if (self->_rcClient && !self.shuttingDown) {
+            rc_client_do_frame(self->_rcClient);
+        }
+    });
+    // If an achievement triggered during this frame, rebuild the snapshot off
+    // the game thread so we don't stall the next frame.
+    if (_snapshotDirty) {
+        _snapshotDirty = NO;
+        [self postSessionSnapshot];
+    }
+}
+
+- (void)idle
+{
+    if (self.shuttingDown) { return; }
+    dispatch_sync(_serialQueue, ^{
+        if (self->_rcClient && !self.shuttingDown) {
+            rc_client_idle(self->_rcClient);
+        }
+    });
+}
+
+- (BOOL)canPauseWithFramesRemaining:(uint32_t *)framesRemaining
+{
+    if (self.shuttingDown) { return YES; }
+    __block BOOL canPause = YES;
+    __block uint32_t frames = 0;
+    dispatch_sync(_serialQueue, ^{
+        if (!self->_rcClient) { canPause = YES; return; }
+        canPause = rc_client_can_pause(self->_rcClient, &frames) != 0;
+    });
+    if (framesRemaining) { *framesRemaining = frames; }
+    return canPause;
+}
+
+- (void)reset
+{
+    if (self.shuttingDown) { return; }
+    dispatch_sync(_serialQueue, ^{
+        if (self->_rcClient && !self.shuttingDown) {
+            rc_client_reset(self->_rcClient);
+        }
+    });
+}
+
+#pragma mark - Hardcore property
+
+- (void)setHardcoreEnabled:(BOOL)hardcoreEnabled
+{
+    _hardcoreEnabled = hardcoreEnabled;
+    if (self.shuttingDown) { return; }
+    dispatch_async(_serialQueue, ^{
+        if (self->_rcClient && !self.shuttingDown) {
+            rc_client_set_hardcore_enabled(self->_rcClient, hardcoreEnabled ? 1 : 0);
+        }
+    });
+}
+
+#pragma mark - Save-state progress
+
+- (NSData *)serializeProgress
+{
+    __block NSData *out = nil;
+    if (self.shuttingDown) { return nil; }
+    dispatch_sync(_serialQueue, ^{
+        if (!self->_rcClient || self.shuttingDown) { return; }
+        size_t size = rc_client_progress_size(self->_rcClient);
+        if (size == 0) { return; }
+        NSMutableData *data = [NSMutableData dataWithLength:size];
+        if (rc_client_serialize_progress_sized(self->_rcClient, data.mutableBytes, size) != RC_OK) { return; }
+        out = data;
+    });
+    return out;
+}
+
+- (void)deserializeProgress:(NSData *)data
+{
+    if (self.shuttingDown) { return; }
+    if (!data) {
+        os_log(OS_LOG_DEFAULT, "[RA-bridge] deserializeProgress: nil sidecar — rcheevos progress will reset for this load.");
+    }
+    NSData *snapshot = [data copy];
+    dispatch_sync(_serialQueue, ^{
+        if (!self->_rcClient || self.shuttingDown) { return; }
+        if (snapshot) {
+            rc_client_deserialize_progress_sized(self->_rcClient,
+                                                 (const uint8_t *)snapshot.bytes,
+                                                 snapshot.length);
+        } else {
+            rc_client_deserialize_progress_sized(self->_rcClient, NULL, 0);
+        }
+    });
+}
+
+#pragma mark - Snapshot publication
+
+- (void)postSessionSnapshot
+{
+    if (self.shuttingDown) { return; }
+    dispatch_async(_snapshotQueue, ^{
+        [self _buildAndPostSnapshot];
+    });
+}
+
+- (void)_buildAndPostSnapshot
+{
+    // Snapshot building reads rc_client extensively; it must run on the
+    // serial queue to be safe vs. concurrent frame/observer mutations.
+    __block NSDictionary *payload = nil;
+    dispatch_sync(_serialQueue, ^{
+        if (!self->_rcClient || self.shuttingDown) { return; }
+        if (!rc_client_is_game_loaded(self->_rcClient)) { return; }
+        payload = [self _snapshotPayloadLocked];
+    });
+    if (payload) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
+                                                            object:nil
+                                                          userInfo:payload];
+    }
+}
+
+// Caller must hold the serial queue.
+- (NSDictionary *)_snapshotPayloadLocked
+{
+    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
+    if (!game || game->id == 0) { return nil; }
+
+    rc_client_user_game_summary_t summary;
+    memset(&summary, 0, sizeof(summary));
+    rc_client_get_user_game_summary(_rcClient, &summary);
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[OERAGameIDKey] = @(game->id);
+    payload[OERAGameTitleKey] = @(game->title ?: "");
+    payload[OERAGameHashKey] = @(game->hash ?: "");
+    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
+    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
+    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
+    payload[OERATotalPointsKey] = @(summary.points_core);
+
+    char gameImageURL[512] = {0};
+    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK) {
+        payload[OERAGameBadgeURLKey] = @(gameImageURL);
+    }
+
+    NSMutableArray *sets = [NSMutableArray array];
+    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
+    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
+    if (subsetList) {
+        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
+            const rc_client_subset_t *subset = subsetList->subsets[i];
+            if (!subset) { continue; }
+            NSString *subsetTitle = @(subset->title ?: "Achievement Set");
+            NSNumber *subsetID = @(subset->id);
+            setTitlesByID[subsetID] = subsetTitle;
+            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
+            setInfo[OERASetIDKey] = subsetID;
+            setInfo[OERASetTitleKey] = subsetTitle;
+            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
+            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
+            if (subset->badge_url) { setInfo[OERASetBadgeURLKey] = @(subset->badge_url); }
+            [sets addObject:setInfo];
+        }
+        rc_client_destroy_subset_list(subsetList);
+    }
+    if (sets.count == 0) {
+        NSNumber *gameID = @(game->id);
+        NSString *gameTitle = @(game->title ?: "Achievement Set");
+        setTitlesByID[gameID] = gameTitle;
+        [sets addObject:@{
+            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
+            OERASetAchievementCountKey: @(summary.num_core_achievements),
+            OERASetLeaderboardCountKey: @0,
+        }];
+    }
+    payload[OERASetsKey] = sets;
+
+    NSMutableArray *achievements = [NSMutableArray array];
+    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
+        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+    if (list) {
+        for (uint32_t b = 0; b < list->num_buckets; b++) {
+            const rc_client_achievement_bucket_t bucket = list->buckets[b];
+            NSString *bucketTitle = @(bucket.label ?: "Achievements");
+            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
+                const rc_client_achievement_t *ach = bucket.achievements[a];
+                if (!ach) { continue; }
+                NSNumber *subsetID = @(bucket.subset_id);
+                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+                entry[OERASetIDKey] = subsetID;
+                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: @(game->title ?: "Achievement Set");
+                entry[OERABucketTitleKey] = bucketTitle;
+                entry[OERABucketTypeKey] = @(bucket.bucket_type);
+                entry[OEAchievementIDKey] = @(ach->id);
+                entry[OEAchievementTitleKey] = @(ach->title ?: "");
+                entry[OEAchievementDescriptionKey] = @(ach->description ?: "");
+                entry[OEAchievementPointsKey] = @(ach->points);
+                entry[OERAStateKey] = @(ach->state);
+                entry[OERATypeKey] = @(ach->type);
+                entry[OERAUnlockedKey] = @(ach->unlocked);
+                entry[OERARarityKey] = @(ach->rarity);
+                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
+                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
+                entry[OERAMeasuredProgressKey] = @(ach->measured_progress ?: "");
+                if (ach->badge_url)         { entry[OEAchievementBadgeURLKey] = @(ach->badge_url); }
+                if (ach->badge_locked_url)  { entry[OERABadgeLockedURLKey]    = @(ach->badge_locked_url); }
+                [achievements addObject:entry];
+            }
+        }
+        rc_client_destroy_achievement_list(list);
+    }
+    payload[OERAAchievementsKey] = achievements;
+    return payload;
+}
+
+@end

--- a/OpenEmuKit/Source/OERetroAchievementsConstants.swift
+++ b/OpenEmuKit/Source/OERetroAchievementsConstants.swift
@@ -126,3 +126,10 @@ public let OERetroAchievementsEventRankKey       = "eventRank"
 public let OERetroAchievementsEventTotalEntriesKey = "eventTotalEntries"
 public let OERetroAchievementsEventErrorMessageKey = "eventErrorMessage"
 public let OERetroAchievementsEventAPIKey        = "eventAPI"
+
+/// Posted inside the helper process by `OERetroAchievementsBridge` when rcheevos
+/// triggers a "warning achievement" (id >= 101000001), indicating RetroAchievements
+/// does not yet recognize OpenEmu-Silicon as a hardcore-compliant client. No payload.
+public extension Notification.Name {
+    static let OERetroAchievementsEmulatorUnrecognized = Notification.Name("OERetroAchievementsEmulatorUnrecognized")
+}

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -40,6 +40,16 @@
 #define OEHardcoreModeDidChangeNotification @"OEHardcoreModeDidChange"
 #define OEHardcoreEnabledKey                @"hardcoreEnabled"
 
+/// NSNotificationCenter name posted by OERetroAchievementsBridge when rcheevos
+/// fires a "warning achievement" (id >= RC_CLIENT_ACHIEVEMENT_WARNING_ID,
+/// currently 101000001). RA attaches these to sessions whose emulator client
+/// isn't on its recognized/hardcore-compliant list. The bridge suppresses the
+/// normal OEAchievementUnlockedNotification for these IDs and posts this
+/// instead so the host can surface a single, clear notice (placard) explaining
+/// hardcore unlocks will land as Softcore until OpenEmu-Silicon is approved.
+/// No userInfo.
+#define OERAEmulatorUnrecognizedNotification @"OERetroAchievementsEmulatorUnrecognized"
+
 /// NSNotificationCenter name posted by a core plugin when an achievement is unlocked.
 /// userInfo keys: `OEAchievementIDKey` (NSNumber UInt32), `OEAchievementTitleKey` (NSString),
 /// `OEAchievementDescriptionKey` (NSString), `OEAchievementBadgeURLKey` (NSString),

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -272,10 +272,16 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
             dataTaskWithRequest:urlRequest
               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             if (error || !data) {
-                const char *message = error ? error.localizedDescription.UTF8String : "";
+                // Copy into a stack buffer so the message outlives any autorelease
+                // pool drain that may occur inside the rcheevos callback.
+                char errBuf[256] = {0};
+                if (error) {
+                    const char *u = error.localizedDescription.UTF8String;
+                    if (u) { strncpy(errBuf, u, sizeof(errBuf) - 1); }
+                }
                 rc_api_server_response_t err = {
-                    .body             = message,
-                    .body_length      = strlen(message),
+                    .body             = errBuf,
+                    .body_length      = strlen(errBuf),
                     .http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR
                 };
                 callback(&err, callback_data);

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -24,6 +24,7 @@
 
 import AudioToolbox
 import Foundation
+internal import os.log
 import OpenEmuBase
 import OpenEmuSystem
 import OpenEmuKitPrivate
@@ -103,6 +104,7 @@ extension OSLog {
     var _achievementObserver: Any?
     var _raSessionObserver: Any?
     var _raEventObserver: Any?
+    var _raUnrecognizedObserver: Any?
     var _raIdleTimer: DispatchSourceTimer?
 
     // frame rate debugging
@@ -384,6 +386,14 @@ extension OSLog {
                   let info = note.userInfo as? [String: Any] else { return }
             owner.retroAchievementsEvent?(info)
         }
+
+        _raUnrecognizedObserver = NotificationCenter.default.addObserver(
+            forName: .OERetroAchievementsEmulatorUnrecognized,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.gameCoreOwner?.retroAchievementsEmulatorUnrecognized?()
+        }
     }
     
     // MARK: - OEGameCoreOwner subclass handles
@@ -550,6 +560,10 @@ extension OSLog {
             NotificationCenter.default.removeObserver(observer)
             _raEventObserver = nil
         }
+        if let observer = _raUnrecognizedObserver {
+            NotificationCenter.default.removeObserver(observer)
+            _raUnrecognizedObserver = nil
+        }
 
         gameCore.stopEmulation {
             self._gameAudio.stopAudio()
@@ -627,7 +641,9 @@ extension OSLog {
                 if success {
                     let sidecarURL = fileURL.appendingPathExtension("raprogress")
                     let blob = try? Data(contentsOf: sidecarURL)
-                    // nil = no sidecar (old save state) — rcheevos resets progress cleanly.
+                    if blob == nil {
+                        os_log(.debug, "[RA] no .raprogress sidecar at %{public}@ — rcheevos progress will reset for this load.", sidecarURL.lastPathComponent)
+                    }
                     self.gameCore.retroAchievementsDeserializeProgress(blob)
                 }
                 block(success, error)

--- a/SNES9x/SNES9x.xcodeproj/project.pbxproj
+++ b/SNES9x/SNES9x.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C6D120FB1711314D00E868A8 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120FA1711314D00E868A8 /* OpenEmuBase.framework */; };
 		OE0SNS90BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0SNS90FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0SNS90BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0SNS90FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0SNS90BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0SNS90FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -264,6 +265,8 @@
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		OE0SNS90FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0SNS90FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0SNS90FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0SNS90FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -643,6 +646,7 @@
 				826C1B1F0F420C2200FB9014 /* SNESGameCore.mm in Sources */,
 				OE0SNS90BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0SNS90BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0SNS90BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 				94790D7A14C0C46900B30798 /* apu.cpp in Sources */,
 				8725B0B91E933E1B00F68CA5 /* sdsp.cpp in Sources */,
 				8725B0BB1E933E2B00F68CA5 /* smp.cpp in Sources */,

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -37,6 +37,7 @@
 #include <rc_client.h>
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
+#import "OERetroAchievementsBridge.h"
 #include "pixform.h"
 #include "gfx.h"
 #include "display.h"
@@ -63,16 +64,11 @@
     uint16_t *_soundBufferCurrent;
     NSURL    *_romURL;
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
-    rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+    OERetroAchievementsBridge *_raBridge;
 }
 
 - (void)finalizeAudioSamples;
 - (void)mapButtons;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
 
 @end
 
@@ -102,57 +98,6 @@ static uint32_t snes9x_rc_read_memory(uint32_t address, uint8_t *buffer,
     return num_bytes;
 }
 
-static void snes9x_rc_log(const char *message, const rc_client_t *client)
-{
-    os_log(OS_LOG_DEFAULT, "[rcheevos] %{public}s", message);
-}
-
-static void snes9x_rc_load_game_callback(int result, const char *error_message,
-                                          rc_client_t *client, void *userdata)
-{
-    SNESGameCore *self = (__bridge SNESGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-SNES9x] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
-
-static void snes9x_rc_login_callback(int result, const char *error_message,
-                                      rc_client_t *client, void *userdata)
-{
-    SNESGameCore *s = (__bridge SNESGameCore *)userdata;
-    if (result == RC_OK) {
-        [s _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-SNES9x] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
-
-static void snes9x_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          @(ach->id),
-        OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
-        OEAchievementPointsKey:      @(ach->points),
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-    SNESGameCore *core = (__bridge SNESGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
-
 @implementation SNESGameCore
 
 static __weak SNESGameCore *_current;
@@ -171,29 +116,22 @@ static __weak SNESGameCore *_current;
 
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -752,165 +690,16 @@ static __weak SNESGameCore *_current;
             S9xSetController(1, CTL_JOYPAD, 1, 0, 0, 0);
         }
 
-        _rcClient = rc_client_create(snes9x_rc_read_memory, oeRetroAchievementsServerCall);
-        if (_rcClient) {
-            rc_client_set_userdata(_rcClient, (__bridge void *)self);
-            rc_client_set_event_handler(_rcClient, snes9x_rc_event_handler);
-            _raHardcoreEnabled = YES;
-            rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-            rc_client_set_allow_background_memory_reads(_rcClient, 0);
-            rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, snes9x_rc_log);
-
-            __weak SNESGameCore *weakSelf = self;
-            _raTokenObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *note) {
-                SNESGameCore *s = weakSelf;
-                if (!s || !s->_rcClient) { return; }
-                NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-                NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-                if (token && username) {
-                    rc_client_begin_login_with_token(s->_rcClient,
-                                                     username.UTF8String,
-                                                     token.UTF8String,
-                                                     snes9x_rc_login_callback,
-                                                     (__bridge void *)s);
-                } else {
-                    rc_client_logout(s->_rcClient);
-                }
-            }];
-
-            _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:OEHardcoreModeDidChangeNotification
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *note) {
-                NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-                if (enabled) {
-                    self->_raHardcoreEnabled = enabled.boolValue;
-                    if (self->_rcClient) {
-                        rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                    }
-                }
-            }];
-        }
+        _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                            memoryReader:snes9x_rc_read_memory
+                                                               consoleID:RC_CONSOLE_SUPER_NINTENDO];
+        [_raBridge startWithROMPath:path];
+        [_raBridge markROMReady];
 
         return YES;
     }
 
     return NO;
-}
-
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romURL) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           RC_CONSOLE_SUPER_NINTENDO,
-                                           _romURL.fileSystemRepresentation,
-                                           NULL, 0,
-                                           snes9x_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK)
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t i = 0; i < subsetList->num_subsets; i++) {
-            const rc_client_subset_t *subset = subsetList->subsets[i];
-            if (!subset) { continue; }
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url)
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID, OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(
-        _rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t b = 0; b < list->num_buckets; b++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[b];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t a = 0; a < bucket.num_achievements; a++) {
-                const rc_client_achievement_t *ach = bucket.achievements[a];
-                if (!ach) { continue; }
-                NSNumber *subsetID = @(bucket.subset_id);
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url)
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                if (ach->badge_locked_url)
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
 }
 
 - (void)executeFrame
@@ -919,8 +708,7 @@ static __weak SNESGameCore *_current;
     _soundBufferCurrent = _soundBuffer;
     S9xMainLoop();
 
-    if (_rcClient)
-        rc_client_do_frame(_rcClient);
+    [_raBridge doFrame];
 
     NSUInteger samples = _soundBufferCurrent - _soundBuffer;
     [[self audioBufferAtIndex:0] write:_soundBuffer maxLength:samples * 2];
@@ -936,26 +724,14 @@ static __weak SNESGameCore *_current;
 
 - (void)resetEmulation
 {
-    if (_rcClient)
-        rc_client_reset(_rcClient);
+    [_raBridge reset];
     S9xSoftReset();
 }
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-    if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
 
     // Save SRAM
     NSURL *url = [NSURL fileURLWithPath:@(Memory.ROMFilename.c_str())];
@@ -1073,8 +849,7 @@ static void FinalizeSamplesAudioCallback(void *context)
     uint32 stateLength = (uint32)state.length;
 
     if(S9xUnfreezeGameMem(stateBytes, stateLength) == SUCCESS) {
-        if (_rcClient)
-            rc_client_reset(_rcClient);
+        [_raBridge reset];
         return YES;
     }
 

--- a/mGBA/mGBA.xcodeproj/project.pbxproj
+++ b/mGBA/mGBA.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		94AE2EFA17B0C1330018DFBB /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94AE2EF917B0C1330018DFBB /* OpenEmuBase.framework */; };
 		OE0MGBA0BUILDFILE000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0MGBA0FILEREF000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1 -DRC_CLIENT_SUPPORTS_HASH=1"; }; };
 		OE0MGBA0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */; };
+		OE0MGBA0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0MGBA0FILEREF000000003 /* OERetroAchievementsBridge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -277,6 +278,8 @@
 		D2F7E65807B2D6F200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		OE0MGBA0FILEREF000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
 		OE0MGBA0FILEREF000000002 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
+		OE0MGBA0FILEREF000000003 /* OERetroAchievementsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsBridge.m; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.m; sourceTree = SOURCE_ROOT; };
+		OE0MGBA0FILEREF000000004 /* OERetroAchievementsBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsBridge.h; path = ../OpenEmuKit/Source/OERetroAchievementsBridge.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -821,6 +824,7 @@
 				87D380E01D92536600FC657D /* audio.c in Sources */,
 				OE0MGBA0BUILDFILE000000001 /* rcheevos_build.c in Sources */,
 				OE0MGBA0BUILDFILE000000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0MGBA0BUILDFILE000000003 /* OERetroAchievementsBridge.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -47,6 +47,7 @@
 #include <rc_client.h>
 #include <rc_consoles.h>
 #import "OERetroAchievementsTransport.h"
+#import "OERetroAchievementsBridge.h"
 
 #define SAMPLES 1024
 
@@ -65,15 +66,10 @@ const char* projectVersion;
 	struct mCore* core;
 	void* outputBuffer;
 	NSMutableDictionary *cheatSets;
-	rc_client_t *_rcClient;
-    id _raTokenObserver;
-    BOOL _raHardcoreEnabled;
-    id _raHardcoreObserver;
+	OERetroAchievementsBridge *_raBridge;
     NSString *_romPath;
 }
 - (struct mCore *)mCore;
-- (void)_beginLoadGame;
-- (void)_postRetroAchievementsSessionSnapshot;
 @end
 
 // rcheevos GBA address space → hardware bus address:
@@ -90,75 +86,19 @@ static uint32_t gba_rc_to_hw(uint32_t addr) {
 static uint32_t mGBA_rc_read_memory(uint32_t address, uint8_t *buffer,
                                      uint32_t num_bytes, rc_client_t *client)
 {
-    mGBAGameCore *c = (__bridge mGBAGameCore *)rc_client_get_userdata(client);
+    OERetroAchievementsBridge *bridge = (__bridge OERetroAchievementsBridge *)rc_client_get_userdata(client);
+    mGBAGameCore *c = (mGBAGameCore *)bridge.core;
+    if (!c) { return 0; }
     struct mCore *mcore = [c mCore];
     if (!mcore) { return 0; }
     for (uint32_t i = 0; i < num_bytes; i++) {
-        buffer[i] = mcore->busRead8(mcore, gba_rc_to_hw(address + i));
+        uint32_t a = address + i;
+        if (a >= 0x058000) { return i; }  // past SRAM region — short-read.
+        buffer[i] = mcore->busRead8(mcore, gba_rc_to_hw(a));
     }
     return num_bytes;
 }
 
-
-static void mGBA_rc_log(const char *message, const rc_client_t *client)
-{
-    NSLog(@"[rcheevos] %s", message);
-}
-
-static void mGBA_rc_load_game_callback(int result, const char *error_message,
-                                        rc_client_t *client, void *userdata)
-{
-    mGBAGameCore *self = (__bridge mGBAGameCore *)userdata;
-    if (result != RC_OK) {
-        NSLog(@"[RA-mGBA] game load failed — result=%d error=%s", result, error_message ?: "(none)");
-        oeRetroAchievementsPostSessionLoadFailure(result, error_message);
-        return;
-    }
-    [self _postRetroAchievementsSessionSnapshot];
-}
-
-static void mGBA_rc_login_callback(int result, const char *error_message,
-                                    rc_client_t *client, void *userdata)
-{
-    mGBAGameCore *self = (__bridge mGBAGameCore *)userdata;
-    if (result == RC_OK) {
-        [self _beginLoadGame];
-    } else {
-        oeRetroAchievementsPostLoginFailure(result, error_message);
-        NSLog(@"[RA-mGBA] login failed — result=%d error=%s", result, error_message ?: "(none)");
-    }
-}
-
-static void mGBA_rc_event_handler(const rc_client_event_t *event, rc_client_t *client)
-{
-    oeRetroAchievementsPostEventNotification(event, client);
-    if (event->type != RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED) { return; }
-    const rc_client_achievement_t *ach = event->achievement;
-    if (!ach) { return; }
-
-    NSString *title       = [NSString stringWithUTF8String:ach->title       ?: ""];
-    NSString *desc        = [NSString stringWithUTF8String:ach->description  ?: ""];
-    NSString *badge       = [NSString stringWithUTF8String:ach->badge_name   ?: ""];
-    NSNumber *achId       = @(ach->id);
-    NSNumber *points      = @(ach->points);
-
-    NSLog(@"[RA-mGBA] achievement triggered: id=%u title=%s", ach->id, ach->title ?: "(nil)");
-
-    NSDictionary *info = @{
-        OEAchievementIDKey:          achId,
-        OEAchievementTitleKey:       title,
-        OEAchievementDescriptionKey: desc,
-        OEAchievementBadgeURLKey:    badge,
-        OEAchievementPointsKey:      points,
-    };
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:OEAchievementUnlockedNotification
-                      object:nil
-                    userInfo:info];
-
-    mGBAGameCore *core = (__bridge mGBAGameCore *)rc_client_get_userdata(client);
-    [core _postRetroAchievementsSessionSnapshot];
-}
 
 static void _log(struct mLogger* log,
                  int category,
@@ -172,129 +112,6 @@ static struct mLogger logger = { .log = _log };
 @implementation mGBAGameCore
 
 - (struct mCore *)mCore { return core; }
-
-- (void)_beginLoadGame
-{
-    if (!_rcClient || !_romPath) { return; }
-    rc_client_begin_identify_and_load_game(_rcClient,
-                                           RC_CONSOLE_GAMEBOY_ADVANCE,
-                                           [_romPath fileSystemRepresentation],
-                                           NULL, 0,
-                                           mGBA_rc_load_game_callback,
-                                           (__bridge void *)self);
-}
-
-- (void)_postRetroAchievementsSessionSnapshot
-{
-    if (!_rcClient || !rc_client_is_game_loaded(_rcClient)) { return; }
-
-    const rc_client_game_t *game = rc_client_get_game_info(_rcClient);
-    if (!game || game->id == 0) { return; }
-
-    rc_client_user_game_summary_t summary;
-    memset(&summary, 0, sizeof(summary));
-    rc_client_get_user_game_summary(_rcClient, &summary);
-
-    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
-    payload[OERAGameIDKey] = @(game->id);
-    payload[OERAGameTitleKey] = [NSString stringWithUTF8String:game->title ?: ""];
-    payload[OERAGameHashKey] = [NSString stringWithUTF8String:game->hash ?: ""];
-    payload[OERAUnlockedCountKey] = @(summary.num_unlocked_achievements);
-    payload[OERAAchievementCountKey] = @(summary.num_core_achievements);
-    payload[OERAUnlockedPointsKey] = @(summary.points_unlocked);
-    payload[OERATotalPointsKey] = @(summary.points_core);
-
-    char gameImageURL[512];
-    if (rc_client_game_get_image_url(game, gameImageURL, sizeof(gameImageURL)) == RC_OK) {
-        payload[OERAGameBadgeURLKey] = [NSString stringWithUTF8String:gameImageURL];
-    }
-
-    NSMutableArray *sets = [NSMutableArray array];
-    NSMutableDictionary<NSNumber *, NSString *> *setTitlesByID = [NSMutableDictionary dictionary];
-
-    rc_client_subset_list_t *subsetList = rc_client_create_subset_list(_rcClient);
-    if (subsetList) {
-        for (uint32_t subsetIndex = 0; subsetIndex < subsetList->num_subsets; subsetIndex++) {
-            const rc_client_subset_t *subset = subsetList->subsets[subsetIndex];
-            if (!subset) { continue; }
-
-            NSString *subsetTitle = [NSString stringWithUTF8String:subset->title ?: "Achievement Set"];
-            NSNumber *subsetID = @(subset->id);
-            setTitlesByID[subsetID] = subsetTitle;
-
-            NSMutableDictionary *setInfo = [NSMutableDictionary dictionary];
-            setInfo[OERASetIDKey] = subsetID;
-            setInfo[OERASetTitleKey] = subsetTitle;
-            setInfo[OERASetAchievementCountKey] = @(subset->num_achievements);
-            setInfo[OERASetLeaderboardCountKey] = @(subset->num_leaderboards);
-            if (subset->badge_url) {
-                setInfo[OERASetBadgeURLKey] = [NSString stringWithUTF8String:subset->badge_url];
-            }
-            [sets addObject:setInfo];
-        }
-        rc_client_destroy_subset_list(subsetList);
-    }
-
-    if (sets.count == 0) {
-        NSNumber *gameID = @(game->id);
-        NSString *gameTitle = [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-        setTitlesByID[gameID] = gameTitle;
-        [sets addObject:@{
-            OERASetIDKey: gameID,
-            OERASetTitleKey: gameTitle,
-            OERASetAchievementCountKey: @(summary.num_core_achievements),
-            OERASetLeaderboardCountKey: @0,
-        }];
-    }
-    payload[OERASetsKey] = sets;
-
-    NSMutableArray *achievements = [NSMutableArray array];
-    rc_client_achievement_list_t *list = rc_client_create_achievement_list(_rcClient,
-                                                                           RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
-                                                                           RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
-    if (list) {
-        for (uint32_t bucketIndex = 0; bucketIndex < list->num_buckets; bucketIndex++) {
-            const rc_client_achievement_bucket_t bucket = list->buckets[bucketIndex];
-            NSString *bucketTitle = [NSString stringWithUTF8String:bucket.label ?: "Achievements"];
-            for (uint32_t achievementIndex = 0; achievementIndex < bucket.num_achievements; achievementIndex++) {
-                const rc_client_achievement_t *ach = bucket.achievements[achievementIndex];
-                if (!ach) { continue; }
-
-                NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-                NSNumber *subsetID = @(bucket.subset_id);
-                entry[OERASetIDKey] = subsetID;
-                entry[OERASetTitleKey] = setTitlesByID[subsetID] ?: [NSString stringWithUTF8String:game->title ?: "Achievement Set"];
-                entry[OERABucketTitleKey] = bucketTitle;
-                entry[OERABucketTypeKey] = @(bucket.bucket_type);
-                entry[OEAchievementIDKey] = @(ach->id);
-                entry[OEAchievementTitleKey] = [NSString stringWithUTF8String:ach->title ?: ""];
-                entry[OEAchievementDescriptionKey] = [NSString stringWithUTF8String:ach->description ?: ""];
-                entry[OEAchievementPointsKey] = @(ach->points);
-                entry[OERAStateKey] = @(ach->state);
-                entry[OERATypeKey] = @(ach->type);
-                entry[OERAUnlockedKey] = @(ach->unlocked);
-                entry[OERARarityKey] = @(ach->rarity);
-                entry[OERAHardcoreRarityKey] = @(ach->rarity_hardcore);
-                entry[OERAMeasuredPercentKey] = @(ach->measured_percent);
-                entry[OERAMeasuredProgressKey] = [NSString stringWithUTF8String:ach->measured_progress];
-                if (ach->badge_url) {
-                    entry[OEAchievementBadgeURLKey] = [NSString stringWithUTF8String:ach->badge_url];
-                }
-                if (ach->badge_locked_url) {
-                    entry[OERABadgeLockedURLKey] = [NSString stringWithUTF8String:ach->badge_locked_url];
-                }
-                [achievements addObject:entry];
-            }
-        }
-        rc_client_destroy_achievement_list(list);
-    }
-
-    payload[OERAAchievementsKey] = achievements;
-    [[NSNotificationCenter defaultCenter] postNotificationName:OERASessionUpdatedNotification
-                                                        object:nil
-                                                      userInfo:payload];
-}
-
 
 - (id)init
 {
@@ -329,29 +146,22 @@ static struct mLogger logger = { .log = _log };
 
 - (void)retroAchievementsIdle
 {
-    if (_rcClient) {
-        rc_client_idle(_rcClient);
-    }
+    [_raBridge idle];
 }
 
 - (BOOL)canPauseRetroAchievementsHardcoreWithFramesRemaining:(uint32_t *)framesRemaining
 {
-    if (!_rcClient) { return YES; }
-    return rc_client_can_pause(_rcClient, framesRemaining) != 0;
+    return _raBridge ? [_raBridge canPauseWithFramesRemaining:framesRemaining] : YES;
 }
 
-- (NSData *)retroAchievementsSerializedProgress {
-    if (!_rcClient) return nil;
-    size_t size = rc_client_progress_size(_rcClient);
-    if (size == 0) return nil;
-    NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
-    return data;
+- (NSData *)retroAchievementsSerializedProgress
+{
+    return [_raBridge serializeProgress];
 }
 
-- (void)retroAchievementsDeserializeProgress:(NSData *)data {
-    if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+- (void)retroAchievementsDeserializeProgress:(NSData *)data
+{
+    [_raBridge deserializeProgress:data];
 }
 
 - (void)dealloc
@@ -387,54 +197,12 @@ static struct mLogger logger = { .log = _log };
 
 	core->reset(core);
 
-    _rcClient = rc_client_create(mGBA_rc_read_memory, oeRetroAchievementsServerCall);
-    if (_rcClient) {
-        _romPath = path;
-        rc_client_set_userdata(_rcClient, (__bridge void *)self);
-        rc_client_set_event_handler(_rcClient, mGBA_rc_event_handler);
-        _raHardcoreEnabled = YES;
-        rc_client_set_hardcore_enabled(_rcClient, _raHardcoreEnabled ? 1 : 0);
-        rc_client_set_allow_background_memory_reads(_rcClient, 0);
-        rc_client_enable_logging(_rcClient, RC_CLIENT_LOG_LEVEL_INFO, mGBA_rc_log);
-
-        // Register token observer before game identification so we don't miss
-        // the notification that fires immediately after setRetroAchievementsToken.
-        // Login happens first; game identification runs in the login callback.
-        __weak mGBAGameCore *weakSelf = self;
-        _raTokenObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OERetroAchievementsTokenDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            mGBAGameCore *s = weakSelf;
-            if (!s || !s->_rcClient) { return; }
-            NSString *token    = note.userInfo[OERetroAchievementsTokenKey];
-            NSString *username = note.userInfo[OERetroAchievementsUsernameKey];
-            if (token && username) {
-                rc_client_begin_login_with_token(s->_rcClient,
-                                                 username.UTF8String,
-                                                 token.UTF8String,
-                                                 mGBA_rc_login_callback,
-                                                 (__bridge void *)s);
-            } else {
-                rc_client_logout(s->_rcClient);
-            }
-        }];
-
-        _raHardcoreObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:OEHardcoreModeDidChangeNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *note) {
-            NSNumber *enabled = note.userInfo[OEHardcoreEnabledKey];
-            if (enabled) {
-                self->_raHardcoreEnabled = enabled.boolValue;
-                if (self->_rcClient) {
-                    rc_client_set_hardcore_enabled(self->_rcClient, self->_raHardcoreEnabled ? 1 : 0);
-                }
-            }
-        }];
-    }
+    _romPath = path;
+    _raBridge = [[OERetroAchievementsBridge alloc] initWithGameCore:self
+                                                        memoryReader:mGBA_rc_read_memory
+                                                           consoleID:RC_CONSOLE_GAMEBOY_ADVANCE];
+    [_raBridge startWithROMPath:path];
+    [_raBridge markROMReady];
 
 	return YES;
 }
@@ -443,9 +211,7 @@ static struct mLogger logger = { .log = _log };
 {
 	core->runFrame(core);
 
-	if (_rcClient) {
-        rc_client_do_frame(_rcClient);
-    }
+	[_raBridge doFrame];
 
 	int16_t samples[SAMPLES * 2];
 	size_t available = 0;
@@ -457,27 +223,14 @@ static struct mLogger logger = { .log = _log };
 
 - (void)stopEmulation
 {
-    if (_raTokenObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raTokenObserver];
-        _raTokenObserver = nil;
-    }
-    if (_raHardcoreObserver) {
-        [[NSNotificationCenter defaultCenter] removeObserver:_raHardcoreObserver];
-        _raHardcoreObserver = nil;
-    }
-	if (_rcClient) {
-        rc_client_unload_game(_rcClient);
-        rc_client_destroy(_rcClient);
-        _rcClient = NULL;
-    }
+    [_raBridge shutdown];
+    _raBridge = nil;
     [super stopEmulation];
 }
 
 - (void)resetEmulation
 {
-	if (_rcClient) {
-        rc_client_reset(_rcClient);
-    }
+	[_raBridge reset];
 	core->reset(core);
 }
 
@@ -596,8 +349,8 @@ static struct mLogger logger = { .log = _log };
 	struct VFile* vf = VFileOpen([fileName fileSystemRepresentation], O_RDONLY);
 	BOOL ok = mCoreLoadStateNamed(core, vf, 0);
 	vf->close(vf);
-	if (ok && _rcClient) {
-		rc_client_reset(_rcClient);
+	if (ok) {
+		[_raBridge reset];
 	}
 	block(ok, nil);
 }


### PR DESCRIPTION
## What does this PR do?

Resolves a SNES9x helper-process crash (PR #560 comment, `EXC_BAD_INSTRUCTION` at `rc_client_begin_identify_and_load_game` on the `NSURLSession-delegate` queue) caused by `rc_client_t*` being mutated from three threads — the game-core thread, the XPC notification thread, and the URL session delegate thread — with no serialization, plus a destroy path that didn't drain in-flight async work. Introduces `OERetroAchievementsBridge`, a per-game-session owner of one `rc_client_t*` that funnels every interaction through an internal serial dispatch queue, tracks and cancels in-flight URL tasks on shutdown, and runs observer dispatches through the same queue. All six RA-enabled cores (SNES9x, Gambatte, FCEU, Nestopia, mGBA, Mednafen) are migrated onto the bridge; their inline ~200-line RA blocks are replaced with a few bridge calls (~1300 net lines removed). Also intercepts rcheevos warning achievements (id ≥ 101000001) and surfaces them as an auto-hiding placard instead of the on-screen "RA: Unknown emulator" chip that overlapped game video (refs #579).

## What did you test?

- Built and installed all 6 RA-enabled cores Release; verified each installed bundle's SHA256 matches the freshly built source bundle (`Scripts/verify-core-installed.sh`).
- Built host app Release; launched via `Scripts/launch-debug.sh --release`.
- Loaded an RA-recognized SNES ROM with hardcore + logged-in account:
  - Game boots; helper process (`OpenEmuHelperApp`) does not crash.
  - rcheevos logs confirm `Game N loaded, hardcore enabled`, 4 achievement sets activated (163 achievements live), 2 RA server roundtrips at HTTP 200.
  - Warning achievement (id 101000001) fires ~5s in; suppressed from the unlock banner path; placard "Emulator Awaiting Approval / Hardcore unlocks will save as Softcore until OpenEmu-Silicon is approved by RetroAchievements / Softcore enforced" renders with title wrapped to ≤2 lines, summary to ≤3 lines, capped at 520pt wide; no on-screen chip overlay.
- Three adversarial-review passes (see below). Final pass returned zero block findings.

## Which cores or systems are affected?

All RetroAchievements-integrated cores: SNES9x, Gambatte, FCEU, Nestopia, mGBA, Mednafen. Host app touched for the placard / `OEGameCoreOwner` protocol method / helper-app observer / notification constants.

## Did you use AI tools?

Yes — Claude drafted the bridge abstraction, migrated each core onto it, and produced the placard UX. I reviewed every change, ran three adversarial-review passes (each surfacing real findings that were fixed before this PR opened), and tested the result against a live RA session locally.

## Linked issues

Fixes #579
Related to #560

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 588 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

This PR touches six RA-enabled cores (SNES9x, Gambatte, FCEU, Nestopia, mGBA, Mednafen). After `gh pr checkout`, install whichever you intend to test (or all of them via the install-core script above) before launching. The Debug build config errors out for the cores; build Release if you need to install (`Scripts/install-core.sh <Name> --release`).

---

## Adversarial review

Three passes. All `block` findings were fixed before this PR opened. Remaining `note`-level items:

- **Bounded `callback_data` leak on shutdown race** (`OpenEmuKit/Source/OERetroAchievementsBridge.m`, URL-completion `shuttingDown` branch). If `shutdown`'s destroy block wins the race against a still-in-flight URL completion that hasn't yet been delivered by the NSURLSession delegate queue, the completion's continuation finds `_rcClient == NULL` and returns without invoking the rcheevos `callback()`, leaking the per-request `callback_data` that rcheevos allocated. Bounded to a handful of in-flight requests per session-end; documented in code. Tracking idea for follow-up: drain the URL session delegate queue before destroying `_rcClient`, or maintain a tracked set of pending `callback_data` for the destroy block to flush.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes (all 6 cores + host built clean, Release)
- [x] Tested on Apple Silicon (M-series Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files include the BSD 2-Clause license header