### PR TITLE
Fix macOS dependency syntax in openemu-silicon.rb

### DIFF
--- a/Casks/openemu-silicon.rb
+++ b/Casks/openemu-silicon.rb
@@ -13,7 +13,7 @@ cask "openemu-silicon" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "OpenEmu.app"
 


### PR DESCRIPTION
## What does this PR do?
Fixes a deprecated string comparison format for `depends_on macos:` in `Casks/openemu-silicon.rb`. Homebrew now requires the symbol format (e.g. `:big_sur`) rather than a string (e.g. `">= :big_sur"`), and was emitting a deprecation warning on every install/upgrade.

## What did you test?
Ran `brew install --cask openemu-silicon` locally after the change and confirmed the deprecation warning no longer appears.

## Which cores or systems are affected?
General app change — no emulation cores or systems are affected.

## Did you use AI tools?
Used Claude to draft the PR description. Identified and applied the fix manually.

## Linked issues
Fixes #

---
## PR checklist
- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header