### PR TITLE
fix: preserve Developer ID signatures on install; warn on duplicate core bundles

### DIFF
--- a/OpenEmu/CoreDownload.swift
+++ b/OpenEmu/CoreDownload.swift
@@ -166,20 +166,37 @@ extension CoreDownload: URLSessionDownloadDelegate {
 
 extension CoreDownload {
 
-    /// Ad-hoc signs the plugin bundle so macOS 26+ will load it.
-    /// Downloaded cores arrive unsigned; the OS refuses to dlopen them even
-    /// with disable-library-validation unless they carry at least an ad-hoc signature.
+    /// Ensure the downloaded plugin has at least an ad-hoc signature so macOS 26+
+    /// will dlopen it. If the plugin already arrives signed (the standard case for
+    /// cores published from our release pipeline, which Developer-ID-signs every
+    /// build), the existing signature is preserved unchanged.
     private func adHocSign(_ bundleURL: URL, completion: @escaping () -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-            task.arguments = ["--force", "--sign", "-", bundleURL.path]
+            // Check for an existing valid signature before potentially overwriting it.
+            let check = Process()
+            check.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+            check.arguments = ["--verify", "--deep", bundleURL.path]
+            check.standardOutput = FileHandle.nullDevice
+            check.standardError = FileHandle.nullDevice
+            if (try? check.run()) != nil {
+                check.waitUntilExit()
+                if check.terminationStatus == 0 {
+                    // Already has a valid signature — preserve it.
+                    DispatchQueue.main.async { completion() }
+                    return
+                }
+            }
+
+            // No valid signature found — apply ad-hoc so the OS will load the bundle.
+            let sign = Process()
+            sign.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+            sign.arguments = ["--force", "--sign", "-", bundleURL.path]
 
             do {
-                try task.run()
-                task.waitUntilExit()
-                if task.terminationStatus != 0 {
-                    DLog("codesign exited with status \(task.terminationStatus) for \(bundleURL.lastPathComponent)")
+                try sign.run()
+                sign.waitUntilExit()
+                if sign.terminationStatus != 0 {
+                    DLog("codesign exited with status \(sign.terminationStatus) for \(bundleURL.lastPathComponent)")
                 }
             } catch {
                 DLog("Failed to run codesign for \(bundleURL.lastPathComponent): \(error)")

--- a/OpenEmu/CoreDownload.swift
+++ b/OpenEmu/CoreDownload.swift
@@ -175,7 +175,7 @@ extension CoreDownload {
             // Check for an existing valid signature before potentially overwriting it.
             let check = Process()
             check.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-            check.arguments = ["--verify", "--deep", bundleURL.path]
+            check.arguments = ["--verify", bundleURL.path]
             check.standardOutput = FileHandle.nullDevice
             check.standardError = FileHandle.nullDevice
             if (try? check.run()) != nil {

--- a/OpenEmu/PrefCoresController.swift
+++ b/OpenEmu/PrefCoresController.swift
@@ -111,6 +111,7 @@ final class PrefCoresController: NSViewController {
 
     private var tableView: NSTableView!
     private var scrollView: NSScrollView!
+    private var warningBanner: NSTextField!
 
     private var entries: [SystemEntry] = []
     private var coreListObservation: NSKeyValueObservation?
@@ -151,7 +152,28 @@ final class PrefCoresController: NSViewController {
         scroll.documentView = table
         self.tableView  = table
         self.scrollView = scroll
-        self.view = scroll
+
+        let warning = NSTextField(wrappingLabelWithString: "")
+        warning.textColor = .systemOrange
+        warning.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        warning.isHidden = true
+        warning.translatesAutoresizingMaskIntoConstraints = false
+        self.warningBanner = warning
+
+        let container = NSView()
+        container.addSubview(scroll)
+        container.addSubview(warning)
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            warning.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
+            warning.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+            warning.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            scroll.topAnchor.constraint(equalTo: warning.bottomAnchor, constant: 4),
+            scroll.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            scroll.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        self.view = container
     }
 
     override func viewDidLayout() {
@@ -188,6 +210,14 @@ final class PrefCoresController: NSViewController {
     }
 
     private func applyEntries(retroArchCores allRetroArch: [RetroArchCore]) {
+        let collisions = OECorePlugin.collidingBundleIdentifiers
+        if collisions.isEmpty {
+            warningBanner.isHidden = true
+        } else {
+            let names = collisions.sorted().joined(separator: ", ")
+            warningBanner.stringValue = "⚠ Duplicate core bundles detected: \(names). Open ~/Library/Application Support/OpenEmu/Cores/ and remove the extra copy of each affected core."
+            warningBanner.isHidden = false
+        }
         var map: [String: (name: String, cores: [CoreDownload])] = [:]
         for core in CoreUpdater.shared.coreList {
             for sysID in core.systemIdentifiers {

--- a/OpenEmu/PrefCoresController.swift
+++ b/OpenEmu/PrefCoresController.swift
@@ -157,23 +157,17 @@ final class PrefCoresController: NSViewController {
         warning.textColor = .systemOrange
         warning.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
         warning.isHidden = true
-        warning.translatesAutoresizingMaskIntoConstraints = false
         self.warningBanner = warning
 
-        let container = NSView()
-        container.addSubview(scroll)
-        container.addSubview(warning)
-        scroll.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            warning.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
-            warning.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
-            warning.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
-            scroll.topAnchor.constraint(equalTo: warning.bottomAnchor, constant: 4),
-            scroll.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            scroll.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            scroll.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
-        self.view = container
+        // NSStackView collapses hidden views to zero height automatically,
+        // so the table fills the full space when no collision banner is shown.
+        let stack = NSStackView(views: [warning, scroll])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.distribution = .fill
+        stack.spacing = 4
+        stack.edgeInsets = NSEdgeInsets(top: 6, left: 8, bottom: 0, right: 8)
+        self.view = stack
     }
 
     override func viewDidLayout() {

--- a/OpenEmuKit/Source/OECorePlugin.swift
+++ b/OpenEmuKit/Source/OECorePlugin.swift
@@ -24,6 +24,7 @@
 
 import Foundation
 import OpenEmuBase
+internal import os.log
 
 public class OECorePlugin: OEPlugin {
     
@@ -37,7 +38,33 @@ public class OECorePlugin: OEPlugin {
     
     @objc public class var allPlugins: [OECorePlugin] {
         // swiftlint:disable:next force_cast
-        return plugins() as! [OECorePlugin]
+        let all = plugins() as! [OECorePlugin]
+        var seen: [String: OECorePlugin] = [:]
+        for plugin in all {
+            let id = plugin.bundleIdentifier
+            if let existing = seen[id] {
+                os_log(.error, "OECorePlugin: CFBundleIdentifier collision — '%{public}@' is claimed by both '%{public}@' and '%{public}@'. The first one found will be used; remove the duplicate from ~/Library/Application Support/OpenEmu/Cores/ to restore correct behaviour.",
+                       id, existing.url.lastPathComponent, plugin.url.lastPathComponent)
+            } else {
+                seen[id] = plugin
+            }
+        }
+        return all
+    }
+
+    /// Bundle identifiers for which more than one .oecoreplugin is present in the
+    /// Cores folder. Non-empty means at least one core has an ambiguous install that
+    /// may cause silent failures (black screen, wrong version loaded, etc.).
+    public class var collidingBundleIdentifiers: Set<String> {
+        var seen = Set<String>()
+        var collisions = Set<String>()
+        for plugin in allPlugins {
+            let id = plugin.bundleIdentifier
+            if !seen.insert(id).inserted {
+                collisions.insert(id)
+            }
+        }
+        return collisions
     }
     
     required init(bundleAtURL bundleURL: URL, name: String?) throws {


### PR DESCRIPTION
## What does this PR do?

Two independent fixes bundled together since they touch related infrastructure (core install and plugin loading).

**#437 — CoreDownload: preserve existing signatures**

`adHocSign` previously ran `codesign --force --sign -` unconditionally, stripping Developer ID signatures from every core immediately after install. The release pipeline signs every core with Developer ID, so this was silently discarding valid signatures on every update.

Fix: run `codesign --verify` first. If the bundle already has a valid signature, skip the re-sign entirely. Only apply ad-hoc as a fallback for unsigned bundles (third-party drops, etc.).

After this change, a freshly installed core will report `Authority=Developer ID Application: Nick Blackmon` instead of `Signature=adhoc`.

**#435 — Plugin loader: detect and surface CFBundleIdentifier collisions**

When two `.oecoreplugin` bundles in the Cores folder share a `CFBundleIdentifier`, OpenEmu silently picks one and ignores the other. The "loser" causes black-screen failures with no diagnostic.

Fix:
- `OECorePlugin.allPlugins` now logs an `os_log(.error)` for every collision, naming both paths and which one was loaded
- New `OECorePlugin.collidingBundleIdentifiers` exposes the set of affected identifiers
- Preferences → Cores shows an orange warning banner when collisions are detected, naming the identifiers and directing the user to remove the duplicate from `~/Library/Application Support/OpenEmu/Cores/`

## What did you test?

- Build passes clean, no new warnings
- Verified `adHocSign` logic flow against the two cases (signed bundle → verify passes → skip; unsigned bundle → verify fails → apply ad-hoc)
- Collision banner wiring verified by code inspection; runtime test requires manually duplicating a core bundle

## Which cores or systems are affected?

All cores (install path) and all systems (plugin loader).

## Did you use AI tools?

Yes — Claude identified the root causes and implemented both fixes. All diffs reviewed before committing.

## Linked issues

Closes #437
Closes #435

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

To test #437: install any core through Preferences → Cores → Check for Updates, then run `codesign -dvv ~/Library/Application\ Support/OpenEmu/Cores/<Core>.oecoreplugin` — should show Developer ID authority, not adhoc.

To test #435: `cp -R ~/Library/Application\ Support/OpenEmu/Cores/Gambatte.oecoreplugin ~/Library/Application\ Support/OpenEmu/Cores/"Gambatte copy.oecoreplugin"`, relaunch OpenEmu, open Preferences → Cores — warning banner should appear.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `BUILD SUCCEEDED`, no new warnings
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header