### PR TITLE
feat: expose additional Atari 8-bit media formats in the import dialog

### DIFF
--- a/OpenEmu/SystemPlugins/Atari 8-bit/Atari 8bit-Info.plist
+++ b/OpenEmu/SystemPlugins/Atari 8-bit/Atari 8bit-Info.plist
@@ -83,8 +83,13 @@
 	<key>OEFileSuffixes</key>
 	<array>
 		<string>atr</string>
+		<string>atx</string>
 		<string>bas</string>
+		<string>car</string>
+		<string>cas</string>
 		<string>com</string>
+		<string>dcm</string>
+		<string>pro</string>
 		<string>rom</string>
 		<string>xex</string>
 		<string>xfd</string>


### PR DESCRIPTION
## What does this PR do?

Expands the Atari 8-bit system's import-file allowlist to include all media formats the bundled libatari800 already supports: adds `atx`, `car`, `cas`, `dcm`, and `pro` alongside the existing `atr`, `bas`, `com`, `rom`, `xex`, `xfd`.

## What did you test?

Build passes (`./Scripts/verify.sh` — ALL PASS). The change is a plist allowlist only — the bundled core's `AFILE_OpenFile` already auto-detects all five new formats by content (verified by reading `Atari800/atari800-src/afile.c`). No new code paths; the worst case for any individual extension that turns out to have an upstream quirk is the same "Failed to open file" behavior as any other unsupported ROM today.

## Which cores or systems are affected?

OpenEmu Atari 8-bit system plugin (`OpenEmu/SystemPlugins/Atari 8-bit/Atari 8bit-Info.plist`). No core code is modified.

## Did you use AI tools?

Used Claude to verify each new extension is actually handled by the bundled libatari800 source, draft the plist change, and run an adversarial review of the diff.

## Linked issues

Fixes #581

## Adversarial review

- **`.cas` collides with the MSX system plugin.** Both Atari 8-bit and MSX now claim `.cas`. MSX's `canHandle` returns `.yes` only when the file starts with the MSX cart header (0x41 0x42) and `.uncertain` otherwise; Atari 8-bit has no `canHandle` override so it's `.uncertain` for all `.cas` files. Result: importing a `.cas` file that isn't an MSX cart will show OpenEmu's system-picker dialog rather than auto-routing to Atari 8-bit. Not a regression (you couldn't import Atari `.cas` files at all before), but worth knowing.
- **`.pro` detection has a debug-only log line under `#ifdef DEBUG_PRO`.** The format detection and `AFILE_OpenFile` handling are unconditional, so `.pro` files load fine; only the diagnostic log line is suppressed in our release builds.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 607 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

To verify the import allowlist, try importing any Atari 8-bit file with one of the new extensions and confirm it lands in the library under "Atari 8-bit". Actually launching the imported game still requires the three Atari 8-bit BIOS files (`ataribas.rom`, `atariosb.rom`, `atarixl.rom`) in OpenEmu's BIOS directory.
