### PR TITLE
fix: render Atari 5200 video on the bundled Atari800 core

### DIFF
--- a/Atari800/Atari800Core/Source/ATR800GameCore.m
+++ b/Atari800/Atari800Core/Source/ATR800GameCore.m
@@ -115,11 +115,6 @@ static ATR800GameCore *_currentCore;
 
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError **)error
 {
-    // Set the default palette (NTSC)
-    NSString *palettePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"Default.act"];
-    strcpy(COLOURS_NTSC_external.filename, palettePath.fileSystemRepresentation);
-    COLOURS_NTSC_external.loaded = TRUE;
-
     Atari800_tv_mode = Atari800_TV_NTSC;
 
     /* It is necessary because of the CARTRIDGE_ColdStart (there must not be the
@@ -130,19 +125,28 @@ static ATR800GameCore *_currentCore;
 
     if([[self systemIdentifier] isEqualToString:@"openemu.system.5200"])
     {
+        // Set machine type before any palette/colour setup so libatari800
+        // initialises 5200 colour state correctly. The 8-bit Default.act
+        // palette is not appropriate for the 5200's GTIA output.
+        Atari800_SetMachineType(Atari800_MACHINE_5200);
+        MEMORY_ram_size = 16;
+
+        COLOURS_NTSC_external.loaded = FALSE;
+
         // Set 5200.rom BIOS path
         char biosFileName[2048];
         NSString *biosPath = [self biosDirectoryPath];
         strcpy(biosFileName, [[biosPath stringByAppendingPathComponent:@"5200.rom"] fileSystemRepresentation]);
 
         SYSROM_SetPath(biosFileName, 1, SYSROM_5200);
-
-        // Setup machine type
-        Atari800_SetMachineType(Atari800_MACHINE_5200);
-        MEMORY_ram_size = 16;
     }
     else if([[self systemIdentifier] isEqualToString:@"openemu.system.atari8bit"])
     {
+        // Custom NTSC palette for Atari 8-bit
+        NSString *palettePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"Default.act"];
+        strcpy(COLOURS_NTSC_external.filename, palettePath.fileSystemRepresentation);
+        COLOURS_NTSC_external.loaded = TRUE;
+
         char basicFileName[2048], osbFileName[2048], xlFileName[2048];
         NSString *biosPath = [self biosDirectoryPath];
         strcpy(basicFileName, [[biosPath stringByAppendingPathComponent:@"ataribas.rom"] fileSystemRepresentation]);


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the bundled Atari800 core where 5200 games loaded with audio but rendered a black screen. The core was applying the 8-bit Default.act NTSC palette to the 5200's GTIA output and setting the machine type after the colour state was already configured.

## What did you test?

Loaded Atari 5200 games on macOS 26 Tahoe / M-series Apple Silicon. Verified video renders correctly on Rescue on Fractalus and Star Wars: Death Star Battle (two of the three titles named by the original reporter). Audio continues to work as before.

## Which cores or systems are affected?

Atari800 core — Atari 5200 system path. The Atari 8-bit system path is also touched (the external Default.act palette load is moved into the 8-bit branch, scoped away from 5200) but its behavior is preserved.

## Did you use AI tools?

Used Claude to investigate the issue, draft the fix, and run an adversarial review of the diff. Tested in-game myself.

## Linked issues

Fixes #432

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use \`-scheme "OpenEmu + Flycast"\` with \`clean build\`; for Mednafen use \`-scheme "OpenEmu + Mednafen" -configuration Release\`.

\`\`\`bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 606 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
\`\`\`

\`verify.sh\` builds, prunes stale DerivedData, and runs a codesign check. \`launch-debug.sh\` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

\`\`\`bash
./Scripts/install-core.sh Atari800
./Scripts/launch-debug.sh
\`\`\`

\`install-core.sh\` quits OpenEmu first, copies files correctly, and re-signs the bundle.

You'll need the \`5200.rom\` BIOS file in OpenEmu's BIOS directory and an Atari 5200 ROM to test with.
