### PR TITLE
fix: keep Cloud Sync status label next to the status dot

### DIFF
--- a/OpenEmu/PrefCloudSyncController.swift
+++ b/OpenEmu/PrefCloudSyncController.swift
@@ -220,7 +220,6 @@ final class PrefCloudSyncController: NSViewController {
 
             bkStatusLabel.centerYAnchor.constraint(equalTo: bkStatusDot.centerYAnchor),
             bkStatusLabel.leadingAnchor.constraint(equalTo: bkStatusDot.trailingAnchor, constant: 6),
-            bkStatusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
 
             bkFolderPathLabel.topAnchor.constraint(equalTo: bkStatusDot.bottomAnchor, constant: 10),
             bkFolderPathLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),


### PR DESCRIPTION
## What does this PR do?

Fixes the Cloud Sync preferences pane so the status word ("Active", "Syncing…", etc.) sits right next to its colored status dot instead of being pinned to the far right edge of the panel.

## What did you test?

Opened Preferences → Cloud Sync and confirmed the status label now hugs the dot for the "Active" state. Ran a full Debug build via `./Scripts/verify.sh --launch` (build, static analyzer, plist lint, codesign verify, smoke launch) — all passed with no new warnings.

## Which cores or systems are affected?

General app change — Cloud Sync preferences pane only, no cores affected.

## Did you use AI tools?

Used Claude to diagnose the Auto Layout constraint bug and apply the fix, reviewed and tested it myself.

## Linked issues

Fixes #

## Adversarial review

Reviewed via the adversarial-reviewer agent. No blocking findings. One non-blocking note: with no trailing/width constraint remaining on the label, an unusually long localized status string (e.g. a translation of "Last backup failed") could in theory run past the row's right edge on the widest locales. Accepted as-is since it's a preferences-pane label with no hard clipping or crash risk, and matches the intended dot-then-label layout.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 647 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header