### PR TITLE
Let Gambatte inherit default code signing

### DIFF
--- a/Gambatte/Gambatte.xcodeproj/project.pbxproj
+++ b/Gambatte/Gambatte.xcodeproj/project.pbxproj
@@ -659,7 +659,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(PROJECT_DIR)/gambatte\"",
@@ -684,7 +683,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(PROJECT_DIR)/gambatte\"",


### PR DESCRIPTION
## What does this PR do?

Removes the `CODE_SIGN_IDENTITY = ""` override from Gambatte's Xcode target (Debug and Release) so it inherits the default code signing like every other core. Without this, Gambatte built unsigned while all 8 other cores built signed.

## What did you test?

Built `OpenEmu + Gambatte` in Release and ran `./Scripts/verify.sh --core Gambatte --release` — **ALL PASS**, including `codesign --verify --deep --strict` and `verify-core-installed.sh`, with no manual re-sign. The build product is now signed (`Signature=adhoc`); before this change it reported `code object is not signed at all`.

Note: `main` can't build bridge cores (including Gambatte) until the import fix in #614 lands, so verification was run with that fix applied. The change here is purely the two-line signing override removal.

## Which cores or systems are affected?

Gambatte (Game Boy / Game Boy Color) only — build configuration change, no source or emulation behavior change.

## Did you use AI tools?

Used Claude Code to diagnose the unsigned-build root cause and make the change; reviewed and tested by me.

## Linked issues

Fixes #616

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 617 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
