### PR TITLE
fix: cache main-thread filesystem checks in library grid

### DIFF
--- a/OpenEmu/OEDBImage.swift
+++ b/OpenEmu/OEDBImage.swift
@@ -234,12 +234,22 @@ final class OEDBImage: OEDBItem {
         }
     }
     
+    private var _cachedImageURL: URL?
+    private var _cachedImageURLRelativePath: String?
+
     var imageURL: URL? {
-        if let relativePath = relativePath {
-            return libraryDatabase.coverFolderURL.appendingPathComponent(relativePath, isDirectory: false)
-        } else {
+        guard let relativePath = relativePath else {
+            _cachedImageURL = nil
+            _cachedImageURLRelativePath = nil
             return nil
         }
+        if let cached = _cachedImageURL, _cachedImageURLRelativePath == relativePath {
+            return cached
+        }
+        let url = libraryDatabase.coverFolderURL.appendingPathComponent(relativePath, isDirectory: false)
+        _cachedImageURL = url
+        _cachedImageURLRelativePath = relativePath
+        return url
     }
     
     var sourceURL: URL? {
@@ -255,7 +265,23 @@ final class OEDBImage: OEDBItem {
         }
     }
     
+    private var _cachedIsLocalImageAvailable: Bool?
+    private var _cachedIsLocalImageAvailableRelativePath: String?
+
     var isLocalImageAvailable: Bool {
-        return (try? imageURL?.checkResourceIsReachable()) ?? false
+        let currentRelativePath = relativePath
+        if let cached = _cachedIsLocalImageAvailable,
+           _cachedIsLocalImageAvailableRelativePath == currentRelativePath {
+            return cached
+        }
+        let value = (try? imageURL?.checkResourceIsReachable()) ?? false
+        _cachedIsLocalImageAvailable = value
+        _cachedIsLocalImageAvailableRelativePath = currentRelativePath
+        return value
+    }
+
+    func invalidateLocalImageAvailabilityCache() {
+        _cachedIsLocalImageAvailable = nil
+        _cachedIsLocalImageAvailableRelativePath = nil
     }
 }

--- a/OpenEmu/OELibraryDatabase.swift
+++ b/OpenEmu/OELibraryDatabase.swift
@@ -564,12 +564,23 @@ final class OELibraryDatabase: NSObject {
         return result.standardized
     }
     
+    private var _cachedCoverFolderURL: URL?
+    private var _cachedCoverFolderBase: URL?
+    private let _coverFolderLock = NSLock()
+
     var coverFolderURL: URL {
-        let coverFolderURL = databaseFolderURL.appendingPathComponent("Artwork", isDirectory: true)
-        
+        let base = databaseFolderURL
+        _coverFolderLock.lock()
+        defer { _coverFolderLock.unlock() }
+        if let cached = _cachedCoverFolderURL, _cachedCoverFolderBase == base {
+            return cached
+        }
+        let coverFolderURL = base.appendingPathComponent("Artwork", isDirectory: true)
         try? FileManager.default.createDirectory(at: coverFolderURL, withIntermediateDirectories: true)
-        
-        return coverFolderURL.standardized
+        let standardized = coverFolderURL.standardized
+        _cachedCoverFolderURL = standardized
+        _cachedCoverFolderBase = base
+        return standardized
     }
     
     var importQueueURL: URL {


### PR DESCRIPTION
## What does this PR do?

Fixes ≥2s main-thread app hangs in the library grid that were showing up in Sentry under `OEDBImage.isLocalImageAvailable`, `OEDBImage.imageURL`, `OEDBImage.prepareImage`, and `OELibraryDatabase.coverFolderURL`. The `IKImageBrowser` data source calls `isLocalImageAvailable` for every visible cell on every redraw, and each call was doing a synchronous `checkResourceIsReachable()` stat plus a `createDirectory` syscall inside `coverFolderURL`. Caches `coverFolderURL` once per `databaseFolderURL`, and caches `imageURL` + `isLocalImageAvailable` per `OEDBImage` instance, both keyed on `relativePath` so writes that change the path self-invalidate.

## What did you test?

Built and ran via `./Scripts/verify.sh` — build, analyzer, plist lint, and codesign all pass with no new warnings. Behavior tested by browsing the library grid in the running app; no visible hangs on scroll. The cache is correctness-preserving: every in-app code path that deletes a tracked image either nils or reassigns `relativePath`, which is the cache key, so stale state is impossible without external interference.

## Which cores or systems are affected?

General app change — affects the library grid and any code that reads `OEDBImage.imageURL` / `OEDBImage.isLocalImageAvailable` / `OELibraryDatabase.coverFolderURL`. No core changes.

## Did you use AI tools?

Used Claude to diagnose the Sentry hang traces, locate the IKImageBrowser data-source hot path, and draft the cache implementation. Reviewed and verified locally.

## Linked issues

Fixes #

---

## Adversarial review

Two `note`-level observations surfaced by the adversarial reviewer:

- **Negative result caching for `isLocalImageAvailable`:** if a file lands on disk after the grid first asked, the cached `false` sticks until `relativePath` changes. All current in-app artwork-write paths (`prepareImage`) assign a fresh UUID `relativePath`, so this self-invalidates. Defensive `invalidateLocalImageAvailabilityCache()` is included for future call sites that might write to an existing path.
- **`coverFolderURL` no longer self-heals if the Artwork folder is deleted out from under the app.** Old code ran `createDirectory` on every access (which silently no-op'd on existing folders, recreating if missing). New code runs it once per `databaseFolderURL` cache fill. If a user deletes `~/OpenEmu/Artwork` while OpenEmu is running, subsequent writes will fail until restart. This is acceptable — it's an external-interference edge case, and the syscall-per-access cost it traded away was a real user-facing hang.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 608 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header