### PR TITLE
fix: trim RetroAchievements password before login

### DIFF
--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -382,7 +382,7 @@ final class PrefRetroAchievementsController: NSViewController {
 
     @objc private func signIn() {
         let username = usernameField.stringValue.trimmingCharacters(in: .whitespaces)
-        let password = passwordField.stringValue
+        let password = passwordField.stringValue.trimmingCharacters(in: .whitespaces)
 
         guard !username.isEmpty else {
             setStatus("Username cannot be empty.", isError: true)


### PR DESCRIPTION
## What does this PR do?

Trims leading/trailing whitespace from the RetroAchievements password before sending the login request, matching the trimming already applied to the username. Internal whitespace within the password is left untouched.

## What did you test?

Ran `./Scripts/verify.sh --launch` — build, static analyzer, plist lint, codesign verify, and smoke launch all pass with no new warnings or crashes. Manual login testing with a real RA account was not performed in this session (would require altering a live password to add trailing whitespace).

## Which cores or systems are affected?

General app change — RetroAchievements sign-in (`OpenEmu/PrefRetroAchievementsController.swift`). No core changes.

## Did you use AI tools?

Used Claude to draft and apply the fix; build/analyzer verification was run by Claude, manual in-app login testing was not performed.

## Linked issues

Fixes #644

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 657 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac) — build/launch verified, in-app RA login not manually tested
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header — N/A, no new files

## Adversarial review

Reviewed by the adversarial-reviewer agent. No blocking findings. Two notes:

- Trimming means a password that legitimately begins/ends with a space would now be rejected if RA's server doesn't also trim it server-side (unverified either way). This is the accepted tradeoff the issue itself requests, not a regression risk being introduced silently.
- `PrefRetroAchievementsController` has no existing test coverage, before or after this change — no regression protection either way.