### PR TITLE
chore: cores-v1.3.5 — RA compliance batch + dSYM backfill

### DIFF
--- a/Appcasts/genesisplus.xml
+++ b/Appcasts/genesisplus.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>GenesisPlus</title>
-                    <item>
+                        <item>
+      <title>GenesisPlus 1.7.5.5</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/GenesisPlus.oecoreplugin.zip"
+        sparkle:version="1.7.5.5"
+        sparkle:shortVersionString="1.7.5.5"
+        length="643568"
+        sparkle:edSignature="6PbfJTcMUBCcJTEHqEMM1ix5R49sZ3Bjs9Gb4WiyOF/ySDgBAG/7KvemhUmXm0FLI/nN2BF3bijp9NAPCkkeCQ=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>Genesis Plus GX 1.7.5.4</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mednafen.xml
+++ b/Appcasts/mednafen.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Mednafen</title>
-                    <item>
+                        <item>
+      <title>Mednafen 1.26.7</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/Mednafen.oecoreplugin.zip"
+        sparkle:version="1.26.7"
+        sparkle:shortVersionString="1.26.7"
+        length="2928160"
+        sparkle:edSignature="f6ctDKlpVP8UjBqaZ4eNCLf92in5rOXobMKFRxmDxXD0oyFEgKL6kdplBttXwJmKQyY8GkdDC2bE2cEmP8wOAA=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>Mednafen 1.26.6</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mgba.xml
+++ b/Appcasts/mgba.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>mGBA</title>
-                    <item>
+                        <item>
+      <title>mGBA 0.10.9</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/mGBA.oecoreplugin.zip"
+        sparkle:version="0.10.9"
+        sparkle:shortVersionString="0.10.9"
+        length="381027"
+        sparkle:edSignature="XmmbKGBNfeqTeNEfOy7GAkm6IbruhsHR99knDDwrDqEStExpcqM2TCXougd8vRSqxOZS5x4UHjE8dVv0otfbAg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>mGBA 0.10.8</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/mupen64plus.xml
+++ b/Appcasts/mupen64plus.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Mupen64Plus</title>
-                    <item>
+                        <item>
+      <title>Mupen64Plus 2.5.16</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/Mupen64Plus.oecoreplugin.zip"
+        sparkle:version="2.5.16"
+        sparkle:shortVersionString="2.5.16"
+        length="1217386"
+        sparkle:edSignature="x6wDASYNnDsstoo+Mwmre97m1rsABpa5u8HQ0H0S+1uMr5toICIWxXTLTvMIJi1qsNCTq59uSZGYzYlEJz8TDw=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>Mupen64Plus 2.5.15</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/nestopia.xml
+++ b/Appcasts/nestopia.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Nestopia</title>
-                    <item>
+                        <item>
+      <title>Nestopia 1.52.4</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/Nestopia.oecoreplugin.zip"
+        sparkle:version="1.52.4"
+        sparkle:shortVersionString="1.52.4"
+        length="807204"
+        sparkle:edSignature="BnsPCfNGVDhjEbfkwrqKeeIdE5+OAgaKQOHPBaEPHgTIUpIuvD26DGd0rrNE3BboK1MjPPB79b0qUXEyG5kWAg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>Nestopia 1.52.3</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/Appcasts/snes9x.xml
+++ b/Appcasts/snes9x.xml
@@ -4,7 +4,18 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>SNES9x</title>
-                    <item>
+                        <item>
+      <title>SNES9x 1.63.4</title>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/nickybmon/OpenEmu-Silicon/releases/download/cores-v1.3.5/SNES9x.oecoreplugin.zip"
+        sparkle:version="1.63.4"
+        sparkle:shortVersionString="1.63.4"
+        length="864360"
+        sparkle:edSignature="WalyzWlS3TF4B7Ie6QJxxsljjQL68Vav363rdzYNT1C0H9Tw/thcCoZ/6qdTWxBl62VES6CcLr7YvBG5wdshAg=="
+        type="application/octet-stream" />
+    </item>
+<item>
       <title>SNES9x 1.63.3</title>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.5.4</string>
+	<string>1.7.5.5</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Mednafen/Info.plist
+++ b/Mednafen/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.26.6</string>
+	<string>1.26.7</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>
@@ -118,9 +118,9 @@
 		<dict>
 			<key>OEGameCoreRequiresFiles</key>
 			<true/>
-			<key>OEGameCoreSupportsRetroAchievements</key>
-			<true/>
 			<key>OEGameCoreSupportsMultipleDiscs</key>
+			<true/>
+			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OERequiredFiles</key>
 			<array>

--- a/Mupen64Plus/Info.plist
+++ b/Mupen64Plus/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.15</string>
+	<string>2.5.16</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.5.15</string>
+	<string>2.5.16</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Nestopia/Info.plist
+++ b/Nestopia/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.52.3</string>
+	<string>1.52.4</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/SNES9x/Info.plist
+++ b/SNES9x/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.63.3</string>
+	<string>1.63.4</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>

--- a/Scripts/package-core.sh
+++ b/Scripts/package-core.sh
@@ -72,7 +72,8 @@ step "Verifying and uploading dSYM to Sentry"
   --upload \
   --wait-for 120 \
   --binary-root "$PLUGIN" \
-  --dsym-root "$DERIVED_DATA/Build/Products/Release"
+  --dsym-root "$DERIVED_DATA/Build/Products/Release" \
+  --allow-missing '\.so$'
 
 # ── 5. Zip with ditto ────────────────────────────────────────────────────────
 step "Creating zip"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -181,7 +181,7 @@ sentry-cli releases set-commits "$SENTRY_RELEASE" --auto \
 sentry-cli releases finalize "$SENTRY_RELEASE" \
   --org openemu-silicon --project openemu-silicon \
   || echo "WARNING: sentry-cli releases finalize failed."
-ok "Sentry release marker: $SENTRY_RELEASE"
+echo "OK: Sentry release marker: $SENTRY_RELEASE"
 
 # ── 2. Notarize (re-sign + notarize + DMG + staple) ──────────────────────────
 step "2/5  Re-signing, notarizing, and creating DMG"

--- a/mGBA/Info.plist
+++ b/mGBA/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.10.8</string>
+	<string>0.10.9</string>
 	<key>NSPrincipalClass</key>
 	<string>OEGameCoreController</string>
 	<key>OEGameCoreClass</key>


### PR DESCRIPTION
## What does this PR do?

Releases six core updates as `cores-v1.3.5`. All six cores pick up the RetroAchievements hardcore compliance and rcheevos state serialization fixes that shipped in the app's 1.2.3 release. Also establishes proper dSYM uploads in Sentry for all six cores.

**Versions:**
- Mupen64Plus 2.5.16
- SNES9x 1.63.4
- GenesisPlus 1.7.5.5
- mGBA 0.10.9
- Mednafen 1.26.7
- Nestopia 1.52.4

**Also fixes:** `Scripts/package-core.sh` now passes `--allow-missing '\.so$'` to `verify-sentry-symbols.sh`, allowing prebuilt native `.so` plugins bundled inside core plugins (e.g. `mupen64plus-video-GLideN64.so`) to skip dSYM verification. These are prebuilt third-party binaries we don't compile, so dSYMs are unavailable.

## What did you test?

- All 6 cores built in Release, version verified in plugin plist
- `package-core.sh` ran cleanly for each: signed, dSYM uploaded to Sentry, zip verified
- Appcasts updated with correct EdDSA signatures via `update_core_appcast.py --sign-zip`
- GitHub release `cores-v1.3.5` created with all 6 zips

## Which cores or systems are affected?

N64, SNES, Genesis/Mega Drive, GBA, multi-system (Mednafen), NES

## Did you use AI tools?

Yes — Claude handled the batch build and packaging.

## Linked issues

Related to #587
Related to #588

---

## How to test locally

```bash
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
```

Open OpenEmu → Preferences → Cores — all six should show an available update. Install each and verify the version matches.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved