### PR TITLE
chore: release v1.2.3

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release receives security fixes. Older versions are not patched.
 
 | Version | Supported |
 |---------|-----------|
-| 1.2.2 (latest) | ✅ |
-| < 1.2.2 | ❌ |
+| 1.2.3 (latest) | ✅ |
+| < 1.2.3 | ❌ |
 
 ## Reporting a Vulnerability
 

--- a/Casks/openemu-silicon.rb
+++ b/Casks/openemu-silicon.rb
@@ -1,6 +1,6 @@
 cask "openemu-silicon" do
-  version "1.2.2"
-  sha256 "40ceff13759254b795069e9f4ef6fb233de7088eddbbe4c868aa45d69da4b82f"
+  version "1.2.3"
+  sha256 "cbc9169e131a37abcee7dad4558e1f43990678b9b3603ea4f23d54f4467768cc"
 
   url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
   name "OpenEmu Silicon"

--- a/OpenEmu/OpenEmu-Info.plist
+++ b/OpenEmu/OpenEmu-Info.plist
@@ -122,7 +122,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -143,7 +143,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -8378,7 +8378,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.OpenEmu.debug;
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
@@ -8418,7 +8418,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.$(PRODUCT_NAME:identifier)";
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_OBJC_BRIDGING_HEADER = "OpenEmu-Bridging-Header.h";

--- a/Releases/notes-1.2.3.md
+++ b/Releases/notes-1.2.3.md
@@ -1,0 +1,11 @@
+## What's New in 1.2.3
+
+- Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly
+- RetroAchievements: Hardcore mode progress is now preserved across sessions, and achievements earned offline are queued and submitted automatically when connectivity is restored
+- The Preferences window now floats above the game so you can adjust settings without interrupting play
+
+## Bug Fixes
+
+- Fixed a freeze that could occur while scrolling or searching the game library
+- Fixed a RetroAchievements crash and state loss that could occur when switching between games (thanks @tao-bioinfo, #579)
+- Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously the updater would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected in the cores folder

--- a/Releases/notes-1.2.3.md
+++ b/Releases/notes-1.2.3.md
@@ -1,7 +1,7 @@
 ## What's New in 1.2.3
 
 - Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly
-- RetroAchievements: Hardcore mode progress is now preserved across sessions, and achievements earned offline are queued and submitted automatically when connectivity is restored
+- RetroAchievements: Hardcore mode progress is now preserved across sessions, achievements earned offline are queued and submitted automatically when connectivity is restored, and slow motion is now correctly blocked during hardcore sessions
 - The Preferences window now floats above the game so you can adjust settings without interrupting play
 
 ## Bug Fixes
@@ -9,3 +9,5 @@
 - Fixed a freeze that could occur while scrolling or searching the game library
 - Fixed a RetroAchievements crash and state loss that could occur when switching between games (thanks @tao-bioinfo, #579)
 - Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously the updater would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected in the cores folder
+- Sega Saturn games now appear as an available update in Preferences → Cores — the Mednafen core was missing from the core registry so Saturn users were not being offered updates
+- Picodrive no longer incorrectly lists Sega CD support; Sega CD is handled by Genesis Plus GX

--- a/Releases/notes-1.2.3.md
+++ b/Releases/notes-1.2.3.md
@@ -1,13 +1,20 @@
 ## What's New in 1.2.3
 
-- Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly
-- RetroAchievements: Hardcore mode progress is now preserved across sessions, achievements earned offline are queued and submitted automatically when connectivity is restored, and slow motion is now correctly blocked during hardcore sessions
-- The Preferences window now floats above the game so you can adjust settings without interrupting play
+- Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly (#591)
+- RetroAchievements: Hardcore mode progress is now preserved across sessions, achievements earned offline are queued and submitted when connectivity returns, and slow motion is now correctly blocked during hardcore sessions (#587, #586)
+- The Preferences window now floats above the game so you can adjust settings without interrupting play (#578)
 
 ## Bug Fixes
 
-- Fixed a freeze that could occur while scrolling or searching the game library
-- Fixed a RetroAchievements crash and state loss that could occur when switching between games (thanks @tao-bioinfo, #579)
-- Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously the updater would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected in the cores folder
-- Sega Saturn games now appear as an available update in Preferences → Cores — the Mednafen core was missing from the core registry so Saturn users were not being offered updates
-- Picodrive no longer incorrectly lists Sega CD support; Sega CD is handled by Genesis Plus GX
+- Fixed a crash in the helper process affecting all six RetroAchievements-enabled cores (SNES9x, Gambatte, FCEU, Nestopia, mGBA, Mednafen) — the rcheevos client was being mutated simultaneously from three threads with no serialization, causing `EXC_BAD_INSTRUCTION` on game load. A new serial bridge (`OERetroAchievementsBridge`) now owns the client and serializes all access (thanks @tao-bioinfo, #579, #588)
+- Fixed a 2000ms+ main-thread hang when typing in the search field with a large game library on macOS 26 Tahoe — each keystroke was triggering a synchronous IPC-locked preferences read for every game in the library (#582)
+- The "RA: Unknown emulator" chip that previously overlapped game video is replaced by an auto-hiding placard when RetroAchievements has not yet approved the client for hardcore credit (#588)
+- Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously re-signing would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected (#592)
+- Sega Saturn games now appear as an available update in Preferences → Cores — the Mednafen core was missing from the core registry so Saturn users were not being offered updates (#590)
+- Picodrive no longer incorrectly lists Sega CD support; Sega CD is handled by Genesis Plus GX (#590)
+
+## Under the Hood
+
+- RetroAchievements network requests now include the active core name and version in the User-Agent string — required for the RA server to grant hardcore credit to this client (#586)
+- Crash reports in Sentry are now fully symbolicated for all shipped binaries — dSYM verification is enforced before each release and release markers are registered so issues show "First seen in vX.Y.Z" (#576, #593)
+- App releases now route through a PR before the Sparkle appcast goes live, ensuring CI version checks pass first (#574)

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -181,7 +181,7 @@ sentry-cli releases set-commits "$SENTRY_RELEASE" --auto \
 sentry-cli releases finalize "$SENTRY_RELEASE" \
   --org openemu-silicon --project openemu-silicon \
   || echo "WARNING: sentry-cli releases finalize failed."
-ok "Sentry release marker: $SENTRY_RELEASE"
+echo "OK: Sentry release marker: $SENTRY_RELEASE"
 
 # ── 2. Notarize (re-sign + notarize + DMG + staple) ──────────────────────────
 step "2/5  Re-signing, notarizing, and creating DMG"

--- a/appcast.xml
+++ b/appcast.xml
@@ -5,7 +5,36 @@
     <link>https://github.com/nickybmon/OpenEmu-Silicon/releases</link>
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
-                                                <item>
+                                                    <item>
+      <title>OpenEmu-Silicon 1.2.3</title>
+      <description>
+        <![CDATA[
+        <h2>OpenEmu-Silicon 1.2.3</h2>
+        <h3>What's New in 1.2.3</h3>
+        <ul>
+        <li>Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly</li>
+        <li>RetroAchievements: Hardcore mode progress is now preserved across sessions, and achievements earned offline are queued and submitted automatically when connectivity is restored</li>
+        <li>The Preferences window now floats above the game so you can adjust settings without interrupting play</li>
+        </ul>
+        <h3>Bug Fixes</h3>
+        <ul>
+        <li>Fixed a freeze that could occur while scrolling or searching the game library</li>
+        <li>Fixed a RetroAchievements crash and state loss that could occur when switching between games (thanks @tao-bioinfo, #579)</li>
+        <li>Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously the updater would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected in the cores folder</li>
+        </ul>
+        ]]>
+      </description>
+      <pubDate>Mon, 08 Jun 2026 14:51:42 +0000</pubDate>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v1.2.3/OpenEmu-Silicon.dmg"
+        sparkle:version="19"
+        sparkle:shortVersionString="1.2.3"
+        sparkle:edSignature="040NIcv+O6EbrD/RIzW9+eIZmIxrQ7buNfj7ZAcaTPTWXwxvyhdJDwaY65SoY0Qy64DA0FhZydv4r+mdTV2kAw=="
+        length="49514834"
+        type="application/octet-stream"/>
+    </item>
+<item>
       <title>OpenEmu-Silicon 1.2.2</title>
       <description>
         <![CDATA[


### PR DESCRIPTION
## Release v1.2.3

This PR lands the appcast update, Homebrew cask, and version files for v1.2.3. Merging makes the Sparkle update live for existing users.

**Before merging:**
- [ ] CI build check passes
- [ ] Draft GitHub Release reviewed — notes look good
- [ ] DMG tested (launch, quick smoke, check version in About)

**After merging:**
Publish the GitHub Release:
```
gh release edit v1.2.3 --draft=false --repo nickybmon/OpenEmu-Silicon
```

---
## What's New in 1.2.3

- Cheats can now be edited and removed without leaving the game — tap the cheat menu in the controls bar to modify existing codes on the fly
- RetroAchievements: Hardcore mode progress is now preserved across sessions, and achievements earned offline are queued and submitted automatically when connectivity is restored
- The Preferences window now floats above the game so you can adjust settings without interrupting play

## Bug Fixes

- Fixed a freeze that could occur while scrolling or searching the game library
- Fixed a RetroAchievements crash and state loss that could occur when switching between games (thanks @tao-bioinfo, #579)
- Core updates installed through the in-app updater now correctly preserve Developer ID signatures — previously the updater would overwrite a properly-signed core with an ad-hoc signature; also added a warning when duplicate core bundles are detected in the cores folder