### PR TITLE
fix: guard N64 controller-connect crash against NULL element copy

### DIFF
--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
@@ -604,7 +604,7 @@ typedef enum {
 
 - (void)dealloc
 {
-    if (_device != NULL) CFRelease(_device);
+    CFRelease(_device);
     if (_elements != NULL) CFRelease(_elements);
 }
 
@@ -626,8 +626,10 @@ typedef enum {
     // in on a low-memory system). Without a non-nil element list there's no
     // device to parse, and proceeding would leave _elements NULL — which would
     // then crash in dealloc on CFRelease(NULL). Bail out so the caller can skip.
-    if (_elements == NULL)
+    if (_elements == NULL) {
+        NSLog(@"OEHIDDeviceParser: IOHIDDeviceCopyMatchingElements returned NULL for device %p; skipping parse.", device);
         return nil;
+    }
 
     NSMutableDictionary<NSValue *, NSValue *> *elementTree = [NSMutableDictionary dictionary];
     for(id e in (__bridge NSArray *)_elements) {

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
@@ -604,8 +604,8 @@ typedef enum {
 
 - (void)dealloc
 {
-    CFRelease(_device);
-    CFRelease(_elements);
+    if (_device != NULL) CFRelease(_device);
+    if (_elements != NULL) CFRelease(_elements);
 }
 
 - (instancetype)init
@@ -620,6 +620,14 @@ typedef enum {
 
     _device = (IOHIDDeviceRef)CFRetain(device);
     _elements = IOHIDDeviceCopyMatchingElements(_device, NULL, 0);
+
+    // IOHIDDeviceCopyMatchingElements can return NULL under memory pressure or
+    // when the device is torn down by IOKit mid-call (e.g. a controller plugged
+    // in on a low-memory system). Without a non-nil element list there's no
+    // device to parse, and proceeding would leave _elements NULL — which would
+    // then crash in dealloc on CFRelease(NULL). Bail out so the caller can skip.
+    if (_elements == NULL)
+        return nil;
 
     NSMutableDictionary<NSValue *, NSValue *> *elementTree = [NSMutableDictionary dictionary];
     for(id e in (__bridge NSArray *)_elements) {


### PR DESCRIPTION
## What does this PR do?

Hardens `_OEHIDDeviceElementTree` in `OEHIDDeviceParser.m` against `IOHIDDeviceCopyMatchingElements` returning NULL — which can happen under memory pressure or when IOKit tears down a device mid-call (matching the reporter's "low memory M1, controller plugged in" scenario). Previously the NULL result was stored and then `CFRelease(_elements)` in dealloc would crash since `CFRelease(NULL)` is a documented runtime crash. The crash surfaced inside `OE_deviceAttributesForUnknownIOHIDDevice` because ARC inserts the tree's release at the end of that method, so dealloc ran in the caller's stack frame.

## Honest scope note

The Sentry trace referenced in #330 (`OPENEMU-SILICON-31`) no longer exists in the project (deleted or aged out). This is defensive hardening that fixes a real, documented failure mode whose trigger conditions match the user's report — but I can't prove it's the same crash. Added an `NSLog` before the nil return so a recurrence is detectable in Console output even without Sentry.

The known-controller path (`OE_deviceAttributesForKnownIOHIDDevice`) also calls `IOHIDDeviceCopyMatchingElements` but uses `__bridge_transfer` directly to `NSArray` + `mutableCopy`, which produces nil collections on a NULL return — silent misbehavior but not a crash. So scoping the fix to the unknown-device path is correct.

## What did you test?

Local `./Scripts/verify.sh` — build, analyzer, codesign all green. App boots cleanly. The crash path can't be exercised on a healthy system without artificially injecting NULL into IOKit, so this is verified via code-path reading + adversarial review, not a live repro. Real-world verification will be the absence of new instances of OPENEMU-SILICON crashes in the same call site after release.

## Which cores or systems are affected?

Frontend / shared HID device parsing. Affects every system that uses `OEHIDDeviceParser` (i.e. every controller-using core). Most likely to show up on N64 because that's what the reporter was running, but the fix is system-agnostic.

## Did you use AI tools?

Yes — Claude investigated the issue body, the Sentry MCP, and the device-parser code, drafted the fix, and ran an adversarial-review pass that caught two cleanups (drop an unreachable dealloc guard; add detection logging). Reviewed and tested by repo owner.

## Linked issues

Fixes #330

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 603 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

This change can't be triggered on a healthy machine — `IOHIDDeviceCopyMatchingElements` doesn't return NULL in normal use. The smoke test is: app launches, controllers connect and work as before, no regression in HID device enumeration.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M-series Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

One `block` finding ("shipped without evidence — Sentry trace gone, hypothesis speculative") rebutted with: the diff fixes a real, documented crash bug (`CFRelease(NULL)`) on the exact call site named in the report, with trigger conditions (low memory, IOKit teardown) matching the reporter's environment. Whether or not it's the same crash, the underlying bug is real and worth fixing on its own merits. To address the "no signal post-release" concern, added an `NSLog` before the nil return so we can detect recurrences in Console.

Two `note` findings accepted and applied in commit `0a7bb578`:
- Dropped the unreachable `_device != NULL` guard in dealloc (`_device` is only set via `CFRetain(device)` with a non-NULL device from the IOKit callback).
- Added detection logging before the early nil return.

One `note` raised by the reviewer — the known-device path also calls `IOHIDDeviceCopyMatchingElements` — was investigated and ruled out as a crash source. That path uses `__bridge_transfer + mutableCopy` which converts NULL to nil arrays without crashing. It can silently misbehave on NULL but won't produce an EXC_BAD_ACCESS like #330.