### PR TITLE
feat: add bulk artwork import from folder

### DIFF
--- a/OpenEmu/ArtworkFolderMatcher.swift
+++ b/OpenEmu/ArtworkFolderMatcher.swift
@@ -1,0 +1,95 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+
+/// Matches image files in a folder to games by exact, normalized filename.
+///
+/// Normalization mirrors the extensionless-filename matching already used by
+/// `GameInfoHelper` and `ImportOperation`: lowercased, extension stripped.
+@objc(OEArtworkFolderMatcher)
+final class ArtworkFolderMatcher: NSObject {
+
+    @objc(OEArtworkFolderMatcherMatch) final class Match: NSObject {
+        @objc let game: OEDBGame
+        @objc let fileURL: URL
+
+        init(game: OEDBGame, fileURL: URL) {
+            self.game = game
+            self.fileURL = fileURL
+        }
+    }
+
+    @objc(OEArtworkFolderMatcherResult) final class Result: NSObject {
+        @objc let matches: [Match]
+        @objc let unmatchedFileURLs: [URL]
+
+        init(matches: [Match], unmatchedFileURLs: [URL]) {
+            self.matches = matches
+            self.unmatchedFileURLs = unmatchedFileURLs
+        }
+    }
+
+    private static func normalize(_ name: String) -> String {
+        (name as NSString).deletingPathExtension.lowercased()
+    }
+
+    /// Scans `folderURL` (non-recursively) for image files and matches each one
+    /// to a game in `games` whose display name normalizes to the same string.
+    @objc(matchWithFolderURL:games:) static func match(folderURL: URL, games: [OEDBGame]) -> Result {
+        let imageTypes = Set(NSImage.imageTypes)
+
+        let fileURLs = (try? FileManager.default.contentsOfDirectory(
+            at: folderURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        )) ?? []
+
+        let imageFileURLs = fileURLs.filter { url in
+            guard let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier else {
+                return false
+            }
+            return imageTypes.contains(uti)
+        }
+
+        var gamesByNormalizedName: [String: OEDBGame] = [:]
+        for game in games {
+            gamesByNormalizedName[normalize(game.displayName)] = game
+        }
+
+        var matches: [Match] = []
+        var unmatchedFileURLs: [URL] = []
+
+        for fileURL in imageFileURLs {
+            let key = normalize(fileURL.lastPathComponent)
+            if let game = gamesByNormalizedName[key] {
+                matches.append(Match(game: game, fileURL: fileURL))
+            } else {
+                unmatchedFileURLs.append(fileURL)
+            }
+        }
+
+        return Result(matches: matches, unmatchedFileURLs: unmatchedFileURLs)
+    }
+}

--- a/OpenEmu/ArtworkFolderMatcher.swift
+++ b/OpenEmu/ArtworkFolderMatcher.swift
@@ -52,24 +52,31 @@ final class ArtworkFolderMatcher: NSObject {
     }
 
     private static func normalize(_ name: String) -> String {
-        (name as NSString).deletingPathExtension.lowercased()
+        (name as NSString).deletingPathExtension
+            .precomposedStringWithCanonicalMapping
+            .lowercased()
     }
 
     /// Scans `folderURL` (non-recursively) for image files and matches each one
     /// to a game in `games` whose display name normalizes to the same string.
+    ///
+    /// If more than one file normalizes to the same game (e.g. `Sonic.png` and
+    /// `sonic.jpg`), only the first one encountered is matched; the rest are
+    /// reported as unmatched rather than silently overwriting one another.
     @objc(matchWithFolderURL:games:) static func match(folderURL: URL, games: [OEDBGame]) -> Result {
         let imageTypes = Set(NSImage.imageTypes)
 
         let fileURLs = (try? FileManager.default.contentsOfDirectory(
             at: folderURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
+            includingPropertiesForKeys: [.isRegularFileKey, .typeIdentifierKey],
             options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
         )) ?? []
 
         let imageFileURLs = fileURLs.filter { url in
-            guard let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier else {
-                return false
-            }
+            let resourceValues = try? url.resourceValues(forKeys: [.isRegularFileKey, .typeIdentifierKey])
+            guard resourceValues?.isRegularFile == true,
+                  let uti = resourceValues?.typeIdentifier
+            else { return false }
             return imageTypes.contains(uti)
         }
 
@@ -80,11 +87,13 @@ final class ArtworkFolderMatcher: NSObject {
 
         var matches: [Match] = []
         var unmatchedFileURLs: [URL] = []
+        var matchedNormalizedNames: Set<String> = []
 
         for fileURL in imageFileURLs {
             let key = normalize(fileURL.lastPathComponent)
-            if let game = gamesByNormalizedName[key] {
+            if let game = gamesByNormalizedName[key], !matchedNormalizedNames.contains(key) {
                 matches.append(Match(game: game, fileURL: fileURL))
+                matchedNormalizedNames.insert(key)
             } else {
                 unmatchedFileURLs.append(fileURL)
             }

--- a/OpenEmu/ArtworkImportReviewViewController.swift
+++ b/OpenEmu/ArtworkImportReviewViewController.swift
@@ -35,13 +35,15 @@ final class ArtworkImportReviewViewController: NSViewController {
 
     private let matches: [ArtworkFolderMatcher.Match]
     private let unmatchedFileCount: Int
+    private let selectedGameCount: Int
     private var includedIndices: Set<Int>
 
     private var tableView: NSTableView!
 
-    @objc(initWithMatches:unmatchedFileCount:) init(matches: [ArtworkFolderMatcher.Match], unmatchedFileCount: Int) {
+    @objc(initWithMatches:unmatchedFileCount:selectedGameCount:) init(matches: [ArtworkFolderMatcher.Match], unmatchedFileCount: Int, selectedGameCount: Int) {
         self.matches = matches
         self.unmatchedFileCount = unmatchedFileCount
+        self.selectedGameCount = selectedGameCount
         self.includedIndices = Set(matches.indices)
         super.init(nibName: nil, bundle: nil)
     }
@@ -54,7 +56,7 @@ final class ArtworkImportReviewViewController: NSViewController {
 
         let headline = NSTextField(labelWithString: matches.isEmpty
             ? NSLocalizedString("No matching artwork found.", comment: "")
-            : String(format: NSLocalizedString("Found artwork for %ld of %ld games.", comment: ""), matches.count, matches.count + unmatchedFileCount))
+            : String(format: NSLocalizedString("Found artwork for %ld of %ld selected games.", comment: ""), matches.count, selectedGameCount))
         headline.font = .boldSystemFont(ofSize: 13)
 
         let subheadline = NSTextField(labelWithString: unmatchedFileCount > 0

--- a/OpenEmu/ArtworkImportReviewViewController.swift
+++ b/OpenEmu/ArtworkImportReviewViewController.swift
@@ -1,0 +1,189 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+
+/// Sheet that lists artwork files matched to games by filename, letting the
+/// user deselect any before applying. Built programmatically (no xib) since
+/// this is a small, self-contained review list.
+@objc(OEArtworkImportReviewViewController)
+final class ArtworkImportReviewViewController: NSViewController {
+
+    @objc var onApply: (([ArtworkFolderMatcher.Match]) -> Void)?
+    @objc var onCancel: (() -> Void)?
+
+    private let matches: [ArtworkFolderMatcher.Match]
+    private let unmatchedFileCount: Int
+    private var includedIndices: Set<Int>
+
+    private var tableView: NSTableView!
+
+    @objc(initWithMatches:unmatchedFileCount:) init(matches: [ArtworkFolderMatcher.Match], unmatchedFileCount: Int) {
+        self.matches = matches
+        self.unmatchedFileCount = unmatchedFileCount
+        self.includedIndices = Set(matches.indices)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+
+        let headline = NSTextField(labelWithString: matches.isEmpty
+            ? NSLocalizedString("No matching artwork found.", comment: "")
+            : String(format: NSLocalizedString("Found artwork for %ld of %ld games.", comment: ""), matches.count, matches.count + unmatchedFileCount))
+        headline.font = .boldSystemFont(ofSize: 13)
+
+        let subheadline = NSTextField(labelWithString: unmatchedFileCount > 0
+            ? String(format: NSLocalizedString("%ld file(s) did not match any game and will be skipped.", comment: ""), unmatchedFileCount)
+            : NSLocalizedString("Uncheck any game you don't want to update.", comment: ""))
+        subheadline.textColor = .secondaryLabelColor
+        subheadline.font = .systemFont(ofSize: 11)
+
+        tableView = NSTableView()
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.headerView = nil
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.rowHeight = 36
+
+        let checkboxColumn = NSTableColumn(identifier: .init("checkbox"))
+        checkboxColumn.width = 24
+        checkboxColumn.resizingMask = []
+        tableView.addTableColumn(checkboxColumn)
+
+        let artworkColumn = NSTableColumn(identifier: .init("artwork"))
+        artworkColumn.width = 28
+        artworkColumn.resizingMask = []
+        tableView.addTableColumn(artworkColumn)
+
+        let matchColumn = NSTableColumn(identifier: .init("match"))
+        matchColumn.width = 360
+        matchColumn.resizingMask = .autoresizingMask
+        tableView.addTableColumn(matchColumn)
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .bezelBorder
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        let cancelButton = NSButton(title: NSLocalizedString("Cancel", comment: ""), target: self, action: #selector(cancelPressed(_:)))
+        cancelButton.keyEquivalent = "\u{1b}"
+
+        let applyButton = NSButton(title: NSLocalizedString("Apply", comment: ""), target: self, action: #selector(applyPressed(_:)))
+        applyButton.keyEquivalent = "\r"
+        applyButton.isEnabled = !matches.isEmpty
+
+        let buttonRow = NSStackView(views: [cancelButton, applyButton])
+        buttonRow.orientation = .horizontal
+        buttonRow.spacing = 8
+        buttonRow.translatesAutoresizingMaskIntoConstraints = false
+
+        let textStack = NSStackView(views: [headline, subheadline])
+        textStack.orientation = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 4
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 440, height: 420))
+        container.addSubview(textStack)
+        container.addSubview(scrollView)
+        container.addSubview(buttonRow)
+
+        NSLayoutConstraint.activate([
+            textStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            textStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            textStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+
+            scrollView.topAnchor.constraint(equalTo: textStack.bottomAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            scrollView.bottomAnchor.constraint(equalTo: buttonRow.topAnchor, constant: -12),
+
+            buttonRow.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            buttonRow.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16),
+        ])
+
+        view = container
+    }
+
+    @objc private func toggleIncluded(_ sender: NSButton) {
+        let row = sender.tag
+        if sender.state == .on {
+            includedIndices.insert(row)
+        } else {
+            includedIndices.remove(row)
+        }
+    }
+
+    @objc private func cancelPressed(_ sender: Any?) {
+        dismiss(sender)
+        onCancel?()
+    }
+
+    @objc private func applyPressed(_ sender: Any?) {
+        let selected = matches.enumerated().filter { includedIndices.contains($0.offset) }.map { $0.element }
+        dismiss(sender)
+        onApply?(selected)
+    }
+}
+
+extension ArtworkImportReviewViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        matches.count
+    }
+}
+
+extension ArtworkImportReviewViewController: NSTableViewDelegate {
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let match = matches[row]
+
+        switch tableColumn?.identifier.rawValue {
+        case "checkbox":
+            let checkbox = NSButton(checkboxWithTitle: "", target: self, action: #selector(toggleIncluded(_:)))
+            checkbox.state = includedIndices.contains(row) ? .on : .off
+            checkbox.tag = row
+            return checkbox
+
+        case "artwork":
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: 28, height: 28))
+            imageView.imageScaling = .scaleProportionallyUpOrDown
+            imageView.image = NSImage(contentsOf: match.fileURL)
+            return imageView
+
+        case "match":
+            let label = NSTextField(labelWithString: "\(match.game.displayName)  \u{2190}  \(match.fileURL.lastPathComponent)")
+            label.lineBreakMode = .byTruncatingMiddle
+            return label
+
+        default:
+            return nil
+        }
+    }
+}

--- a/OpenEmu/OEGameCollectionViewController.h
+++ b/OpenEmu/OEGameCollectionViewController.h
@@ -41,6 +41,7 @@ extern NSNotificationName const OEGameCollectionViewControllerDidSetSelectionInd
 - (void)downloadCoverArt:(nullable id)sender;
 - (void)cancelCoverArtDownload:(nullable id)sender;
 - (void)addCoverArtFromFile:(nullable id)sender;
+- (void)importArtworkFromFolder:(nullable id)sender;
 - (void)addSaveStateFromFile:(nullable id)sender;
 - (void)consolidateFiles:(nullable id)sender;
 

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -528,7 +528,7 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
         NSArray<OEDBGame *> *selectedGames = [strongSelf selectedGames];
         OEArtworkFolderMatcherResult *matchResult = [OEArtworkFolderMatcher matchWithFolderURL:[openPanel URL] games:selectedGames];
 
-        OEArtworkImportReviewViewController *reviewController = [[OEArtworkImportReviewViewController alloc] initWithMatches:matchResult.matches unmatchedFileCount:matchResult.unmatchedFileURLs.count];
+        OEArtworkImportReviewViewController *reviewController = [[OEArtworkImportReviewViewController alloc] initWithMatches:matchResult.matches unmatchedFileCount:matchResult.unmatchedFileURLs.count selectedGameCount:selectedGames.count];
         reviewController.onApply = ^(NSArray<OEArtworkFolderMatcherMatch *> *confirmedMatches) {
             typeof(self) strongSelf = weakSelf;
             if(strongSelf == nil || confirmedMatches.count == 0)

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -506,6 +506,49 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
     }];
 }
 
+- (void)importArtworkFromFolder:(id)sender
+{
+    NSOpenPanel *openPanel = [NSOpenPanel openPanel];
+
+    [openPanel setAllowsMultipleSelection:NO];
+    [openPanel setCanChooseDirectories:YES];
+    [openPanel setCanChooseFiles:NO];
+    [openPanel setPrompt:NSLocalizedString(@"Choose", @"")];
+    [openPanel setMessage:NSLocalizedString(@"Choose a folder of artwork images. Files are matched to games by exact name.", @"")];
+
+    __weak typeof(self) weakSelf = self;
+    [openPanel beginWithCompletionHandler:^(NSInteger result) {
+        if(result != NSModalResponseOK)
+            return;
+
+        typeof(self) strongSelf = weakSelf;
+        if(strongSelf == nil)
+            return;
+
+        NSArray<OEDBGame *> *selectedGames = [strongSelf selectedGames];
+        OEArtworkFolderMatcherResult *matchResult = [OEArtworkFolderMatcher matchWithFolderURL:[openPanel URL] games:selectedGames];
+
+        OEArtworkImportReviewViewController *reviewController = [[OEArtworkImportReviewViewController alloc] initWithMatches:matchResult.matches unmatchedFileCount:matchResult.unmatchedFileURLs.count];
+        reviewController.onApply = ^(NSArray<OEArtworkFolderMatcherMatch *> *confirmedMatches) {
+            typeof(self) strongSelf = weakSelf;
+            if(strongSelf == nil || confirmedMatches.count == 0)
+                return;
+
+            NSManagedObjectContext *context = nil;
+            for(OEArtworkFolderMatcherMatch *match in confirmedMatches)
+            {
+                [match.game setBoxImageByURL:match.fileURL];
+                context = match.game.managedObjectContext;
+            }
+            [context save:nil];
+
+            [strongSelf reloadDataIndexes:[strongSelf selectionIndexes]];
+        };
+
+        [strongSelf presentViewControllerAsSheet:reviewController];
+    }];
+}
+
 - (void)addSaveStateFromFile:(id)sender
 {
     [self doesNotImplementSelector:_cmd];
@@ -729,6 +772,7 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
             [menu addItemWithTitle:NSLocalizedString(@"Cancel Cover Art Download", @"") action:@selector(cancelCoverArtDownload:) keyEquivalent:@""];
 
         [menu addItemWithTitle:NSLocalizedString(@"Add Cover Art from File…", @"") action:@selector(addCoverArtFromFile:) keyEquivalent:@""];
+        [menu addItemWithTitle:NSLocalizedString(@"Import Artwork from Folder…", @"") action:@selector(importArtworkFromFolder:) keyEquivalent:@""];
         if(hasLocalFiles)
             [menu addItemWithTitle:NSLocalizedString(@"Consolidate Files…", @"") action:@selector(consolidateFiles:) keyEquivalent:@""];
 
@@ -772,6 +816,7 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
 
         [menu addItemWithTitle:NSLocalizedString(@"Download Cover Art", @"") action:@selector(downloadCoverArt:) keyEquivalent:@""];
         [menu addItemWithTitle:NSLocalizedString(@"Add Cover Art from File…", @"") action:@selector(addCoverArtFromFile:) keyEquivalent:@""];
+        [menu addItemWithTitle:NSLocalizedString(@"Import Artwork from Folder…", @"") action:@selector(importArtworkFromFolder:) keyEquivalent:@""];
         [menu addItemWithTitle:NSLocalizedString(@"Consolidate Files…", @"") action:@selector(consolidateFiles:) keyEquivalent:@""];
 
         [menu addItem:[NSMenuItem separatorItem]];

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		94DEA000171896AE00073397 /* NDS.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 94D7E8C915073BA000FBDD85 /* NDS.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		94E6C304166DB15900082F27 /* Controller-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94E6C303166DB15900082F27 /* Controller-Mappings.plist */; };
 		9ACAEF142DD44E2AACFFB26F /* OEWiiSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C5E668B27CE43FF88AE57AF /* OEWiiSystemResponder.m */; };
+		C0D2C87DC8E70B924B0364B8 /* ArtworkFolderMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5948C5F42D3088794677A8C0 /* ArtworkFolderMatcher.swift */; };
 		C3A0FE0857AF614EBC218749 /* OpenEmuLibretroBridge.oecoreplugin in Copy Libretro Bridge to App PlugIns */ = {isa = PBXBuildFile; fileRef = C44B2D2208894931909A8618 /* OpenEmuLibretroBridge.oecoreplugin */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C6252DAC14E752E300350A13 /* Controller-Preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6252DAA14E752E300350A13 /* Controller-Preferences.plist */; };
 		C6252DAE14E7556800350A13 /* Controller-Preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6252DAD14E7556800350A13 /* Controller-Preferences.plist */; };
@@ -658,8 +659,9 @@
 		CC0011223344556901900001 /* PrefScreenScraperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556801900001 /* PrefScreenScraperController.swift */; };
 		CC0011223344556B01900001 /* LibretroThumbnailsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344556A01900001 /* LibretroThumbnailsClient.swift */; };
 		CC0011223344557101900001 /* ScreenScraperDevCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */; };
-		DEAAB8E598494A97A260F43C84A6B563 /* Dreamcast.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 87DF04FE1BCE2D100060E2C2 /* Dreamcast.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEA508990AF842369046D92D /* OEFolderBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9964A7D7B3C4438D9BE62654 /* OEFolderBackupManager.swift */; };
+		D3360575D5430005882E67D6 /* ArtworkImportReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44117B42E921F7FC91F8889D /* ArtworkImportReviewViewController.swift */; };
+		DEAAB8E598494A97A260F43C84A6B563 /* Dreamcast.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 87DF04FE1BCE2D100060E2C2 /* Dreamcast.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DFDDE95A9D47B0C0B525780A /* OESaveSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F74677D2124A2E934C10038 /* OESaveSyncManager.swift */; };
 		E0D3D5AF068C48148780583F /* Keyboard-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6534A32E31642F3805D9A90 /* Keyboard-Mappings.plist */; };
 		E96D97FB8B2AA2119A472430 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120C317112E1300E868A8 /* OpenEmuBase.framework */; };
@@ -1240,6 +1242,7 @@
 		3E3511CE1C35DA920063E8CA /* nl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3E3511CF1C35DA920063E8CA /* nl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ControlLabels.strings; sourceTree = "<group>"; };
 		42A14B489D09FD1B597AD586 /* OECredentialStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OECredentialStore.swift; sourceTree = "<group>"; };
+		44117B42E921F7FC91F8889D /* ArtworkImportReviewViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtworkImportReviewViewController.swift; sourceTree = "<group>"; };
 		4C5E668B27CE43FF88AE57AF /* OEWiiSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEWiiSystemResponder.m; sourceTree = "<group>"; };
 		53439A8A13B92C4A005C0CC8 /* OELibraryDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELibraryDatabase.h; sourceTree = "<group>"; };
 		53439A9313B92C97005C0CC8 /* OEDBAllGamesCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEDBAllGamesCollection.swift; sourceTree = "<group>"; };
@@ -1300,6 +1303,7 @@
 		55D2C55E2B2A8BCD005E4B02 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		55D2C55F2B2A8BD2005E4B02 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Debug.strings; sourceTree = "<group>"; };
 		55D2C5602B2A8BD6005E4B02 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		5948C5F42D3088794677A8C0 /* ArtworkFolderMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtworkFolderMatcher.swift; sourceTree = "<group>"; };
 		5A2CE899206EA61B00790F89 /* NSArray+OEAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSArray+OEAdditions.swift"; sourceTree = "<group>"; };
 		5A3BB0381D964A4500E10F27 /* CenteredTextFieldCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenteredTextFieldCell.swift; sourceTree = "<group>"; };
 		5A3DB1681D8C93C3009445EC /* PreferencesControlsBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesControlsBox.swift; sourceTree = "<group>"; };
@@ -1331,7 +1335,6 @@
 		669734CE138046AC84F66296 /* OEWiiSystemController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEWiiSystemController.h; sourceTree = "<group>"; };
 		68416A57049F48B997026285 /* Controller-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Mappings.plist"; sourceTree = "<group>"; };
 		6F74677D2124A2E934C10038 /* OESaveSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OESaveSyncManager.swift; sourceTree = "<group>"; };
-		9964A7D7B3C4438D9BE62654 /* OEFolderBackupManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OEFolderBackupManager.swift; sourceTree = "<group>"; };
 		6FAD47F297164AD6B87C99DF /* OECoreMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OECoreMigration.swift; sourceTree = "<group>"; };
 		7699EC921D6303EB005BC437 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		7699EC931D6303EC005BC437 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1836,6 +1839,7 @@
 		94D7E8E215073E3800FBDD85 /* OENDSSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OENDSSystemResponderClient.h; sourceTree = "<group>"; };
 		94E6C303166DB15900082F27 /* Controller-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Mappings.plist"; sourceTree = "<group>"; };
 		99574CB1B5EE4AE89B192EBD /* OEWiiSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEWiiSystemResponder.h; sourceTree = "<group>"; };
+		9964A7D7B3C4438D9BE62654 /* OEFolderBackupManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OEFolderBackupManager.swift; sourceTree = "<group>"; };
 		9BAF3ECDABF5A2D068218C7F /* OEGoogleDriveConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OEGoogleDriveConfig.swift; sourceTree = "<group>"; };
 		AC6CB8F335B64A48AE857C59 /* Wii.oesystemplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Wii.oesystemplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		AEF58A5A63D543529C6A8983 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -3123,6 +3127,8 @@
 				8F2F92A92519A9E700699691 /* GameScannerButton.swift */,
 				8306CD0E1BD3AC180025BC6C /* LibraryGamesViewController.swift */,
 				8F5074751C10BCEC00F52B83 /* LibraryGamesViewController.xib */,
+				5948C5F42D3088794677A8C0 /* ArtworkFolderMatcher.swift */,
+				44117B42E921F7FC91F8889D /* ArtworkImportReviewViewController.swift */,
 			);
 			name = "Games Library";
 			sourceTree = "<group>";
@@ -6439,6 +6445,8 @@
 				1E0E90051A8932BB72161909 /* PrefCloudSyncController.swift in Sources */,
 				170AA9A84CF138836883E194 /* OEGoogleDriveSecrets.template.swift in Sources */,
 				F2E3C43668DB03A494D5B16E /* OECredentialStore.swift in Sources */,
+				C0D2C87DC8E70B924B0364B8 /* ArtworkFolderMatcher.swift in Sources */,
+				D3360575D5430005882E67D6 /* ArtworkImportReviewViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## What does this PR do?

Lets users apply their own cover art to a whole library selection in one pass instead of adding covers one game at a time or relying on online scraping. Right-click → "Import Artwork from Folder…", pick a folder of images named after game titles, and it matches files to games by exact filename, shows a review sheet to confirm or deselect matches, then applies them through the existing cover art assignment pipeline (`setBoxImageByURL:`).

## What did you test?

Manually tested end-to-end in the debug app against a real library: selected three GameCube games (Zelda: The Wind Waker, Zelda: Twilight Princess, Super Smash Bros. Melee), pointed the new menu item at a test folder with images named exactly after those titles plus one unmatched file. The review sheet correctly showed 3 matches and 1 unmatched, and Apply correctly updated the three games' cover art.

Also ran an adversarial review pass against the diff, which caught two real bugs before this went out: a review-sheet headline that reported match count against files-found instead of games-selected (misleading on large selections with few matches), and a duplicate-match race where two files normalizing to the same game name could both match and non-deterministically overwrite each other. Both are fixed in this PR, and a follow-up review confirmed the fixes are correct with no regressions.

## Which cores or systems are affected?

General app change (Library UI / artwork handling) — no cores affected.

## Did you use AI tools?

Used Claude to design and implement the feature, including an adversarial review pass that caught two real bugs before merge; reviewed and manually tested it myself.

## Linked issues

Fixes #634

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 649 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

To try the feature itself: select one or more games in your library, right-click, choose "Import Artwork from Folder…", and point it at a folder containing images named exactly after the selected games' titles.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header