### PR TITLE
fix: report host version in RetroAchievements User-Agent and unblock RA cores

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -276,13 +276,13 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     size_t size = rc_client_progress_size(_rcClient);
     if (size == 0) return nil;
     NSMutableData *data = [NSMutableData dataWithLength:size];
-    rc_client_serialize_progress(_rcClient, data.mutableBytes);
+    rc_client_serialize_progress(_rcClient, (uint8_t *)data.mutableBytes);
     return data;
 }
 
 - (void)retroAchievementsDeserializeProgress:(NSData *)data {
     if (!_rcClient) return;
-    rc_client_deserialize_progress(_rcClient, data ? data.bytes : NULL);
+    rc_client_deserialize_progress(_rcClient, data ? (const uint8_t *)data.bytes : NULL);
 }
 
 - (void)dealloc

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -450,11 +450,13 @@ static __weak GenPlusGameCore *_current;
         bram_load();
 
     // Determine RA console from the system this ROM was identified as.
+    // NOTE: openemu.system.sg is Genesis/Mega Drive; openemu.system.sg1000 is the SG-1000.
+    // The names are misleading — see oecores.xml — so map both explicitly.
     if ([self.systemIdentifier isEqualToString:@"openemu.system.sms"])
         _rcConsole = RC_CONSOLE_MASTER_SYSTEM;
     else if ([self.systemIdentifier isEqualToString:@"openemu.system.gg"])
         _rcConsole = RC_CONSOLE_GAME_GEAR;
-    else if ([self.systemIdentifier isEqualToString:@"openemu.system.sg"])
+    else if ([self.systemIdentifier isEqualToString:@"openemu.system.sg1000"])
         _rcConsole = RC_CONSOLE_SG1000;
     else if ([self.systemIdentifier isEqualToString:@"openemu.system.scd"])
         _rcConsole = RC_CONSOLE_SEGA_CD;

--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -110,6 +110,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsRetroAchievements</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 		</dict>

--- a/OpenEmu-SDK/OpenEmuBase/HardcoreModePolicy.swift
+++ b/OpenEmu-SDK/OpenEmuBase/HardcoreModePolicy.swift
@@ -50,8 +50,12 @@ public enum HardcoreModePolicy {
         guard hardcoreEnabled else { return true }
 
         switch action {
-        case .loadState, .rewind, .fastForward, .slowMotion, .frameStep, .cheats:
+        case .loadState, .rewind, .slowMotion, .frameStep, .cheats:
             return false
+        case .fastForward:
+            // Fast-forward is permitted in hardcore. RA's hardcore-compliance
+            // spec restricts only slowdown and frame advance, not speed-up.
+            return true
         case .saveState:
             // Saving is permitted; RA only restricts restoring prior state.
             return true

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -89,8 +89,13 @@ static Class GameCoreClass = Nil;
     if (hardcoreEnabled) {
         isRewinding = NO;
         singleFrameStep = NO;
-        lastRate = 1.0;
-        if (_rate != 0) {
+        // Clear an active slow-motion rate (slowdown stays blocked in hardcore)
+        // while preserving fast-forward (permitted per RA's hardcore spec).
+        // Normalize both the live rate and the stored resume rate used when paused.
+        if (lastRate > 0.0 && lastRate < 1.0) {
+            lastRate = 1.0;
+        }
+        if (_rate > 0.0 && _rate < 1.0) {
             self.rate = 1.0;
         }
     }
@@ -670,7 +675,8 @@ static Class GameCoreClass = Nil;
 
 - (void)fastForwardAtSpeed:(CGFloat)fastForwardSpeed;
 {
-    if (self.hardcoreEnabled) return;
+    // Fast-forward is permitted in hardcore mode per RA's hardcore-compliance
+    // spec (only slowdown and frame advance are restricted, not speed-up).
     [self setRate:fastForwardSpeed];
 }
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -598,7 +598,8 @@ static Class GameCoreClass = Nil;
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)fastForward:(BOOL)flag
 {
-    if (self.hardcoreEnabled) return;
+    // Fast-forward is permitted in hardcore mode per RA's hardcore-compliance
+    // spec (only slowdown and frame advance are restricted, not speed-up).
     float newrate = flag ? 5.0 : 1.0;
 
     if (self.isEmulationPaused) {

--- a/OpenEmu-SDK/OpenEmuBaseTests/HardcoreModePolicyTests.swift
+++ b/OpenEmu-SDK/OpenEmuBaseTests/HardcoreModePolicyTests.swift
@@ -59,9 +59,9 @@ final class HardcoreModePolicyTests: XCTestCase {
                        "RA spec: rewind must be blocked in hardcore.")
     }
 
-    func testHardcoreBlocksFastForward() {
-        XCTAssertFalse(HardcoreModePolicy.allows(.fastForward, hardcoreEnabled: true),
-                       "RA spec: fast-forward must be blocked in hardcore.")
+    func testHardcoreAllowsFastForward() {
+        XCTAssertTrue(HardcoreModePolicy.allows(.fastForward, hardcoreEnabled: true),
+                      "RA spec: fast-forward is allowed in hardcore — only slowdown and frame advance are restricted.")
     }
 
     func testHardcoreBlocksFrameStep() {

--- a/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
+++ b/OpenEmu-SDK/OpenEmuBaseTests/OEGameCoreHardcoreTests.m
@@ -96,7 +96,7 @@
 
 #pragma mark - fastForward:
 
-- (void)testFastForwardBlockedWhenHardcoreEnabled
+- (void)testFastForwardAllowedWhenHardcoreEnabled
 {
     OEGameCore *core = [[OEGameCore alloc] init];
     core.rate = 1.0f;
@@ -104,8 +104,8 @@
 
     [core fastForward:YES];
 
-    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
-                               @"fastForward: must be a no-op when hardcoreEnabled is YES — the rate must not change.");
+    XCTAssertEqualWithAccuracy(core.rate, 5.0f, 0.0001f,
+                               @"fastForward: must speed up even when hardcoreEnabled is YES — RA's hardcore spec permits fast-forward.");
 }
 
 - (void)testFastForwardAllowedWhenHardcoreDisabled
@@ -120,7 +120,7 @@
                          @"fastForward: must increase rate when hardcoreEnabled is NO (sanity check that the gate is the only thing blocking).");
 }
 
-- (void)testFastForwardAtSpeedBlockedWhenHardcoreEnabled
+- (void)testFastForwardAtSpeedAllowedWhenHardcoreEnabled
 {
     OEGameCore *core = [[OEGameCore alloc] init];
     core.rate = 1.0f;
@@ -128,8 +128,8 @@
 
     [core fastForwardAtSpeed:4.0f];
 
-    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
-                               @"fastForwardAtSpeed: must be a no-op when hardcoreEnabled is YES — latent analog bindings must not bypass hardcore.");
+    XCTAssertEqualWithAccuracy(core.rate, 4.0f, 0.0001f,
+                               @"fastForwardAtSpeed: must set the requested rate even when hardcoreEnabled is YES — analog fast-forward is permitted in hardcore.");
 }
 
 - (void)testFastForwardAtSpeedAllowedWhenHardcoreDisabled
@@ -296,7 +296,7 @@
                    @"setHardcoreEnabled: must clear pending frame-step immediately.");
 }
 
-- (void)testEnablingHardcoreClearsActiveFastForwardRate
+- (void)testEnablingHardcorePreservesActiveFastForwardRate
 {
     OEGameCore *core = [[OEGameCore alloc] init];
     core.hardcoreEnabled = NO;
@@ -306,8 +306,8 @@
 
     core.hardcoreEnabled = YES;
 
-    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
-                               @"setHardcoreEnabled: must return active fast-forward to normal speed immediately.");
+    XCTAssertEqualWithAccuracy(core.rate, 4.0f, 0.0001f,
+                               @"setHardcoreEnabled: must preserve an active fast-forward rate — fast-forward is permitted in hardcore.");
 }
 
 - (void)testEnablingHardcoreClearsActiveSlowMotionRate
@@ -324,7 +324,7 @@
                                @"setHardcoreEnabled: must return active slow motion to normal speed immediately.");
 }
 
-- (void)testEnablingHardcoreClearsPausedFastForwardResumeRate
+- (void)testEnablingHardcorePreservesPausedFastForwardResumeRate
 {
     OEGameCore *core = [[OEGameCore alloc] init];
     core.hardcoreEnabled = NO;
@@ -336,8 +336,8 @@
     core.hardcoreEnabled = YES;
     [core setPauseEmulation:NO];
 
-    XCTAssertEqualWithAccuracy(core.rate, 1.0f, 0.0001f,
-                               @"setHardcoreEnabled: must clear paused fast-forward resume rate before unpausing.");
+    XCTAssertEqualWithAccuracy(core.rate, 4.0f, 0.0001f,
+                               @"setHardcoreEnabled: must preserve the paused fast-forward resume rate — fast-forward is permitted in hardcore.");
 }
 
 - (void)testToggleReEnablesAffordances

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -2527,7 +2527,7 @@ extension OEGameDocument: OESystemBindingsObserver {
     }
     
     func fastForwardGameplay(_ enable: Bool) {
-        if isHardcoreModeEnabled { return }
+        if !HardcoreModePolicy.allows(.fastForward, hardcoreEnabled: isHardcoreModeEnabled) { return }
         if emulationStatus != .playing { return }
         gameViewController.showFastForwardNotification(enable)
     }

--- a/OpenEmu/PrefCoresController.swift
+++ b/OpenEmu/PrefCoresController.swift
@@ -272,6 +272,9 @@ final class PrefCoresController: NSViewController {
     }
 
     private func displayName(for sysID: String, fallback: String) -> String {
+        // OpenEmu models Game Boy and Game Boy Color as one system (openemu.system.gb);
+        // Gambatte handles both. Make the dual coverage explicit in the UI.
+        if sysID == "openemu.system.gb" { return "Game Boy / Game Boy Color" }
         guard fallback == sysID else { return fallback }
         let last = sysID.components(separatedBy: ".").last ?? sysID
         return last

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -281,8 +281,11 @@ final class PrefRetroAchievementsController: NSViewController {
         let systems: [(name: String, icon: NSImage)] = supportedIDs
             .compactMap { id -> (String, NSImage)? in
                 guard let sys = OESystemPlugin.systemPlugin(forIdentifier: id) else { return nil }
-                let name = sys.systemName
+                var name = sys.systemName
                     .replacingOccurrences(of: #"\s*\([^)]+\)"#, with: "", options: .regularExpression)
+                // OpenEmu models Game Boy and Game Boy Color as one system (openemu.system.gb);
+                // Gambatte detects the cartridge type and earns GBC achievements. Show both.
+                if id == "openemu.system.gb" { name = "Game Boy / Game Boy Color" }
                 return (name, sys.systemIcon)
             }
             .sorted { $0.0 < $1.0 }

--- a/OpenEmu/PreferencesWindowController.swift
+++ b/OpenEmu/PreferencesWindowController.swift
@@ -57,7 +57,7 @@ final class PreferencesWindowController: NSWindowController {
     override func windowDidLoad() {
         
         super.windowDidLoad()
-        window?.level = .floating // make Settings window floating so it always stays on top
+        window?.level = .normal // Settings window behaves like a normal window (not always on top)
         
         preferencesTabViewController = PreferencesTabViewController()
         self.window?.contentView = preferencesTabViewController.view

--- a/OpenEmuKit/Source/OERetroAchievementsBridge.m
+++ b/OpenEmuKit/Source/OERetroAchievementsBridge.m
@@ -18,6 +18,7 @@
 
 #import "OERetroAchievementsBridge.h"
 #import "OERetroAchievementsTransport.h"
+#import <OpenEmuBase/OpenEmuBase.h> // full OEGameCore + OEGameCoreController interfaces (core.pluginName/owner.bundle)
 #import <os/log.h>
 
 // Bridge owns its own copy of the OERetroAchievements* notification names
@@ -241,7 +242,7 @@ static void oe_ra_bridge_server_call(const rc_api_request_t *request,
 
     char rcClause[64] = {0};
     rc_client_get_user_agent_clause(_rcClient, rcClause, sizeof(rcClause));
-    NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
+    NSString *hostVersion = OEHostAppVersion();
     NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
     NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %ld.%ld.%ld) %@%s",
                             hostVersion, (long)osv.majorVersion, (long)osv.minorVersion,

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.h
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.h
@@ -131,6 +131,17 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
                                     rc_client_t *client);
 
 /**
+ * Returns the host app's marketing version (CFBundleShortVersionString) for the
+ * RetroAchievements User-Agent. The RA client runs in the emulator helper
+ * process, where -[NSBundle mainBundle] does not resolve to OpenEmu.app and
+ * reports no version — which RA rejects as non-numeric ("unknown"). This
+ * resolves the version from the enclosing .app of the running executable, so
+ * the real shipped version is always sent regardless of process. Falls back to
+ * the main bundle, then "unknown".
+ */
+NSString *OEHostAppVersion(void);
+
+/**
  * Posts a property-list-safe OERAEventNotification for rcheevos gameplay UI
  * events. Core event handlers should call this before handling achievement
  * unlocks or refreshing session snapshots.

--- a/OpenEmuKit/Source/OERetroAchievementsTransport.m
+++ b/OpenEmuKit/Source/OERetroAchievementsTransport.m
@@ -25,6 +25,8 @@
 
 #import <Foundation/Foundation.h>
 #import <string.h>
+#import <limits.h>
+#import <mach-o/dyld.h>
 #import "OERetroAchievementsTransport.h"
 
 static NSString *OEStringFromCString(const char *string)
@@ -32,6 +34,37 @@ static NSString *OEStringFromCString(const char *string)
     if (!string) { return @""; }
     NSString *value = [NSString stringWithCString:string encoding:NSUTF8StringEncoding];
     return value ?: @"";
+}
+
+NSString *OEHostAppVersion(void)
+{
+    // In the host app process the main bundle carries the version. The RA client
+    // runs in the emulator helper process (OpenEmu.app/Contents/MacOS/
+    // OpenEmuHelperApp), where -mainBundle yields no version. Core plugins also
+    // load from outside the app bundle, so the plugin bundle is no anchor either.
+    // The one stable anchor in either process is the running executable, which
+    // always lives inside OpenEmu.app — walk up from it to the enclosing .app.
+    NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    if (version.length > 0) { return version; }
+
+    char execPath[PATH_MAX] = {0};
+    uint32_t size = (uint32_t)sizeof(execPath);
+    NSString *path = (_NSGetExecutablePath(execPath, &size) == 0)
+        ? [NSString stringWithUTF8String:execPath]
+        : nil;
+    while (path.length > 1 && ![path.pathExtension isEqualToString:@"app"]) {
+        path = [path stringByDeletingLastPathComponent];
+    }
+    if ([path.pathExtension isEqualToString:@"app"]) {
+        // Read Contents/Info.plist directly. In the helper process
+        // -[NSBundle bundleWithPath: objectForInfoDictionaryKey:] returns nil
+        // for this bundle even though the file is readable, so go to disk.
+        NSString *plistPath = [path stringByAppendingPathComponent:@"Contents/Info.plist"];
+        NSDictionary *info = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+        version = info[@"CFBundleShortVersionString"];
+        if (version.length > 0) { return version; }
+    }
+    return @"unknown";
 }
 
 static void OEPostSessionStatus(NSString *status, int result, const char *error_message)
@@ -245,7 +278,7 @@ void oeRetroAchievementsServerCall(const rc_api_request_t *request,
 
     // RA expects an identifying User-Agent so they can correlate traffic to the host app.
     // Format: OpenEmu-Silicon/<host-version> (macOS <os-version>) rcheevos/<...> <Core>/<ver>
-    NSString *hostVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"unknown";
+    NSString *hostVersion = OEHostAppVersion();
     NSOperatingSystemVersion osv = [[NSProcessInfo processInfo] operatingSystemVersion];
     NSString *osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld", (long)osv.majorVersion, (long)osv.minorVersion, (long)osv.patchVersion];
     NSString *userAgent = [NSString stringWithFormat:@"OpenEmu-Silicon/%@ (macOS %@) %@%@",

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -970,7 +970,7 @@ extension OSLog {
     }
     
     public func fastForwardGameplay(_ enable: Bool) {
-        if _hardcoreEnabled { return }
+        if !HardcoreModePolicy.allows(.fastForward, hardcoreEnabled: _hardcoreEnabled) { return }
         // Required so that _videoLayer.nextDrawable() vends frames faster than the display refresh rate
         // Fixes: https://github.com/OpenEmu/OpenEmu/issues/4780
         _videoLayer.displaySyncEnabled = !enable


### PR DESCRIPTION
## What does this PR do?

Fixes the RetroAchievements integration so hardcore unlocks are accepted, and clears two related bugs found along the way. The headline fix: the RA User-Agent was reporting the host version as `unknown` (the RA client runs in the emulator helper process, where `NSBundle.mainBundle` resolves no version), which RetroAchievements rejects as non-numeric and blocks hardcore. It now resolves the real shipped version from the running executable's enclosing `.app`.

## What did you test?

- **End-to-end on Sega Genesis:** signed into RetroAchievements, confirmed via the unified log that the outgoing User-Agent is now `OpenEmu-Silicon/1.2.3 (macOS …) rcheevos/12.3 GenesisPlus/…` (previously `OpenEmu-Silicon/unknown`), the "outdated emulator" warning no longer appears, and **hardcore achievements unlocked**.
- **GenesisPlus console mapping:** verified `openemu.system.sg` (Genesis) now loads the Mega Drive achievement set and `sg1000` loads the SG-1000 set (previously swapped).
- **Build:** `xcodebuild … -scheme OpenEmu build` succeeds; GenesisPlus and Mupen64Plus build+install+hash-verify clean. The #609 import regression fix was confirmed by rebuilding a bridge core (Gambatte) that previously failed to compile.
- **Fast-forward in hardcore:** unit-test verified — the full `OEGameCoreHardcoreTests` + `HardcoreModePolicyTests` suite passes, including new cases asserting fast-forward (button and analog) is allowed in hardcore while rewind, slow-motion, and frame-step stay blocked. In-game behavior to be re-confirmed in a hardcore session.

## Which cores or systems are affected?

- **GenesisPlus** — RA console mapping fix + SG-1000 RA enabled.
- **All RA cores** (Mednafen, mGBA, Gambatte, FCEU, Nestopia, SNES9x, BSNES, Mupen64Plus) — the shared User-Agent fix and the #609 build-regression fix live in code each core compiles; they must be rebuilt/re-released to pick it up.
- **General app change** — Game Boy / Game Boy Color pane labels, Settings window level, fast-forward hardcore policy (OEGameCore + helper affect all cores).

## Did you use AI tools?

Used Claude Code to diagnose the User-Agent/helper-process issue, write the fixes, and verify them (including capturing the live User-Agent from the unified log). Reviewed and tested by me.

## Linked issues

Related to #613

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 614 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [ ] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [ ] No build logs, binaries, or credentials committed
- [ ] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

An adversarial-reviewer pass was run on the full diff. Two findings:

- **[block — FIXED] Fast-forward "unblock" was a no-op, then incompletely fixed.** The original change only touched `OEGameDocument.fastForwardGameplay` (the on-screen banner), which is downstream of the gates that actually stop fast-forward: `OpenEmuHelperApp.fastForwardGameplay` (`if _hardcoreEnabled { return }`) and `OEGameCore.fastForward:` (`if (self.hardcoreEnabled) return;`). Both ran first, so fast-forward stayed blocked. The first pass routed the helper gate through `HardcoreModePolicy.allows(.fastForward, …)` and dropped the early-return in `OEGameCore.fastForward:`, but left two sibling paths inconsistent: `OEGameCore.fastForwardAtSpeed:` still no-oped in hardcore (analog fast-forward), and `setHardcoreEnabled:` force-reset any active/paused fast-forward rate back to 1.0. Now fully resolved — both removed, with `setHardcoreEnabled:` normalizing only a blocked slow-motion rate while preserving fast-forward. Unit-test verified: the `OEGameCoreHardcoreTests` + `HardcoreModePolicyTests` suite passes with cases asserting the coherent behavior.
- **[note] Settings window level revert.** Setting the Preferences window back to `.normal` reverts the always-on-top behavior introduced in #578. This is intentional and per user request (the floating window was obscuring other windows); flagged for visibility.

Ruled out by the reviewer: the GenesisPlus if/else console mapping (correct fall-through), the `OEHostAppVersion` path-walk (cannot loop/overflow; nil-safe), and `HardcoreModePolicy` switch exhaustiveness.
