### PR TITLE
fix: per-system Add Cheat dialog placeholders + N64 format validation

### DIFF
--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1657,35 +1657,126 @@ final class OEGameDocument: NSDocument {
     
     @IBAction func addCheat(_ sender: Any?) {
         if isHardcoreModeEnabled { return }
-        let alert = OEAlert()
+        let format = Self.cheatFormat(for: systemPlugin.systemIdentifier)
 
-        alert.otherInputLabelText = NSLocalizedString("Title:", comment: "")
-        alert.showsOtherInputField = true
-        alert.otherInputPlaceholderText = NSLocalizedString("Cheat Description", comment: "")
-        
-        alert.inputLabelText = NSLocalizedString("Code:", comment: "")
-        alert.showsInputField = true
-        alert.inputPlaceholderText = NSLocalizedString("Join multi-line cheats with '+' e.g. 000-000+111-111", comment: "")
-        
-        alert.defaultButtonTitle = NSLocalizedString("Add Cheat", comment: "")
-        alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
-        
-        alert.showsSuppressionButton = true
-        alert.suppressionLabelText = NSLocalizedString("Enable now", comment: "Cheats button label")
-        
-        alert.inputLimit = 1000
-        
-        if alert.runModal() == .alertFirstButtonReturn {
-            let cheat = Cheat(code: alert.stringValue, type: "GameShark", name: alert.otherStringValue)
+        var presetCode = ""
+        var presetName = ""
+
+        while true {
+            let alert = OEAlert()
+
+            alert.otherInputLabelText = NSLocalizedString("Title:", comment: "")
+            alert.showsOtherInputField = true
+            alert.otherInputPlaceholderText = NSLocalizedString("Cheat Description", comment: "")
+            alert.otherStringValue = presetName
+
+            alert.inputLabelText = NSLocalizedString("Code:", comment: "")
+            alert.showsInputField = true
+            alert.inputPlaceholderText = format.placeholder
+            alert.stringValue = presetCode
+
+            alert.defaultButtonTitle = NSLocalizedString("Add Cheat", comment: "")
+            alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
+
+            alert.showsSuppressionButton = true
+            alert.suppressionLabelText = NSLocalizedString("Enable now", comment: "Cheats button label")
+
+            alert.inputLimit = 1000
+
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+            let code = alert.stringValue
+            let name = alert.otherStringValue
+            let shouldEnable = alert.suppressionButtonState
+
+            if let validate = format.validator, !validate(code) {
+                let warn = OEAlert()
+                warn.messageText = NSLocalizedString("This code doesn't match a known cheat format for this system.", comment: "Add Cheat validation alert title")
+                warn.informativeText = format.validationHint
+                warn.defaultButtonTitle = NSLocalizedString("Edit", comment: "Add Cheat validation alert: return to the cheat dialog to fix the code")
+                warn.alternateButtonTitle = NSLocalizedString("Save Anyway", comment: "Add Cheat validation alert: save the unrecognized code as-is")
+                warn.otherButtonTitle = NSLocalizedString("Cancel", comment: "")
+
+                switch warn.runModal() {
+                case .alertFirstButtonReturn:
+                    presetCode = code
+                    presetName = name
+                    continue
+                case .alertSecondButtonReturn:
+                    break
+                default:
+                    return
+                }
+            }
+
+            let cheat = Cheat(code: code, type: "GameShark", name: name)
             cheat.isUserAdded = true
 
-            if alert.suppressionButtonState {
+            if shouldEnable {
                 cheat.isEnabled = true
                 setCheat(cheat)
             }
 
             cheats.append(cheat)
             saveUserCheats()
+            return
+        }
+    }
+
+    private struct CheatFormat {
+        let placeholder: String
+        let validationHint: String
+        let validator: ((String) -> Bool)?
+    }
+
+    private static let defaultCheatFormat = CheatFormat(
+        placeholder: NSLocalizedString("Join multi-line cheats with '+' e.g. 000-000+111-111", comment: "Add Cheat dialog placeholder for systems without a specific format hint"),
+        validationHint: "",
+        validator: nil
+    )
+
+    private static func cheatFormat(for systemIdentifier: String) -> CheatFormat {
+        switch systemIdentifier {
+        case "openemu.system.n64":
+            return CheatFormat(
+                placeholder: NSLocalizedString("12 hex chars per code, e.g. 8033B21D0064. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, N64"),
+                validationHint: NSLocalizedString("N64 codes must be 12 hex characters (8-char address + 4-char value), e.g. 8033B21D0064. Longer 16-char GameShark Pro / Action Replay codes are not supported by the Mupen64Plus core.", comment: "Add Cheat validation hint, N64"),
+                validator: { code in
+                    let parts = code.replacingOccurrences(of: " ", with: "")
+                                    .replacingOccurrences(of: "\n", with: "")
+                                    .split(separator: "+")
+                    guard !parts.isEmpty else { return false }
+                    return parts.allSatisfy { p in
+                        p.count == 12 && p.allSatisfy { $0.isHexDigit }
+                    }
+                }
+            )
+        case "openemu.system.nes", "openemu.system.fds":
+            return CheatFormat(
+                placeholder: NSLocalizedString("Game Genie or raw hex (XXXX:YY). Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, NES"),
+                validationHint: "",
+                validator: nil
+            )
+        case "openemu.system.snes":
+            return CheatFormat(
+                placeholder: NSLocalizedString("Game Genie or PAR codes. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, SNES"),
+                validationHint: "",
+                validator: nil
+            )
+        case "openemu.system.gb", "openemu.system.gba":
+            return CheatFormat(
+                placeholder: NSLocalizedString("GameShark (no dash) or Game Genie (with dash). Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Game Boy / GBA"),
+                validationHint: "",
+                validator: nil
+            )
+        case "openemu.system.sg", "openemu.system.sms", "openemu.system.gg", "openemu.system.32x", "openemu.system.scd":
+            return CheatFormat(
+                placeholder: NSLocalizedString("Game Genie or Action Replay. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Sega"),
+                validationHint: "",
+                validator: nil
+            )
+        default:
+            return defaultCheatFormat
         }
     }
     

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1661,6 +1661,7 @@ final class OEGameDocument: NSDocument {
 
         var presetCode = ""
         var presetName = ""
+        var presetEnable = false
 
         while true {
             let alert = OEAlert()
@@ -1680,6 +1681,7 @@ final class OEGameDocument: NSDocument {
 
             alert.showsSuppressionButton = true
             alert.suppressionLabelText = NSLocalizedString("Enable now", comment: "Cheats button label")
+            alert.suppressionButtonState = presetEnable
 
             alert.inputLimit = 1000
 
@@ -1701,6 +1703,7 @@ final class OEGameDocument: NSDocument {
                 case .alertFirstButtonReturn:
                     presetCode = code
                     presetName = name
+                    presetEnable = shouldEnable
                     continue
                 case .alertSecondButtonReturn:
                     break


### PR DESCRIPTION
## What does this PR do?

Replaces the Add Cheat dialog's one-size-fits-all "Game Genie" placeholder with per-system guidance, and adds format validation for N64 codes so users get a clear warning instead of silently saving a code the core will drop.

## What did you test?

Local build and analyzer (`./Scripts/verify.sh`) pass. App boots cleanly. I did not click through the Add Cheat dialog with a running ROM in this session — that needs a manual smoke check with at least one N64 game (paste a 16-char GameShark Pro code and confirm the warning appears with N64-specific guidance) and one non-N64 system (confirm the placeholder updates and no warning fires).

## Which cores or systems are affected?

Frontend / app change only. The dialog's text differs by `systemPlugin.systemIdentifier`; the validator currently runs only for N64 (`openemu.system.n64`). No changes to any core source.

## Did you use AI tools?

Yes — Claude drafted the implementation off the design in the issue body; I reviewed, tested the build, and ran an adversarial review pass that caught one real bug (suppression checkbox state lost across the Edit re-prompt) before this PR opened.

## Linked issues

Fixes #312

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 602 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

To exercise the change: launch any N64 game, open Cheats → Add Cheat, paste a 16-char GameShark Pro code (e.g. `8133B21D 00000064`), and confirm the warning alert appears with the N64-specific hint. Click Edit and confirm the typed code, title, and Enable now checkbox state are all preserved on the next attempt. Then try an N64 12-char code (e.g. `8033B21D 0064`) and confirm it saves without a warning.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M-series Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

One `block` finding caught and fixed in commit `aca0b78a`: the "Enable now" suppression checkbox state was not preserved when the user picked Edit from the validation warning. A user who checked Enable now, hit Add Cheat, then picked Edit to fix the code would land on a corrected save with the cheat silently disabled. Fix carries the prior state through the loop alongside the code and title.

Four `note` findings surfaced (do not gate this PR, follow-ups for later):

1. **Whitespace stripping is incomplete.** The N64 validator strips spaces and `\n` but not `\t` or `\r`. A code pasted from a Windows source with CRLF or tab characters can be rejected even though the core would accept it after its own normalization.
2. **`Character.isHexDigit` accepts non-ASCII hex.** Swift's `isHexDigit` matches Unicode hex digits (Arabic-Indic, fullwidth, etc.), but Mupen64Plus's C parser is ASCII-only. Theoretical false positive — extremely unlikely in real cheat code text but worth tightening if we ever generalize this validator.
3. **`split(separator:)` omits empty subsequences by default.** Codes like `"+ABC..."` or `"...++..."` validate as fine because the empty segments are dropped before length checking. The core may reject these even though our validator says yes. Low-risk in practice.
4. **System identifier matching is literal lowercase.** If the canonical casing ever changes upstream, all per-system placeholders silently fall through to the generic default. Could be centralized as constants alongside the system plugins.