### PR TITLE
fix: stop forcing MMU emulation on for every Dolphin game

### DIFF
--- a/Dolphin/DolHost.mm
+++ b/Dolphin/DolHost.mm
@@ -115,7 +115,6 @@ void DolHost::Init(std::string supportDirectoryPath, std::string cpath)
     Config::SetBase(Config::MAIN_USE_BUILT_IN_TITLE_DATABASE, true);
     
     //Setup the CPU Settings
-    Config::SetBase(Config::MAIN_MMU, true);
     Config::SetBase(Config::MAIN_ENABLE_CHEATS, true);
     SConfig::GetInstance().bBootToPause = false;
     


### PR DESCRIPTION
## What does this PR do?

Removes `Config::SetBase(Config::MAIN_MMU, true)` from `DolHost::Init`, which unconditionally forced Dolphin's Memory Management Unit emulation on for every GameCube/Wii game. Upstream Dolphin's own default is `false`, and its UI labels the setting "ON = Compatible, OFF = Fast" — MMU emulation adds a continuous per-instruction memory-check cost in the JIT (`jo.memcheck` in `JitBase.cpp`) for every game, whether or not that game actually needs it. Dolphin already ships a per-game `GameSettings/*.ini` database that turns MMU on for the ~32 titles that genuinely require it (loaded automatically via `ConfigManager`'s per-game config layers, which sit above the base layer this override lived in), so removing the blanket override lets those specific titles keep MMU while everything else runs at full speed.

## What did you test?

Traced from a user report (Reddit) of lag/choppiness in Super Smash Bros. Melee. Shader compilation mode was initially suspected and tested across four configurations (Hybrid Ubershaders, wait-for-shaders-before-starting, stock Debug, and Hybrid Ubershaders in a Release build) — none affected the feel. Removing the forced MMU override (tested in a Release-configuration core build, matching the original report) fixed the lag; confirmed no MMU-related "Invalid Read"/panic log lines afterward.

## Which cores or systems are affected?

Dolphin (GameCube/Wii).

## Did you use AI tools?

Used Claude to investigate, trace the root cause through Dolphin's config/JIT source, verify per-game ini layering order, draft the fix, and run an adversarial review of the diff. Tested and confirmed the fix in-game myself.

## Linked issues

Not tied to a tracked GitHub issue — originated from a Reddit report.

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 648 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh Dolphin
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header