### PR TITLE
fix: identify emulator core in RetroAchievements User-Agent

### DIFF
--- a/OpenEmuKit/Source/OERetroAchievementsBridge.m
+++ b/OpenEmuKit/Source/OERetroAchievementsBridge.m
@@ -41,6 +41,7 @@ static const void *const kOERABridgeQueueKey = &kOERABridgeQueueKey;
     OERetroAchievementsMemoryReader             _memoryReader;
     uint32_t                                    _consoleID;
     NSString                                   *_romPath;
+    NSString                                   *_coreUserAgentClause;
 
     dispatch_queue_t                            _serialQueue;
     dispatch_queue_t                            _snapshotQueue;
@@ -65,6 +66,29 @@ static const void *const kOERABridgeQueueKey = &kOERABridgeQueueKey;
         _core            = core;
         _memoryReader    = reader;
         _consoleID       = consoleID;
+
+        // Capture the core's name + version now, while `core` is guaranteed
+        // alive. The network path runs later off a weak ref that can have
+        // niled out by request time. RetroAchievements wants the emulator core
+        // identified in the User-Agent, matching RetroArch's
+        // "<frontend>/<ver> (<os>) <core_name>/<core_version>" form — spaces in
+        // the core name become underscores so the clause stays a single token.
+        // Several cores (e.g. Gambatte, Nestopia) ship only CFBundleVersion,
+        // not CFBundleShortVersionString, so fall back to it — otherwise the
+        // version silently drops for those cores.
+        NSString *coreName    = core.pluginName;
+        NSBundle *coreBundle  = core.owner.bundle;
+        NSString *coreVersion = [coreBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"]
+                             ?: [coreBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+        if (coreName.length) {
+            NSString *safeName = [coreName stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+            _coreUserAgentClause = coreVersion.length
+                ? [NSString stringWithFormat:@"%@/%@ ", safeName, coreVersion]
+                : [NSString stringWithFormat:@"%@ ", safeName];
+        } else {
+            _coreUserAgentClause = @"";
+        }
+
         _serialQueue     = dispatch_queue_create("com.openemu.ra-bridge.serial", DISPATCH_QUEUE_SERIAL);
         _snapshotQueue   = dispatch_queue_create("com.openemu.ra-bridge.snapshot", DISPATCH_QUEUE_SERIAL);
         // Tag _serialQueue so we can detect "already running on this bridge's
@@ -219,9 +243,9 @@ static void oe_ra_bridge_server_call(const rc_api_request_t *request,
     rc_client_get_user_agent_clause(_rcClient, rcClause, sizeof(rcClause));
     NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
     NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
-    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %ld.%ld.%ld) %s",
+    NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %ld.%ld.%ld) %@%s",
                             hostVersion, (long)osv.majorVersion, (long)osv.minorVersion,
-                            (long)osv.patchVersion, rcClause];
+                            (long)osv.patchVersion, _coreUserAgentClause ?: @"", rcClause];
     [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
     if (postBody) {


### PR DESCRIPTION
## What does this PR do?

Adds the active emulator core's name and version to the RetroAchievements server-call `User-Agent` header. Previously the header only carried the host app version and the rcheevos library version; the core was never identified. This matches RetroArch's behavior and was requested by the RetroAchievements reviewer.

## What did you test?

Built the main app via `./Scripts/verify.sh` (build + analyzer + plist lint + codesign all pass). Verified the resulting header format by inspection: `OpenEmu-Silicon/<host> (macOS X.Y.Z) <CoreName>/<coreVersion> rcheevos/<ver>`. Confirmed against the bundled core Info.plists that the version is resolved correctly, including cores (Gambatte, Nestopia) that ship only `CFBundleVersion` rather than `CFBundleShortVersionString`.

## Which cores or systems are affected?

General app change in OpenEmuKit (the RetroAchievements bridge). Affects the User-Agent reported for every core that runs with RetroAchievements enabled; no core binary changes.

## Did you use AI tools?

Used Claude to draft the change and run an adversarial review of the diff; reviewed and verified the build myself.

## Linked issues

Related to #438

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 609 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh`
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

Ran the adversarial reviewer against the diff. No blocking findings. Ruled out: a thread-safety race on the cached clause (assigned once in `init`, which happens-before any server call on the rcheevos thread), nil `core`/`owner`/`bundle` (handled by the length guard and nil-coalescing), and header injection / malformed output (values come from build-controlled plists, spaces sanitized to underscores, clause always nil-coalesced).

One `note` was raised and **fixed in this PR**: several cores (Gambatte, Nestopia) ship only `CFBundleVersion`, not `CFBundleShortVersionString`, so the version would have silently dropped for them. The code now falls back to `CFBundleVersion`.