### PR TITLE
fix: use badge_url for RetroAchievements unlock notifications (#651)

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -114,8 +114,8 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     NSDictionary *info = @{
         OEAchievementIDKey:          @(ach->id),
         OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementDescriptionKey: @(ach->description ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_url   ?: ""),
         OEAchievementPointsKey:      @(ach->points),
     };
     [[NSNotificationCenter defaultCenter]

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -201,8 +201,8 @@ static void genplus_rc_event_handler(const rc_client_event_t *event, rc_client_t
     NSDictionary *info = @{
         OEAchievementIDKey:          @(ach->id),
         OEAchievementTitleKey:       @(ach->title       ?: ""),
-        OEAchievementDescriptionKey: @(ach->description  ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name   ?: ""),
+        OEAchievementDescriptionKey: @(ach->description ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_url   ?: ""),
         OEAchievementPointsKey:      @(ach->points),
     };
     [[NSNotificationCenter defaultCenter]

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -189,7 +189,7 @@ static void mupen_rc_event_handler(const rc_client_event_t *event, rc_client_t *
         OEAchievementIDKey:          @(ach->id),
         OEAchievementTitleKey:       @(ach->title       ?: ""),
         OEAchievementDescriptionKey: @(ach->description ?: ""),
-        OEAchievementBadgeURLKey:    @(ach->badge_name  ?: ""),
+        OEAchievementBadgeURLKey:    @(ach->badge_url   ?: ""),
         OEAchievementPointsKey:      @(ach->points),
     };
     [[NSNotificationCenter defaultCenter]

--- a/OpenEmuKit/Source/OERetroAchievementsBridge.m
+++ b/OpenEmuKit/Source/OERetroAchievementsBridge.m
@@ -169,7 +169,7 @@ static void oe_ra_bridge_event_handler(const rc_client_event_t *event, rc_client
                     OEAchievementIDKey:          @(ach->id),
                     OEAchievementTitleKey:       @(ach->title       ?: ""),
                     OEAchievementDescriptionKey: @(ach->description ?: ""),
-                    OEAchievementBadgeURLKey:    @(ach->badge_name  ?: ""),
+                    OEAchievementBadgeURLKey:    @(ach->badge_url   ?: ""),
                     OEAchievementPointsKey:      @(ach->points),
                 };
                 [[NSNotificationCenter defaultCenter]


### PR DESCRIPTION
## What does this PR do?

Fixes RetroAchievements unlock toasts displaying the fallback trophy icon instead of the achievement badge.

The affected notification producers were forwarding `badge_name`, which is only the badge identifier, while the UI expects a full URL. This PR forwards `badge_url` instead.

## What did you test?

Tested with SNES9x using *Neugier: Umi to Kaze no Kodou*.

Verified that:

- the achievement unlock notification still appears correctly;

- the title, description, and points are unchanged;

- the actual RetroAchievements badge is downloaded and displayed instead of the fallback trophy icon.

The equivalent changes in BSNES, Genesis Plus, and Mupen64Plus were not runtime-tested, as they are identical field substitutions.

### Before
<img width="446" height="92" alt="Before" src="https://github.com/user-attachments/assets/d84c2690-6b1b-44c1-92a0-20cc92d04477" />

### After
<img width="470" height="102" alt="After" src="https://github.com/user-attachments/assets/c61f5c56-130b-4036-b7b4-d4d94706aaf5" />


## Which cores or systems are affected?

- Bridge-based cores, including SNES9x

- BSNES

- Genesis Plus

- Mupen64Plus

This affects the shared RetroAchievements unlock notification payload rather than emulation behavior.

## Did you use AI tools?

Yes. I used ChatGPT to help trace the achievement notification flow, interpret the relevant rcheevos fields, and review the final change. I implemented, built, and tested the fix myself.

## Linked issues

Fixes #651

---

## How to test locally

Rebuild the SNes9X Core, install it, and run any game that quickly unlocks an achievement. On earning it, the notification should now include the RetroAchievements badge.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
