### PR TITLE
fix: add in-app reset for stale Input Monitoring permission

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -867,19 +867,78 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
             alert.defaultButtonTitle = NSLocalizedString("Open System Preferences", comment:"Button to open System Preferences for Input Monitoring permission")
         }
         alert.alternateButtonTitle = NSLocalizedString("Ignore", comment: "")
+        alert.otherButtonTitle = NSLocalizedString("Reset Permission", comment: "Button to reset the Input Monitoring permission when toggling it in System Settings hasn't fixed keyboard input")
 
         UserDefaults.standard.set(true, forKey: suppressionKey)
 
         guard let window = mainWindowController.window else { return }
         alert.beginSheetModal(for: window) { res in
-            if res == .alertFirstButtonReturn {
+            switch res {
+            case .alertFirstButtonReturn:
                 if #available(macOS 13.0, *) {
                     NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_ListenEvent")!)
                 } else {
                     NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!)
                 }
+            case .alertThirdButtonReturn:
+                self.resetInputMonitoringPermission(nil)
+            default:
+                break
             }
         }
+    }
+
+    /// Clears a stale/corrupted Input Monitoring TCC grant for this app via
+    /// `tccutil reset` and re-triggers the OS permission prompt. This is the
+    /// same fix users have had to achieve manually by deleting and
+    /// reinstalling the app when toggling the permission in System Settings
+    /// alone didn't resolve broken keyboard input (see issue #628).
+    @IBAction fileprivate func resetInputMonitoringPermission(_ sender: Any?) {
+        guard let bundleID = Bundle.main.bundleIdentifier else { return }
+
+        let script = "do shell script \"/usr/bin/tccutil reset ListenEvent \(bundleID)\" with administrator privileges"
+        guard let appleScript = NSAppleScript(source: script) else { return }
+
+        var error: NSDictionary?
+        appleScript.executeAndReturnError(&error)
+        if let error = error {
+            // -128 is the user cancelling the administrator-privileges prompt.
+            if error[NSAppleScript.errorNumber] as? Int16 != -128 {
+                os_log(.error, log: .default, "Failed to reset Input Monitoring permission { error = %{public}@ }",
+                       (error[NSAppleScript.errorMessage] as? String) ?? "unknown")
+            }
+            return
+        }
+
+        UserDefaults.standard.removeObject(forKey: "OEInputMonitoringPreviouslyGranted")
+        UserDefaults.standard.removeObject(forKey: OEAlert.OEInputMonitoringAlertSuppressionKey)
+
+        // Re-requesting access in this same process immediately after the
+        // reset is unreliable: IOHIDRequestAccess can race with tccd and
+        // silently add a disabled entry instead of showing the consent
+        // dialog. Relaunching gives the OS a fresh process to prompt
+        // against, which is how this request behaves reliably at normal
+        // app launch.
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString("Permission reset", comment: "Headline shown after successfully resetting Input Monitoring permission")
+        alert.informativeText = NSLocalizedString("OpenEmu needs to relaunch to request Input Monitoring access again.", comment: "Message shown after successfully resetting Input Monitoring permission")
+        alert.addButton(withTitle: NSLocalizedString("Relaunch Now", comment: "Button to relaunch OpenEmu after resetting Input Monitoring permission"))
+        alert.runModal()
+
+        relaunchToReapplyInputMonitoringPermission()
+    }
+
+    private func relaunchToReapplyInputMonitoringPermission() {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let path = Bundle.main.bundlePath
+        let script = "(while /bin/kill -0 \(pid) >&/dev/null; do /bin/sleep 0.1; done; /usr/bin/open \"\(path)\") &"
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = ["-c", script]
+        try? task.run()
+
+        NSApp.terminate(self)
     }
     
     // MARK: - Help Menu

--- a/OpenEmu/Main.storyboard
+++ b/OpenEmu/Main.storyboard
@@ -898,6 +898,16 @@ DQ
                                                 <action selector="showOEWebSite:" target="-1" id="O8U-HO-a1Q"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hR2-mK-8pQ"/>
+                                        <menuItem title="Reset Input Monitoring Permission…" id="rIm-4X-9zT">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="boolean" keyPath="localizeTitle" value="YES"/>
+                                            </userDefinedRuntimeAttributes>
+                                            <connections>
+                                                <action selector="resetInputMonitoringPermission:" target="-1" id="fVn-2K-3bW"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="1g0-za-3ea"/>
                                         <menuItem title="Submit Feedback" id="ftM-3D-CSh">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -23,13 +23,15 @@
 	<key>ALERT_INPUT_MONITORING_PART1</key>
 	<string>OpenEmu must be granted the Input Monitoring permission in order to use the keyboard as an input device.</string>
 	<key>ALERT_INPUT_MONITORING_PART2</key>
-	<string>Toggling the permission may also resolve keyboard input issues.</string>
+	<string>Toggling the permission may also resolve keyboard input issues. If that doesn't help, try "Reset Permission" below.</string>
 	<key>ALERT_INPUT_MONITORING_PART2_MONTEREY</key>
-	<string>Removing and re-granting the permission may also resolve keyboard input issues.</string>
+	<string>Removing and re-granting the permission may also resolve keyboard input issues. If that doesn't help, try "Reset Permission" below.</string>
 	<key>ALERT_INPUT_MONITORING_PART2_TAHOE</key>
-	<string>Click "Open System Settings" below, find OpenEmu in the list, and enable the toggle. Then relaunch the app for the change to take effect.</string>
+	<string>Click "Open System Settings" below, find OpenEmu in the list, and enable the toggle. Then relaunch the app for the change to take effect. If that doesn't help, try "Reset Permission" below.</string>
 	<key>Open System Settings</key>
 	<string>Open System Settings</string>
+	<key>Reset Permission</key>
+	<string>Reset Permission</string>
 	<key>ALERT_MOVE_LIBRARY_HTML</key>
 	<string>The OpenEmu Game Library contains a database file which could get corrupted if the library is moved to the following locations:&lt;br&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Folders managed by cloud synchronization software (like &lt;b&gt;iCloud Drive&lt;/b&gt;)&lt;/li&gt;&lt;li&gt;Network drives&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;Additionally, &lt;b&gt;sharing the same library between multiple computers or users&lt;/b&gt; may also corrupt it. This also applies to moving the library to external USB drives.</string>
 	<key>Add</key>

--- a/OpenEmu/en.lproj/MainMenu.strings
+++ b/OpenEmu/en.lproj/MainMenu.strings
@@ -96,6 +96,8 @@
 	<string>Redo</string>
 	<key>Release Notes</key>
 	<string>Release Notes</string>
+	<key>Reset Input Monitoring Permission…</key>
+	<string>Reset Input Monitoring Permission…</string>
 	<key>Save State</key>
 	<string>Save State</string>
 	<key>Select All</key>


### PR DESCRIPTION
## What does this PR do?

Adds a way to clear a stale/conflicting Input Monitoring (TCC) permission from inside the app, instead of requiring users to manually delete and reinstall OpenEmu when toggling the permission in System Settings doesn't fix broken keyboard input.

## What did you test?

- Reproduced the stale-permission state: removed the Input Monitoring entry for the debug build, relaunched, granted access via the native system prompt, then used Help → Reset Input Monitoring Permission… to reset it. Confirmed the entry cleared, the app relaunched, the native prompt reappeared, and re-granting worked.
- Loaded a ROM after the reset+relaunch cycle and confirmed keyboard input registers in-game.
- Verified the existing three-button alert (Open System Settings / Ignore / Reset Permission) all behave correctly, including cancelling the admin-auth prompt.
- `./Scripts/verify.sh --launch`: build, static analyzer, plist lint, codesign verify, and smoke launch all pass.

## Which cores or systems are affected?

None — general host-app change (keyboard/HID permission handling).

## Did you use AI tools?

Yes — used Claude Code to investigate the root cause (issue #628 comments plus code review of the existing `AppMover.swift`/`AppDelegate.swift` permission handling), implement the fix, and iterate on it after live testing surfaced a race condition between `tccutil reset` and re-requesting access in the same process. Reviewed and tested myself.

## Linked issues

Related to #628

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

To exercise the actual fix: remove OpenEmu from System Settings → Privacy & Security → Input Monitoring, relaunch, then try Help → Reset Input Monitoring Permission…

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --launch`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header (no new files)