### PR TITLE
fix: reduce and de-clutter RetroAchievements corner overlay

### DIFF
--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -378,6 +378,12 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     private var leaderboardTimers: [UInt32: Timer] = [:]
     private let progressLabel = OERetroAchievementsChipLabel(labelWithString: "")
     private var progressTimer: Timer?
+    /// The latest progress text, kept even while suppressed by an active
+    /// challenge so it can be revealed (with a fresh dismiss clock) once the
+    /// challenge ends, instead of expiring unseen in the background.
+    private var pendingProgressText: String?
+
+    private var hasActiveChallenge: Bool { !challengeOrder.isEmpty }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -407,6 +413,14 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     func hideChallenge(id: UInt32) {
         guard challengeTitles.removeValue(forKey: id) != nil else { return }
         challengeOrder.removeAll { $0 == id }
+        // Reveal any progress that arrived (and was suppressed) while a
+        // challenge was active, giving it a fresh full dismiss window now
+        // that the player can actually see it.
+        if !hasActiveChallenge, let text = pendingProgressText {
+            progressLabel.stringValue = text
+            progressLabel.isHidden = false
+            resetProgressDismissTimer()
+        }
         updateArrangedSubviews()
     }
 
@@ -444,14 +458,22 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         let text = progress.isEmpty ? title : "\(title): \(progress)"
         // RA can re-send the same progress value on a cadence of its own even
         // when nothing has actually changed. Only treat this as a fresh,
-        // pertinent update (and restart the dismiss clock) if the displayed
-        // text is different or the chip isn't currently showing — otherwise
-        // a steady drip of unchanged pings would keep the chip on screen
-        // indefinitely instead of letting it disappear.
-        let isNewUpdate = progressLabel.isHidden || progressLabel.stringValue != text
-        progressLabel.stringValue = text
-        progressLabel.isHidden = false
-        if isNewUpdate {
+        // pertinent update if the value is different from what's already
+        // pending — otherwise a steady drip of unchanged pings would keep
+        // resetting the dismiss clock and the chip would never disappear.
+        guard pendingProgressText != text else { return }
+        pendingProgressText = text
+
+        if hasActiveChallenge {
+            // Don't start the dismiss clock on a toast the player can't even
+            // see yet — it would expire in the background and never be
+            // shown at all. hideChallenge(id:) reveals it once possible.
+            progressTimer?.invalidate()
+            progressTimer = nil
+            progressLabel.isHidden = true
+        } else {
+            progressLabel.stringValue = text
+            progressLabel.isHidden = false
             resetProgressDismissTimer()
         }
         updateArrangedSubviews()
@@ -460,6 +482,7 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     func hideProgress() {
         progressTimer?.invalidate()
         progressTimer = nil
+        pendingProgressText = nil
         progressLabel.isHidden = true
         updateArrangedSubviews()
     }
@@ -469,6 +492,7 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         leaderboardTimers.removeAll()
         progressTimer?.invalidate()
         progressTimer = nil
+        pendingProgressText = nil
         challengeTitles.removeAll()
         challengeOrder.removeAll()
         leaderboardViews.removeAll()
@@ -493,18 +517,18 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     /// Rebuilds the stack's arranged subviews from current state: the single
     /// most-recently-active challenge chip (if any), followed by transient
     /// progress/leaderboard chips. The progress toast is suppressed entirely
-    /// while a challenge is active — a challenge is the thing worth the
-    /// player's attention, and stacking a progress ping on top of it just
-    /// reintroduces the clutter this indicator is meant to avoid.
+    /// while a challenge is active (kept hidden by showProgress/hideChallenge
+    /// above) — a challenge is the thing worth the player's attention, and
+    /// stacking a progress ping on top of it just reintroduces the clutter
+    /// this indicator is meant to avoid.
     private func updateArrangedSubviews() {
         for view in arrangedSubviews { removeArrangedSubview(view); view.removeFromSuperview() }
 
-        let hasActiveChallenge = !challengeOrder.isEmpty
-        if hasActiveChallenge, let currentChallengeID = challengeOrder.last, let title = challengeTitles[currentChallengeID] {
+        if let currentChallengeID = challengeOrder.last, let title = challengeTitles[currentChallengeID] {
             challengeChip.stringValue = "Challenge: \(title)"
             addArrangedSubview(challengeChip)
         }
-        if !progressLabel.isHidden && !hasActiveChallenge { addArrangedSubview(progressLabel) }
+        if !progressLabel.isHidden { addArrangedSubview(progressLabel) }
         for label in leaderboardViews.values { addArrangedSubview(label) }
 
         isHidden = arrangedSubviews.isEmpty

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -477,10 +477,16 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         chips.append(contentsOf: challengeViews.values)
         chips.append(contentsOf: leaderboardViews.values)
 
-        let visible = chips.prefix(Self.maxVisibleChips)
-        let overflowCount = chips.count - visible.count
+        // When overflow is needed, the overflow chip itself counts toward the
+        // cap so the total number of stacked items never exceeds maxVisibleChips.
+        let hasOverflow = chips.count > Self.maxVisibleChips
+        let visibleCount = hasOverflow ? Self.maxVisibleChips - 1 : chips.count
+        let visible = chips.prefix(visibleCount)
         for chip in visible { addArrangedSubview(chip) }
-        if overflowCount > 0 {
+
+        overflowLabel.isHidden = !hasOverflow
+        if hasOverflow {
+            let overflowCount = chips.count - visible.count
             overflowLabel.stringValue = String(format: NSLocalizedString("+%d more", comment: "RetroAchievements indicator overflow chip"), overflowCount)
             addArrangedSubview(overflowLabel)
         }

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -492,15 +492,19 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
 
     /// Rebuilds the stack's arranged subviews from current state: the single
     /// most-recently-active challenge chip (if any), followed by transient
-    /// progress/leaderboard chips.
+    /// progress/leaderboard chips. The progress toast is suppressed entirely
+    /// while a challenge is active — a challenge is the thing worth the
+    /// player's attention, and stacking a progress ping on top of it just
+    /// reintroduces the clutter this indicator is meant to avoid.
     private func updateArrangedSubviews() {
         for view in arrangedSubviews { removeArrangedSubview(view); view.removeFromSuperview() }
 
-        if let currentChallengeID = challengeOrder.last, let title = challengeTitles[currentChallengeID] {
+        let hasActiveChallenge = !challengeOrder.isEmpty
+        if hasActiveChallenge, let currentChallengeID = challengeOrder.last, let title = challengeTitles[currentChallengeID] {
             challengeChip.stringValue = "Challenge: \(title)"
             addArrangedSubview(challengeChip)
         }
-        if !progressLabel.isHidden { addArrangedSubview(progressLabel) }
+        if !progressLabel.isHidden && !hasActiveChallenge { addArrangedSubview(progressLabel) }
         for label in leaderboardViews.values { addArrangedSubview(label) }
 
         isHidden = arrangedSubviews.isEmpty

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -441,9 +441,19 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     }
 
     func showProgress(title: String, progress: String) {
-        progressLabel.stringValue = progress.isEmpty ? title : "\(title): \(progress)"
+        let text = progress.isEmpty ? title : "\(title): \(progress)"
+        // RA can re-send the same progress value on a cadence of its own even
+        // when nothing has actually changed. Only treat this as a fresh,
+        // pertinent update (and restart the dismiss clock) if the displayed
+        // text is different or the chip isn't currently showing — otherwise
+        // a steady drip of unchanged pings would keep the chip on screen
+        // indefinitely instead of letting it disappear.
+        let isNewUpdate = progressLabel.isHidden || progressLabel.stringValue != text
+        progressLabel.stringValue = text
         progressLabel.isHidden = false
-        resetProgressDismissTimer()
+        if isNewUpdate {
+            resetProgressDismissTimer()
+        }
         updateArrangedSubviews()
     }
 

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -359,24 +359,25 @@ final class OERetroAchievementsNoticeView: NSStackView {
 }
 
 final class OERetroAchievementsIndicatorStackView: NSStackView {
-    /// Maximum number of individual chips shown at once. Beyond this, the
-    /// remainder are collapsed into a single "+N more" chip so the stack
-    /// can never grow tall enough to overlap the video (see #638).
-    private static let maxVisibleChips = 4
+    /// Leaderboard tracker and progress chips are transient: they auto-dismiss
+    /// this long after their last show/update, regardless of whether a
+    /// matching hide event ever arrives. They're informational blips, not
+    /// state the player needs to keep checking back on (see #638).
+    private static let transientDismissInterval: TimeInterval = 5
 
-    /// A leaderboard tracker chip is considered stale, and is removed, if it
-    /// goes this long without a `leaderboardTrackerUpdate` event. Active
-    /// trackers are updated frequently by RA, so this only fires when a
-    /// matching hide event was missed. Challenge chips have no equivalent
-    /// heartbeat (a challenge can legitimately stay active for an entire
-    /// session), so they are not auto-timed-out.
-    private static let leaderboardStaleInterval: TimeInterval = 30
+    /// Only one challenge chip is ever shown at a time — the most recently
+    /// shown active challenge — since a challenge is the one thing (e.g. a
+    /// timed challenge) the player actually needs ongoing visible status on.
+    /// It has no auto-dismiss timer; it persists until its matching hide
+    /// event arrives.
+    private var challengeTitles: [UInt32: String] = [:]
+    private var challengeOrder: [UInt32] = []
+    private let challengeChip = OERetroAchievementsChipLabel(labelWithString: "")
 
-    private var challengeViews: [UInt32: OERetroAchievementsChipLabel] = [:]
     private var leaderboardViews: [UInt32: OERetroAchievementsChipLabel] = [:]
-    private var leaderboardStaleTimers: [UInt32: Timer] = [:]
+    private var leaderboardTimers: [UInt32: Timer] = [:]
     private let progressLabel = OERetroAchievementsChipLabel(labelWithString: "")
-    private let overflowLabel = OERetroAchievementsChipLabel(labelWithString: "")
+    private var progressTimer: Timer?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -384,29 +385,28 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         alignment = .trailing
         spacing = 6
         isHidden = true
+        configureChip(challengeChip, color: .systemOrange)
         configureChip(progressLabel, color: .systemGreen)
         progressLabel.isHidden = true
-        configureChip(overflowLabel, color: .systemGray)
-        overflowLabel.isHidden = true
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     deinit {
-        for timer in leaderboardStaleTimers.values { timer.invalidate() }
+        for timer in leaderboardTimers.values { timer.invalidate() }
+        progressTimer?.invalidate()
     }
 
     func showChallenge(id: UInt32, title: String) {
-        let label = challengeViews[id] ?? makeChip(color: .systemOrange)
-        label.stringValue = "Challenge: \(title)"
-        if challengeViews[id] == nil {
-            challengeViews[id] = label
-        }
+        challengeTitles[id] = title
+        challengeOrder.removeAll { $0 == id }
+        challengeOrder.append(id)
         updateArrangedSubviews()
     }
 
     func hideChallenge(id: UInt32) {
-        guard challengeViews.removeValue(forKey: id) != nil else { return }
+        guard challengeTitles.removeValue(forKey: id) != nil else { return }
+        challengeOrder.removeAll { $0 == id }
         updateArrangedSubviews()
     }
 
@@ -416,26 +416,26 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         if leaderboardViews[id] == nil {
             leaderboardViews[id] = label
         }
-        resetLeaderboardStaleTimer(id: id)
+        resetLeaderboardDismissTimer(id: id)
         updateArrangedSubviews()
     }
 
     func updateLeaderboard(id: UInt32, display: String) {
         guard let label = leaderboardViews[id] else { return }
         label.stringValue = "Leaderboard: \(display)"
-        resetLeaderboardStaleTimer(id: id)
+        resetLeaderboardDismissTimer(id: id)
         updateArrangedSubviews()
     }
 
     func hideLeaderboard(id: UInt32) {
-        leaderboardStaleTimers.removeValue(forKey: id)?.invalidate()
+        leaderboardTimers.removeValue(forKey: id)?.invalidate()
         guard leaderboardViews.removeValue(forKey: id) != nil else { return }
         updateArrangedSubviews()
     }
 
     func hideAllLeaderboards() {
-        for timer in leaderboardStaleTimers.values { timer.invalidate() }
-        leaderboardStaleTimers.removeAll()
+        for timer in leaderboardTimers.values { timer.invalidate() }
+        leaderboardTimers.removeAll()
         leaderboardViews.removeAll()
         updateArrangedSubviews()
     }
@@ -443,55 +443,57 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
     func showProgress(title: String, progress: String) {
         progressLabel.stringValue = progress.isEmpty ? title : "\(title): \(progress)"
         progressLabel.isHidden = false
+        resetProgressDismissTimer()
         updateArrangedSubviews()
     }
 
     func hideProgress() {
+        progressTimer?.invalidate()
+        progressTimer = nil
         progressLabel.isHidden = true
         updateArrangedSubviews()
     }
 
     func clear() {
-        for timer in leaderboardStaleTimers.values { timer.invalidate() }
-        leaderboardStaleTimers.removeAll()
-        challengeViews.removeAll()
+        for timer in leaderboardTimers.values { timer.invalidate() }
+        leaderboardTimers.removeAll()
+        progressTimer?.invalidate()
+        progressTimer = nil
+        challengeTitles.removeAll()
+        challengeOrder.removeAll()
         leaderboardViews.removeAll()
         progressLabel.isHidden = true
         updateArrangedSubviews()
     }
 
-    private func resetLeaderboardStaleTimer(id: UInt32) {
-        leaderboardStaleTimers.removeValue(forKey: id)?.invalidate()
-        leaderboardStaleTimers[id] = Timer.scheduledTimer(withTimeInterval: Self.leaderboardStaleInterval, repeats: false) { [weak self] _ in
+    private func resetLeaderboardDismissTimer(id: UInt32) {
+        leaderboardTimers.removeValue(forKey: id)?.invalidate()
+        leaderboardTimers[id] = Timer.scheduledTimer(withTimeInterval: Self.transientDismissInterval, repeats: false) { [weak self] _ in
             self?.hideLeaderboard(id: id)
         }
     }
 
-    /// Rebuilds the stack's arranged subviews from current state, applying
-    /// the visible-chip cap and folding any overflow into a single chip.
+    private func resetProgressDismissTimer() {
+        progressTimer?.invalidate()
+        progressTimer = Timer.scheduledTimer(withTimeInterval: Self.transientDismissInterval, repeats: false) { [weak self] _ in
+            self?.hideProgress()
+        }
+    }
+
+    /// Rebuilds the stack's arranged subviews from current state: the single
+    /// most-recently-active challenge chip (if any), followed by transient
+    /// progress/leaderboard chips.
     private func updateArrangedSubviews() {
         for view in arrangedSubviews { removeArrangedSubview(view); view.removeFromSuperview() }
 
-        var chips: [OERetroAchievementsChipLabel] = []
-        if !progressLabel.isHidden { chips.append(progressLabel) }
-        chips.append(contentsOf: challengeViews.values)
-        chips.append(contentsOf: leaderboardViews.values)
-
-        // When overflow is needed, the overflow chip itself counts toward the
-        // cap so the total number of stacked items never exceeds maxVisibleChips.
-        let hasOverflow = chips.count > Self.maxVisibleChips
-        let visibleCount = hasOverflow ? Self.maxVisibleChips - 1 : chips.count
-        let visible = chips.prefix(visibleCount)
-        for chip in visible { addArrangedSubview(chip) }
-
-        overflowLabel.isHidden = !hasOverflow
-        if hasOverflow {
-            let overflowCount = chips.count - visible.count
-            overflowLabel.stringValue = String(format: NSLocalizedString("+%d more", comment: "RetroAchievements indicator overflow chip"), overflowCount)
-            addArrangedSubview(overflowLabel)
+        if let currentChallengeID = challengeOrder.last, let title = challengeTitles[currentChallengeID] {
+            challengeChip.stringValue = "Challenge: \(title)"
+            addArrangedSubview(challengeChip)
         }
+        if !progressLabel.isHidden { addArrangedSubview(progressLabel) }
+        for label in leaderboardViews.values { addArrangedSubview(label) }
 
-        isHidden = chips.isEmpty
+        isHidden = arrangedSubviews.isEmpty
     }
 
     private func makeChip(color: NSColor) -> OERetroAchievementsChipLabel {

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -359,9 +359,24 @@ final class OERetroAchievementsNoticeView: NSStackView {
 }
 
 final class OERetroAchievementsIndicatorStackView: NSStackView {
+    /// Maximum number of individual chips shown at once. Beyond this, the
+    /// remainder are collapsed into a single "+N more" chip so the stack
+    /// can never grow tall enough to overlap the video (see #638).
+    private static let maxVisibleChips = 4
+
+    /// A leaderboard tracker chip is considered stale, and is removed, if it
+    /// goes this long without a `leaderboardTrackerUpdate` event. Active
+    /// trackers are updated frequently by RA, so this only fires when a
+    /// matching hide event was missed. Challenge chips have no equivalent
+    /// heartbeat (a challenge can legitimately stay active for an entire
+    /// session), so they are not auto-timed-out.
+    private static let leaderboardStaleInterval: TimeInterval = 30
+
     private var challengeViews: [UInt32: OERetroAchievementsChipLabel] = [:]
     private var leaderboardViews: [UInt32: OERetroAchievementsChipLabel] = [:]
+    private var leaderboardStaleTimers: [UInt32: Timer] = [:]
     private let progressLabel = OERetroAchievementsChipLabel(labelWithString: "")
+    private let overflowLabel = OERetroAchievementsChipLabel(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -371,25 +386,28 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         isHidden = true
         configureChip(progressLabel, color: .systemGreen)
         progressLabel.isHidden = true
+        configureChip(overflowLabel, color: .systemGray)
+        overflowLabel.isHidden = true
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    deinit {
+        for timer in leaderboardStaleTimers.values { timer.invalidate() }
+    }
 
     func showChallenge(id: UInt32, title: String) {
         let label = challengeViews[id] ?? makeChip(color: .systemOrange)
         label.stringValue = "Challenge: \(title)"
         if challengeViews[id] == nil {
             challengeViews[id] = label
-            addArrangedSubview(label)
         }
-        updateVisibility()
+        updateArrangedSubviews()
     }
 
     func hideChallenge(id: UInt32) {
-        guard let label = challengeViews.removeValue(forKey: id) else { return }
-        removeArrangedSubview(label)
-        label.removeFromSuperview()
-        updateVisibility()
+        guard challengeViews.removeValue(forKey: id) != nil else { return }
+        updateArrangedSubviews()
     }
 
     func showLeaderboard(id: UInt32, display: String) {
@@ -397,53 +415,77 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         label.stringValue = "Leaderboard: \(display)"
         if leaderboardViews[id] == nil {
             leaderboardViews[id] = label
-            addArrangedSubview(label)
         }
-        updateVisibility()
+        resetLeaderboardStaleTimer(id: id)
+        updateArrangedSubviews()
     }
 
     func updateLeaderboard(id: UInt32, display: String) {
         guard let label = leaderboardViews[id] else { return }
         label.stringValue = "Leaderboard: \(display)"
-        updateVisibility()
+        resetLeaderboardStaleTimer(id: id)
+        updateArrangedSubviews()
     }
 
     func hideLeaderboard(id: UInt32) {
-        guard let label = leaderboardViews.removeValue(forKey: id) else { return }
-        removeArrangedSubview(label)
-        label.removeFromSuperview()
-        updateVisibility()
+        leaderboardStaleTimers.removeValue(forKey: id)?.invalidate()
+        guard leaderboardViews.removeValue(forKey: id) != nil else { return }
+        updateArrangedSubviews()
     }
 
     func hideAllLeaderboards() {
-        for label in leaderboardViews.values {
-            removeArrangedSubview(label)
-            label.removeFromSuperview()
-        }
+        for timer in leaderboardStaleTimers.values { timer.invalidate() }
+        leaderboardStaleTimers.removeAll()
         leaderboardViews.removeAll()
-        updateVisibility()
+        updateArrangedSubviews()
     }
 
     func showProgress(title: String, progress: String) {
-        if progressLabel.superview == nil { addArrangedSubview(progressLabel) }
         progressLabel.stringValue = progress.isEmpty ? title : "\(title): \(progress)"
         progressLabel.isHidden = false
-        updateVisibility()
+        updateArrangedSubviews()
     }
 
     func hideProgress() {
         progressLabel.isHidden = true
-        updateVisibility()
+        updateArrangedSubviews()
     }
 
     func clear() {
-        for label in Array(challengeViews.values) + Array(leaderboardViews.values) {
-            removeArrangedSubview(label)
-            label.removeFromSuperview()
-        }
+        for timer in leaderboardStaleTimers.values { timer.invalidate() }
+        leaderboardStaleTimers.removeAll()
         challengeViews.removeAll()
         leaderboardViews.removeAll()
-        hideProgress()
+        progressLabel.isHidden = true
+        updateArrangedSubviews()
+    }
+
+    private func resetLeaderboardStaleTimer(id: UInt32) {
+        leaderboardStaleTimers.removeValue(forKey: id)?.invalidate()
+        leaderboardStaleTimers[id] = Timer.scheduledTimer(withTimeInterval: Self.leaderboardStaleInterval, repeats: false) { [weak self] _ in
+            self?.hideLeaderboard(id: id)
+        }
+    }
+
+    /// Rebuilds the stack's arranged subviews from current state, applying
+    /// the visible-chip cap and folding any overflow into a single chip.
+    private func updateArrangedSubviews() {
+        for view in arrangedSubviews { removeArrangedSubview(view); view.removeFromSuperview() }
+
+        var chips: [OERetroAchievementsChipLabel] = []
+        if !progressLabel.isHidden { chips.append(progressLabel) }
+        chips.append(contentsOf: challengeViews.values)
+        chips.append(contentsOf: leaderboardViews.values)
+
+        let visible = chips.prefix(Self.maxVisibleChips)
+        let overflowCount = chips.count - visible.count
+        for chip in visible { addArrangedSubview(chip) }
+        if overflowCount > 0 {
+            overflowLabel.stringValue = String(format: NSLocalizedString("+%d more", comment: "RetroAchievements indicator overflow chip"), overflowCount)
+            addArrangedSubview(overflowLabel)
+        }
+
+        isHidden = chips.isEmpty
     }
 
     private func makeChip(color: NSColor) -> OERetroAchievementsChipLabel {
@@ -462,10 +504,6 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
         label.maximumNumberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
         label.widthAnchor.constraint(lessThanOrEqualToConstant: 340).isActive = true
-    }
-
-    private func updateVisibility() {
-        isHidden = challengeViews.isEmpty && leaderboardViews.isEmpty && progressLabel.isHidden
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the RetroAchievements challenge/leaderboard/progress indicators piling up in the upper-right corner and overlapping the video. The design went through a few iterations based on hands-on testing:

- **Challenge chips** collapse to a single persistent chip showing only the most-recently-active challenge (no stacking multiple), since a challenge is the one thing a player needs continuous visible status on (e.g. a timed challenge). No auto-dismiss — it persists until RA sends the matching hide event.
- **Leaderboard tracker chips** are 5-second auto-dismissing toasts, refreshed on each update while genuinely active.
- **Progress chips** are also 5-second toasts, but only reset their dismiss clock on a genuinely new value (RA can re-ping the same value on its own cadence, which previously kept the chip stuck on screen indefinitely).
- **Challenge takes priority over progress**: the progress toast is suppressed entirely while a challenge chip is showing, rather than stacking both at once. If a progress update arrives while suppressed, it's revealed with a full fresh 5-second window once the challenge ends, rather than expiring unseen in the background.

## What did you test?

Built and launched the debug app repeatedly through each design iteration (`xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug build` + `./Scripts/launch-debug.sh`), confirming a fresh build/branch/binary match before each round via mtime + running-process checks. Live-tested in a real RetroAchievements session (challenges, leaderboard trackers, and progress indicators) to iterate on the corner-clutter feel, not just a one-off smoke test.

## Which cores or systems are affected?

General app change (RetroAchievements overlay UI) — not core-specific.

## Did you use AI tools?

Used Claude to investigate the issue, draft and iterate on the fix based on live in-game feedback, and run adversarial review passes that caught several real bugs before they shipped (see below).

## Linked issues

Fixes #638

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac) — live RA session with real challenges/leaderboards/progress
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header — N/A, no new files

---

## Adversarial review

Several rounds of adversarial review across this branch's commits caught real bugs before they shipped, all fixed prior to this PR being finalized:
- The overflow "+N more" chip (from an earlier design iteration, since replaced) never actually unhid itself, so it could never render.
- The visible-chip cap (also since replaced) didn't count the overflow chip itself toward the total.
- A rewrite accidentally dropped `progressLabel.isHidden = true` from init, which would show a blank progress chip before any progress event ever fired.
- The progress toast's dismiss timer ran even while suppressed by an active challenge, so it could expire in the background and never be shown at all — fixed by only starting the timer once the toast is actually revealed to the player.

One `note`-level finding not fixed: the progress toast's "is this a new update" check compares only the displayed text, not an achievement id (RA's progress event doesn't currently carry one through to this view). Two different achievements that happen to format to an identical string could in theory be treated as the same update. Left as-is since RA typically tracks only one progress-eligible achievement at a time, and a proper fix means threading an id through `GameViewController`/`OEGameDocument` as well, beyond this file's scope.